### PR TITLE
fix: Set autoHide to false explicitly

### DIFF
--- a/ui/src/plot.tsx
+++ b/ui/src/plot.tsx
@@ -616,7 +616,7 @@ const
   makeScale = (typ: S | undefined, format: Fmt | undefined, title: S | undefined, min: S | F | undefined, max: S | F | undefined, nice: B | undefined): [ScaleOption, AxisOption | null] => {
     const
       scale: ScaleOption = {},
-       axis: AxisOption = { label: { autoHide: false } } // Bug in G2? `autoHide` should be set to false by default (it is not).
+      axis: AxisOption = { label: { autoHide: false } } // Bug in G2? `autoHide` should be set to false by default (it is not).
     if (isS(typ)) scale.type = typ as any
     if (format) scale.formatter = (v: any) => format(undefined, v)
     if (isS(title)) {


### PR DESCRIPTION
If PR merged, labels on axis' will be set to not hide explicitly. This should be the default value according to G2 documentation but apparently it is not.

## Notes

- I went through all the plots in `tour.py` and it seems PR doesn't affect anything but the #25 issue.
- The alternative approach would be to make `autoHide` a settable option.

Resolves #25