### PR TITLE
fix: display error stacktrace on top of all cards #89

### DIFF
--- a/ui/src/card_menu.test.tsx
+++ b/ui/src/card_menu.test.tsx
@@ -14,7 +14,7 @@ describe('CardMenu.tsx', () => {
   })
 
   it('Renders menu when commands are specified', () => {
-    const { queryByTestId } = render(<CardMenu name={name}, commands={[{ name }]} changedB={box(false)} />)
+    const { queryByTestId } = render(<CardMenu name={name} commands={[{ name }]} changedB={box(false)} />)
     expect(queryByTestId(name)).toBeTruthy()
   })
 })

--- a/ui/src/layout.tsx
+++ b/ui/src/layout.tsx
@@ -158,10 +158,12 @@ export const
             const
               placement = grid.place(c.state.box),
               { left, top, right, bottom, width, height } = placement,
-              display = placement === badPlacement ? 'none' : 'block'
+              display = placement === badPlacement ? 'none' : 'block',
+              zIndex = c.name === '__unhandled_error__' ? 1 : 'initial'
+
             c.size = { width: width || 0, height: height || 0 } // TODO compute width from grid width; height cannot be relied upon
             return (
-              <div key={c.id} className={css.slot} style={{ display, left, top, right, bottom, width, height }}>
+              <div key={c.id} className={css.slot} style={{ display, left, top, right, bottom, width, height, zIndex }}>
                 <CardView card={c} />
                 { c.state.commands && c.state.commands.length ? <CardMenu name={c.name} commands={c.state.commands} changedB={c.changed} /> : null}
               </div>


### PR DESCRIPTION
The underlying problem is, that displaying the stack trace does not prevent qd server from working. That means, you can still navigate using url. After changing url, new cards can be added to the page, which results in rendering below content. There are 2 ways to fix this:
* Client side (current implementation of this PR) - render error page above everything, but don't prevent interaction with qd server via urls for instance.
* Server side, in case of error, cut off any additional interactions with client. The implementation can consist of a simple if statement [here](https://github.com/h2oai/qd/blob/d8e9696b896a7860eae052756f4eebd695921782/py/h2o_q/server.py#L138).

Closes #89