### PR TITLE
fix: rerender table icon on sort event #184

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -1,1 +1,6 @@
-module.exports = { extends: ['@commitlint/config-conventional'] }
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    "header-max-length": [0, "always", Infinity],
+  }
+}

--- a/ui/src/icon_table_cell_type.tsx
+++ b/ui/src/icon_table_cell_type.tsx
@@ -1,6 +1,6 @@
 import * as Fluent from '@fluentui/react'
 import React from 'react'
-import { bond, S } from './qd'
+import { S } from './qd'
 
 /**
  * Create a cell type that renders a column's cells as icons instead of plain text.
@@ -11,9 +11,6 @@ export interface IconTableCellType {
   color?: S
 }
 
-export const XIconTableCellType = bond(({ model: m, icon }: { model: IconTableCellType, icon: S }) => {
-  const
-    render = () => <Fluent.Icon iconName={icon} styles={{ root: { fontSize: '1.2rem', color: m.color || 'inherit' } }} />
-
-  return { render }
-})
+export const XIconTableCellType = ({ model: m, icon }: { model: IconTableCellType, icon: S }) => (
+  <Fluent.Icon iconName={icon} styles={{ root: { fontSize: '1.2rem', color: m.color || 'inherit' } }} />
+)

--- a/ui/src/progress_table_cell_type.tsx
+++ b/ui/src/progress_table_cell_type.tsx
@@ -1,9 +1,9 @@
 
 import React from 'react'
-import { bond, F, S } from './qd'
-import { ProgressArc } from './parts/progress_arc'
-import { grid } from './layout'
 import { stylesheet } from 'typestyle'
+import { grid } from './layout'
+import { ProgressArc } from './parts/progress_arc'
+import { F, S } from './qd'
 import { getTheme } from './theme'
 
 const
@@ -38,16 +38,11 @@ export interface ProgressTableCellType {
   color?: S
 }
 
-export const XProgressTableCellType = bond(({ model: m, progress }: { model: ProgressTableCellType, progress: F }) => {
-  const
-    render = () => (
-      <div className={css.container}>
-        <ProgressArc size={grid.unitInnerHeight} thickness={2} color={theme.color(m.color || 'red')} value={progress} />
-        <div className={css.percentContainer}>
-          <div className={css.percent}>{`${Math.round(progress * 100)}%`}</div>
-        </div>
-      </div>
-    )
-
-  return { render }
-})
+export const XProgressTableCellType = ({ model: m, progress }: { model: ProgressTableCellType, progress: F }) => (
+  <div className={css.container}>
+    <ProgressArc size={grid.unitInnerHeight} thickness={2} color={theme.color(m.color || 'red')} value={progress} />
+    <div className={css.percentContainer}>
+      <div className={css.percent}>{`${Math.round(progress * 100)}%`}</div>
+    </div>
+  </div>
+)

--- a/ui/src/table.tsx
+++ b/ui/src/table.tsx
@@ -407,8 +407,8 @@ export const
           return <Fluent.Link onClick={onClick}>{v}</Fluent.Link>
         }
 
-        if (col.cellType?.progress) return <XProgressTableCellType key={item[col.key]} model={col.cellType.progress} progress={item[col.key]} />
-        else if (col.cellType?.icon) return <XIconTableCellType key={item[col.key]} model={col.cellType.icon} icon={item[col.key]} />
+        if (col.cellType?.progress) return <XProgressTableCellType model={col.cellType.progress} progress={item[col.key]} />
+        else if (col.cellType?.icon) return <XIconTableCellType model={col.cellType.icon} icon={item[col.key]} />
 
         return <span>{v}</span>
       },


### PR DESCRIPTION
Icons didn't move because `bond` component doesn't update on props change as opposed to regular React function component (Tried with that one and it worked). As a solution I added a `key` prop to tell React that this component is different than previous one and should be replaced. Note that this is not an optimal solution performance wise since simple component update would be sufficient in this case. @lo5 any hints on how to rerender `bond` component on props change? I tried to use a boxed variable as a prop and return it afterwards but it didn't help.

Closes #184