### PR TITLE
feat: FileSize and FileType control for file_upload component h2oai/q#1140

### DIFF
--- a/py/examples/file_upload.py
+++ b/py/examples/file_upload.py
@@ -9,7 +9,7 @@ page['example'] = ui.form_card(
     box='1 1 4 10',
     items=[
         ui.file_upload(name='file_upload', label='Upload!', multiple=True, 
-        allowedFileTypes=['.csv', '.gz'], maxSizePerFile=10, maxSizeTotal=15)
+        file_extensions=['csv', 'gz'], max_file_size=10, max_size=15)
     ]
 )
 

--- a/py/telesync/types.py
+++ b/py/telesync/types.py
@@ -1726,28 +1726,28 @@ class FileUpload:
     :param name: An identifying name for this component.
     :param label: Text to be displayed alongside the component.
     :param multiple: True if the component should allow multiple files to be uploaded.
+    :param file_extensions: List of allowed file extensions, e.g. `pdf`, `docx`, etc.
+    :param max_file_size: Maximum allowed size (Mb) per file. Defaults to no limit.
+    :param max_size: Maximum allowed size (Mb) for all files combined. Defaults to no limit.
     :param tooltip: An optional tooltip message displayed when a user clicks the help icon to the right of the component.
-    :param allowedFileTypes: An optional string array for defining allowed upload types. E.g. .pdf, .docx ... . Default value is empty - every file type is allowed.
-    :param maxSizePerFile: Maximum file size in Mb that none of the files uploaded can exceed. Default value is unlimited.
-    :param maxSizeTotal: Maximum file size in Mb for all uploaded files combined that cannot be excceeded. Default value is unlimited.
     """
     def __init__(
             self,
             name: str,
             label: Optional[str] = None,
             multiple: Optional[bool] = None,
+            file_extensions: Optional[List[str]] = None,
+            max_file_size: Optional[float] = None,
+            max_size: Optional[float] = None,
             tooltip: Optional[str] = None,
-            allowedFileTypes: Optional[List[str]] = None,
-            maxSizePerFile: Optional[int] = None,
-            maxSizeTotal: Optional[int] = None,
     ):
         self.name = name
         self.label = label
         self.multiple = multiple
+        self.file_extensions = file_extensions
+        self.max_file_size = max_file_size
+        self.max_size = max_size
         self.tooltip = tooltip
-        self.allowedFileTypes = allowedFileTypes
-        self.maxSizePerFile = maxSizePerFile
-        self.maxSizeTotal = maxSizeTotal
 
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""
@@ -1757,10 +1757,10 @@ class FileUpload:
             name=self.name,
             label=self.label,
             multiple=self.multiple,
+            file_extensions=self.file_extensions,
+            max_file_size=self.max_file_size,
+            max_size=self.max_size,
             tooltip=self.tooltip,
-            allowedFileTypes=self.allowedFileTypes,
-            maxSizePerFile=self.maxSizePerFile,
-            maxSizeTotal=self.maxSizeTotal,
         )
 
     @staticmethod
@@ -1771,25 +1771,25 @@ class FileUpload:
             raise ValueError('FileUpload.name is required.')
         __d_label: Any = __d.get('label')
         __d_multiple: Any = __d.get('multiple')
+        __d_file_extensions: Any = __d.get('file_extensions')
+        __d_max_file_size: Any = __d.get('max_file_size')
+        __d_max_size: Any = __d.get('max_size')
         __d_tooltip: Any = __d.get('tooltip')
-        __d_allowedFileTypes: Any = __d.get('allowedFileTypes')
-        __d_maxSizePerFile: Any = __d.get('maxSizePerFile')
-        __d_maxSizeTotal: Any = __d.get('maxSizeTotal')
         name: str = __d_name
         label: Optional[str] = __d_label
         multiple: Optional[bool] = __d_multiple
+        file_extensions: Optional[List[str]] = __d_file_extensions
+        max_file_size: Optional[float] = __d_max_file_size
+        max_size: Optional[float] = __d_max_size
         tooltip: Optional[str] = __d_tooltip
-        allowedFileTypes: Optional[List[str]] = __d_allowedFileTypes
-        maxSizePerFile: Optional[int] = __d_maxSizePerFile
-        maxSizeTotal: Optional[int] = __d_maxSizeTotal
         return FileUpload(
             name,
             label,
             multiple,
+            file_extensions,
+            max_file_size,
+            max_size,
             tooltip,
-            allowedFileTypes,
-            maxSizePerFile,
-            maxSizeTotal,
         )
 
 

--- a/py/telesync/ui.py
+++ b/py/telesync/ui.py
@@ -800,10 +800,10 @@ def file_upload(
         name: str,
         label: Optional[str] = None,
         multiple: Optional[bool] = None,
+        file_extensions: Optional[List[str]] = None,
+        max_file_size: Optional[float] = None,
+        max_size: Optional[float] = None,
         tooltip: Optional[str] = None,
-        allowedFileTypes: Optional[List[str]] = None,
-        maxSizePerFile: Optional[int] = None,
-        maxSizeTotal: Optional[int] = None,
 ) -> Component:
     """Create a file upload component.
     A file upload component allows a user to browse, select and upload one or more files.
@@ -811,20 +811,20 @@ def file_upload(
     :param name: An identifying name for this component.
     :param label: Text to be displayed alongside the component.
     :param multiple: True if the component should allow multiple files to be uploaded.
+    :param file_extensions: List of allowed file extensions, e.g. `pdf`, `docx`, etc.
+    :param max_file_size: Maximum allowed size (Mb) per file. Defaults to no limit.
+    :param max_size: Maximum allowed size (Mb) for all files combined. Defaults to no limit.
     :param tooltip: An optional tooltip message displayed when a user clicks the help icon to the right of the component.
-    :param allowedFileTypes: An optional string array for defining allowed upload types. E.g. .pdf, .docx ... . Default value is empty - every file type is allowed.
-    :param maxSizePerFile: Maximum file size in Mb that none of the files uploaded can exceed. Default value is unlimited.
-    :param maxSizeTotal: Maximum file size in Mb for all uploaded files combined that cannot be excceeded. Default value is unlimited.
     :return: A :class:`telesync.types.FileUpload` instance.
     """
     return Component(file_upload=FileUpload(
         name,
         label,
         multiple,
+        file_extensions,
+        max_file_size,
+        max_size,
         tooltip,
-        allowedFileTypes,
-        maxSizePerFile,
-        maxSizeTotal,
     ))
 
 


### PR DESCRIPTION
Additional file_upload component API:
* _allowedFileTypes_ - List of allowed file extensions. Known limits: Only a single extension can be specified when using native OS filepicker (e.g. only `.gz` instead of `.tar.gz`) - https://bugs.chromium.org/p/chromium/issues/detail?id=521781
* _maxSizePerFile_ - Maximum size per single file.
* _maxSizeTotal_ - Maximum size for all files in total.

Note: File sizes are in Mb currently, not sure if this is appropriate unit. There are also 2 options. Either let it hardcoded or add another prop to define the unit. @lo5 please let me know what you think.

Closes h2oai/q#1140