### PR TITLE
fix unstable test

### DIFF
--- a/py/examples/wizard.py
+++ b/py/examples/wizard.py
@@ -45,13 +45,13 @@ async def main(q: Q):
 def try_walk_through(cy: Cypress):
     cy.visit('/demo')
     cy.locate('step1').click()
-    cy.locate('text').should('have.text', 'What is your name?')
+    cy.locate('text').should('contain.text', 'What is your name?')
     cy.locate('nickname').clear().type('Fred')
     cy.locate('step2').click()
-    cy.locate('text').should('have.text', 'Hi Fred! How do you feel right now?')
+    cy.locate('text').should('contain.text', 'Hi Fred! How do you feel right now?')
     cy.locate('feeling').clear().type('quirky')
     cy.locate('step3').click()
-    cy.locate('text').should('have.text', 'What a coincidence, Fred! I feel quirky too!')
+    cy.locate('text').should('contain.text', 'What a coincidence, Fred! I feel quirky too!')
 
 
 listen('/demo', main)

--- a/website/docs/testing.md
+++ b/website/docs/testing.md
@@ -33,13 +33,13 @@ from h2o_q import cypress
 def test_wizard(cy):
     cy.visit('/demo')
     cy.locate('step1').click()
-    cy.locate('text').should('have.text', 'What is your name?')
+    cy.locate('text').should('contain.text', 'What is your name?')
     cy.locate('nickname').clear().type('Fred')
     cy.locate('step2').click()
-    cy.locate('text').should('have.text', 'Hi Fred! How do you feel right now?')
+    cy.locate('text').should('contain.text', 'Hi Fred! How do you feel right now?')
     cy.locate('feeling').clear().type('quirky')
     cy.locate('step3').click()
-    cy.locate('text').should('have.text', 'What a coincidence, Fred! I feel quirky too!')
+    cy.locate('text').should('contain.text', 'What a coincidence, Fred! I feel quirky too!')
 
 ```
 


### PR DESCRIPTION
On some browsers the example test fails on a following assertion:
`cy.locate('text').should('have.text', 'What is your name?')`

with error:
`expected <span.css-*> to have text What is your name?, but the text was What is your name?\n`

let's use more benevolent `contain.text`