### PR TITLE
feat: Catch NumPy objects and raise error #41

### DIFF
--- a/py/h2o_q/core.py
+++ b/py/h2o_q/core.py
@@ -254,7 +254,7 @@ def _is_numpy_obj(x: Any) -> bool:
 
 def _dump(xs: Any):
     if _is_numpy_obj(xs):
-        raise ValueError('NumPy objects are not serializable by Qd')
+        raise ValueError('NumPy objects are not serializable by Q')
 
     if isinstance(xs, (list, tuple)):
         return [_dump(x) for x in xs]


### PR DESCRIPTION
If PR merged, `NumPy` objects will be caught during the execution of a `_dump()` function and custom error will be raised.

## Design decisions
`NumPy` object implements `dump()` function as well which means it throws error during `_dump()` function [here](https://github.com/h2oai/qd/blob/63f7f469d6c47c476a80a72e8b0e163d6d00bccf/py/h2o_q/core.py#L264) and never gets to marshalling. To catch `NumPy` objects simple [`sys.modules`](https://docs.python.org/3/library/sys.html#sys.modules) has been used and compared to appropriate `NumPy` classes. This should be performant as `sys.modules` is dict of currently loaded modules.

## Docs
I started doing docs to educate user. As there is no place currently where to put it I'm putting it here. Please, use it or throw it 👍 .

Resolves #41

---
---

# NumPy Serialization

Q won't serialize NumPy objects. This is by design as NumPy library is not a part of Q. To properly pass a values to Q components a conversion needs to be made.

To convert ndarray to python list use [tolist()](https://numpy.org/doc/stable/reference/generated/numpy.ndarray.tolist.html?highlight=ndarray%20tolist#numpy.ndarray.tolist) function:
```python
>>> x = np.array([1, 2, 3])
>>> x # <class 'numpy.ndarray'>
array([1, 2, 3])
>>> x.tolist() # <class 'list'>
[1, 2, 3]
```

To get a scalar value use [item()](https://numpy.org/doc/stable/reference/generated/numpy.ndarray.item.html) function:
```python
>>> x = np.array([1, 2, 3])
>>> x # <class 'numpy.ndarray'>
array([1, 2, 3])
>>> x.item(0) # <class 'int'>
1
```

A simple NumPy type can be handled by Python `int()` and `float()` functions:
```python
>>> x = np.int32(128)
>>> x # <class 'numpy.int32'>
128
>>> int(x) # <class 'int'>
128
```

```python
>>> x = np.float64(12.8)
>>> x # <class 'numpy.float64'>
12.8
>>> float(x) # <class 'float'>
12.8
```

## Example

```python
from h2o_q import site, data, ui
import numpy as np

page = site['/demo']

n = 20
v = page.add('example', ui.plot_card(
    box='1 1 4 5',
    title='Interval',
    data=data('product price', n),
    plot=ui.plot([ui.mark(type='interval', x='=product', y='=price', y_min=0)])
))
data = np.random.uniform(size=n)
serializable = data.tolist()
v.data = [(f'C{i}', serializable[i]) for i in range(n)]

page.save()
```

