### PR TITLE
fix: call qd.sync for empty hash (homepage) as well #114

### DIFF
--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -46,8 +46,8 @@ const
         const h = window.location.hash
         if (h && h.length > 1) {
           qd.args['#'] = h.substr(1)
-          qd.sync()
         }
+        qd.sync()
       },
       init = () => {
         connect('/_s', onSocket)


### PR DESCRIPTION
Closes #114