### PR TITLE
fix: remove unnecessary gap below table caused by hardcoded initial table height #165

### DIFF
--- a/ui/src/table.test.tsx
+++ b/ui/src/table.test.tsx
@@ -36,6 +36,64 @@ describe('Table.tsx', () => {
     expect(queryByTestId(name)).toBeInTheDocument()
   })
 
+  describe('Height compute', () => {
+
+    it('Computes properly for simple table - header, rows', () => {
+      tableProps = {
+        ...tableProps,
+        columns: [
+          { name: 'colname1', label: 'Col1' },
+          { name: 'colname2', label: 'Col2' },
+        ],
+      }
+      const { getByTestId } = render(<XTable model={tableProps} />)
+      expect(getByTestId(name).style.height).toBe('189px')
+
+    })
+
+    it('Computes properly for searchable table - toptoolbar, header, rows, footer', () => {
+      tableProps = {
+        ...tableProps,
+        columns: [
+          { name: 'colname1', label: 'Col1', searchable: true },
+          { name: 'colname2', label: 'Col2' },
+        ],
+      }
+      const { getByTestId } = render(<XTable model={tableProps} />)
+      expect(getByTestId(name).style.height).toBe('293px')
+    })
+
+    it('Computes properly for custom progress cell - toptoolbar, header, rows, footer', () => {
+      tableProps = {
+        ...tableProps,
+        columns: [
+          { name: 'colname1', label: 'Col1', searchable: true },
+          { name: 'colname2', label: 'Col2', cell_type: { progress: {} } },
+        ],
+      }
+      const { getByTestId } = render(<XTable model={tableProps} />)
+      expect(getByTestId(name).style.height).toBe('368px')
+    })
+
+    it('Computes properly for custom icon cell - toptoolbar, header, rows, footer', () => {
+      tableProps = {
+        ...tableProps,
+        columns: [
+          { name: 'colname1', label: 'Col1', searchable: true },
+          { name: 'colname2', label: 'Col2', cell_type: { icon: {} } },
+        ],
+        rows: [
+          { name: 'rowname1', cells: [cell11, 'BoxMultiplySolid'] },
+          { name: 'rowname2', cells: [cell21, 'BoxMultiplySolid'] },
+          { name: 'rowname2', cells: [cell31, 'BoxMultiplySolid'] }
+        ]
+      }
+      const { getByTestId } = render(<XTable model={tableProps} />)
+      expect(getByTestId(name).style.height).toBe('314px')
+    })
+
+  })
+
   describe('Q calls', () => {
     it('Sets args and calls sync on doubleclick', () => {
       const syncMock = jest.fn()

--- a/ui/src/table.tsx
+++ b/ui/src/table.tsx
@@ -411,10 +411,23 @@ export const
 
         return <span>{v}</span>
       },
+      computeHeight = () => {
+        if (m.height) return m.height
+        if (items.length > 10) return 500
+
+        const
+          topToolbarHeight = searchableKeys.length || m.groupable ? 60 : 0,
+          headerHeight = 60,
+          rowHeight = m.columns.some(c => c.cell_type)
+            ? m.columns.some(c => c.cell_type?.progress) ? 68 : 50
+            : 43,
+          footerHeight = m.downloadable || m.resettable || searchableKeys.length ? 44 : 0
+
+        return topToolbarHeight + headerHeight + (items.length * rowHeight) + footerHeight
+      },
       DataTable = () => (
         <>
           <Fluent.DetailsList
-            styles={{ contentWrapper: { minHeight: m.height ? `calc(${m.height} - 100px)` : 400 } }}
             items={filteredItemsB()}
             columns={columnsB()}
             layoutMode={Fluent.DetailsListLayoutMode.fixedColumns}
@@ -433,7 +446,7 @@ export const
         </>
       ),
       render = () => (
-        <div data-test={m.name} style={{ position: 'relative', height: m.height || 500 }}>
+        <div data-test={m.name} style={{ position: 'relative', height: computeHeight() }}>
           <Fluent.Stack horizontal horizontalAlign='space-between' >
             {m.groupable && <Fluent.Dropdown data-test='groupby' label='Group by' selectedKey={groupByKeyB()} onChange={onGroupByChange} options={groupByOptions} styles={{ root: { width: 300 } }} />}
             {!!searchableKeys.length && <Fluent.TextField data-test='search' label='Search' onChange={onSearchChange} value={searchStrB()} styles={{ root: { width: '50%' } }} />}


### PR DESCRIPTION
As mentioned in the issue, the `ScrollablePane` component is obliged to have height specified. This is said to be by design, but I am not a fan of this approach and agree that `max-height` should be used instead.

As a workaround I have implemented custom function that computes table height or sets `max-height` (`500px` currently). 

@lo5 @geomodular wdyt?
Closes #165