### PR TITLE
Candidate alternative strategy for front-end state management

### DIFF
--- a/py/h2o_wave/types.py
+++ b/py/h2o_wave/types.py
@@ -4030,6 +4030,7 @@ class VegaVisualization:
             visible,
         )
 
+id_ = 0
 
 class Stat:
     """Create a stat (a label-value pair) for displaying a metric.
@@ -4234,6 +4235,9 @@ class Component:
             stats: Optional[Stats] = None,
             inline: Optional[Inline] = None,
     ):
+        global id_
+        id_ += 1
+        self.id = id_
         self.text = text
         """Text block."""
         self.text_xl = text_xl
@@ -4314,6 +4318,7 @@ class Component:
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""
         return _dump(
+            id=self.id,
             text=None if self.text is None else self.text.dump(),
             text_xl=None if self.text_xl is None else self.text_xl.dump(),
             text_l=None if self.text_l is None else self.text_l.dump(),

--- a/py/h2o_wave/types.py
+++ b/py/h2o_wave/types.py
@@ -18,6 +18,7 @@
 
 from typing import Any, Optional, Union, Dict, List
 from .core import Data
+import uuid
 
 Value = Union[str, float, int]
 PackedRecord = Union[dict, str]
@@ -4030,7 +4031,6 @@ class VegaVisualization:
             visible,
         )
 
-id_ = 0
 
 class Stat:
     """Create a stat (a label-value pair) for displaying a metric.
@@ -4235,9 +4235,7 @@ class Component:
             stats: Optional[Stats] = None,
             inline: Optional[Inline] = None,
     ):
-        global id_
-        id_ += 1
-        self.id = id_
+        self.id = str(uuid.uuid4())
         self.text = text
         """Text block."""
         self.text_xl = text_xl

--- a/tools/wavegen/src/wavegen.ts
+++ b/tools/wavegen/src/wavegen.ts
@@ -379,6 +379,10 @@ const
           }
         }
 
+        // Every form component element has to have a unique id to make React list rerendering work correctly.
+        if (type.name === 'Component') {
+          p('id_ = 0')
+        }
         p('')
         p(`class ${type.name}:`)
         p(`    """` + genComments(type.comments, '    '))
@@ -389,6 +393,12 @@ const
           p(`            ${getSigWithDefault(m)},`)
         }
         p(`    ):`)
+        // Every form component element has to have a unique id to make React list rerendering work correctly.
+        if (type.name === 'Component') {
+          p(`        global id_`)
+          p(`        id_ += 1`)
+          p(`        self.id = id_`)
+        }
         for (const m of type.members) {
           p(`        self.${m.name} = ${m.name}`)
           p(`        """${m.comments.join(' ')}"""`)
@@ -407,6 +417,10 @@ const
           }
         }
         p(`        return _dump(`)
+        // Every form component element has to have a unique id to make React list rerendering work correctly.
+        if (type.name === 'Component') {
+          p(`            id=self.id,`)
+        }
         if (type.isRoot) {
           p(`            view='${type.file}',`)
         }

--- a/tools/wavegen/src/wavegen.ts
+++ b/tools/wavegen/src/wavegen.ts
@@ -379,10 +379,6 @@ const
           }
         }
 
-        // Every form component element has to have a unique id to make React list rerendering work correctly.
-        if (type.name === 'Component') {
-          p('id_ = 0')
-        }
         p('')
         p(`class ${type.name}:`)
         p(`    """` + genComments(type.comments, '    '))
@@ -395,9 +391,7 @@ const
         p(`    ):`)
         // Every form component element has to have a unique id to make React list rerendering work correctly.
         if (type.name === 'Component') {
-          p(`        global id_`)
-          p(`        id_ += 1`)
-          p(`        self.id = id_`)
+          p(`        self.id = str(uuid.uuid4())`)
         }
         for (const m of type.members) {
           p(`        self.${m.name} = ${m.name}`)
@@ -486,6 +480,7 @@ const
         p('')
         p('from typing import Any, Optional, Union, Dict, List')
         p('from .core import Data')
+        p('import uuid')
         p('')
         p('Value = Union[str, float, int]')
         p('PackedRecord = Union[dict, str]')

--- a/ui/.eslintrc.js
+++ b/ui/.eslintrc.js
@@ -21,8 +21,7 @@ module.exports = {
   },
   "parserOptions": {
     "ecmaFeatures": {
-      "jsx": true,
-      "modules": true
+      "jsx": true
     },
     "ecmaVersion": 2018,
     "sourceType": "module",

--- a/ui/.eslintrc.js
+++ b/ui/.eslintrc.js
@@ -21,7 +21,8 @@ module.exports = {
   },
   "parserOptions": {
     "ecmaFeatures": {
-      "jsx": true
+      "jsx": true,
+      "modules": true
     },
     "ecmaVersion": 2018,
     "sourceType": "module",

--- a/ui/src/dialog.tsx
+++ b/ui/src/dialog.tsx
@@ -15,7 +15,7 @@
 import * as Fluent from '@fluentui/react'
 import React from 'react'
 import { XButtons } from './button'
-import { Component, XComponents } from './form'
+import { Component, XComponents, ComponentWithId } from './form'
 import { B, bond, qd, S } from './qd'
 
 /**
@@ -58,7 +58,7 @@ export default bond(() => {
 
       return (
         <Fluent.Dialog hidden={!dialogB()} dialogContentProps={dialogContentProps} modalProps={{ isBlocking: blocking }} minWidth={width} maxWidth={width}>
-          <XComponents items={items} />
+          <XComponents items={items as ComponentWithId[]} />
           {lastComponent?.buttons && <Fluent.DialogFooter><XButtons model={lastComponent.buttons} /></Fluent.DialogFooter>}
         </Fluent.Dialog>
       )

--- a/ui/src/expander.tsx
+++ b/ui/src/expander.tsx
@@ -15,7 +15,7 @@
 import * as Fluent from '@fluentui/react'
 import React from 'react'
 import { stylesheet } from 'typestyle'
-import { Component, XComponents } from './form'
+import { Component, XComponents, ComponentWithId } from './form'
 import { B, bond, box, S, qd } from './qd'
 import { displayMixin } from './theme'
 
@@ -83,7 +83,9 @@ export const
                 onClick={onClick}
                 styles={{ root: { paddingLeft: 0 }, icon: { marginLeft: 0 } }}>{m.label}</Fluent.ActionButton>
             </Fluent.Separator>
-            <XComponents items={m.items || []} />
+            <div>
+              <XComponents items={m.items as ComponentWithId[] || []} />
+            </div>
           </div>
         )
       }

--- a/ui/src/form.tsx
+++ b/ui/src/form.tsx
@@ -34,7 +34,7 @@ import { MessageBar, XMessageBar } from './message_bar'
 import { Picker, XPicker } from './picker'
 import { Visualization, XVisualization } from './plot'
 import { Progress, XProgress } from './progress'
-import { B, bond, Card, Packed, S, unpack, xid } from './qd'
+import { B, bond, Card, Packed, S, unpack, U } from './qd'
 import { RangeSlider, XRangeSlider } from './range_slider'
 import { Separator, XSeparator } from './separator'
 import { Slider, XSlider } from './slider'
@@ -200,9 +200,9 @@ const
 export enum XComponentAlignment { Top, Left, Right }
 
 export const
-  XComponents = ({ items, alignment, inset }: { items: Component[], alignment?: XComponentAlignment, inset?: B }) => {
+  XComponents = ({ items, alignment, inset }: { items: ComponentWithId[], alignment?: XComponentAlignment, inset?: B }) => {
     const
-      components = items.map((m, i) => <XComponent key={i} model={m} />),
+      components = items.map(m => <XComponent key={m.id} model={m} />),
       className = alignment === XComponentAlignment.Left
         ? clas(css.horizontal, css.horizontalLeft, inset ? css.inset : '')
         : alignment === XComponentAlignment.Right
@@ -218,6 +218,7 @@ export const
     />
   )
 
+export type ComponentWithId = Component & { id: U }
 
 const
   XComponent = ({ model: m }: { model: Component }) => {
@@ -268,8 +269,12 @@ export const
       render = () => {
         const
           s = theme.merge(defaults, state),
+<<<<<<< HEAD
           title = s.title,
           items = unpack<Component[]>(s.items) // XXX ugly
+=======
+          items = unpack<ComponentWithId[]>(s.items) // XXX ugly
+>>>>>>> feat: add unique id to each form component to allow react rerender form list properly
 
         return (
           <div data-test={name} className={css.card}>

--- a/ui/src/form.tsx
+++ b/ui/src/form.tsx
@@ -34,7 +34,7 @@ import { MessageBar, XMessageBar } from './message_bar'
 import { Picker, XPicker } from './picker'
 import { Visualization, XVisualization } from './plot'
 import { Progress, XProgress } from './progress'
-import { B, bond, Card, Packed, S, unpack, U } from './qd'
+import { B, bond, Card, Packed, S, U, unpack } from './qd'
 import { RangeSlider, XRangeSlider } from './range_slider'
 import { Separator, XSeparator } from './separator'
 import { Slider, XSlider } from './slider'
@@ -212,7 +212,7 @@ export const
   },
   XInline = ({ model: m }: { model: Inline }) => (
     <XComponents
-      items={m.items}
+      items={m.items as ComponentWithId[]}
       alignment={m.justify === 'end' ? XComponentAlignment.Right : XComponentAlignment.Left}
       inset={m.inset}
     />
@@ -269,12 +269,8 @@ export const
       render = () => {
         const
           s = theme.merge(defaults, state),
-<<<<<<< HEAD
           title = s.title,
-          items = unpack<Component[]>(s.items) // XXX ugly
-=======
           items = unpack<ComponentWithId[]>(s.items) // XXX ugly
->>>>>>> feat: add unique id to each form component to allow react rerender form list properly
 
         return (
           <div data-test={name} className={css.card}>

--- a/ui/src/form.tsx
+++ b/ui/src/form.tsx
@@ -202,7 +202,7 @@ export enum XComponentAlignment { Top, Left, Right }
 export const
   XComponents = ({ items, alignment, inset }: { items: Component[], alignment?: XComponentAlignment, inset?: B }) => {
     const
-      components = items.map(m => <XComponent key={xid()} model={m} />),
+      components = items.map((m, i) => <XComponent key={i} model={m} />),
       className = alignment === XComponentAlignment.Left
         ? clas(css.horizontal, css.horizontalLeft, inset ? css.inset : '')
         : alignment === XComponentAlignment.Right

--- a/ui/src/frame.tsx
+++ b/ui/src/frame.tsx
@@ -76,7 +76,7 @@ const
   )
 
 // HACK: Applying width/height styles directly on iframe don't work in Chrome/FF; so wrap in div instead.
-export const XFrame = ({ model: { name, path, content, width = '100%', height = '150px', visible } }: { model: Frame }) => (
+export const XFrame = ({ model: { name, path, content, width = '100%', height = '150px', visible = true } }: { model: Frame }) => (
   <div data-test={name} style={{ width, ...displayMixin(visible), height: visible ? height : 0 }}>
     <InlineFrame path={path} content={content} />
   </div>

--- a/ui/src/frame.tsx
+++ b/ui/src/frame.tsx
@@ -77,7 +77,7 @@ const
 
 // HACK: Applying width/height styles directly on iframe don't work in Chrome/FF; so wrap in div instead.
 export const XFrame = ({ model: { name, path, content, width = '100%', height = '150px', visible } }: { model: Frame }) => (
-  <div data-test={name} style={{ width, height, ...displayMixin(visible) }}>
+  <div data-test={name} style={{ width, ...displayMixin(visible), height: visible ? height : 0 }}>
     <InlineFrame path={path} content={content} />
   </div>
 )

--- a/ui/src/section.tsx
+++ b/ui/src/section.tsx
@@ -14,7 +14,7 @@
 
 import React from 'react'
 import { stylesheet } from 'typestyle'
-import { Component, XComponentAlignment, XComponents } from './form'
+import { Component, XComponentAlignment, XComponents, ComponentWithId } from './form'
 import { CardEffect, cards } from './layout'
 import { Markdown } from './markdown'
 import { bond, Card, Packed, S, unpack } from './qd'
@@ -65,7 +65,7 @@ export const
           components = unpack<Component[]>(items), // XXX ugly
           form = items && (
             <div>
-              <XComponents items={components} alignment={XComponentAlignment.Right} />
+              <XComponents items={components as ComponentWithId[]} alignment={XComponentAlignment.Right} />
             </div>
           )
 

--- a/ui/src/table.tsx
+++ b/ui/src/table.tsx
@@ -183,6 +183,7 @@ export const
         return item
       }),
       isMultiple = m.values?.length || m.multiple,
+      { visible = true } = m,
       filteredItemsB = box(items),
       searchableKeys = m.columns.filter(({ searchable }) => searchable).map(({ name }) => name),
       searchStrB = box(''),
@@ -485,7 +486,7 @@ export const
         </>
       ),
       render = () => (
-        <div data-test={m.name} style={{ position: 'relative', height: computeHeight(), ...displayMixin(m.visible) }}>
+        <div data-test={m.name} style={{ position: 'relative', ...displayMixin(visible), height: visible ? computeHeight() : 0, }}>
           <Fluent.Stack horizontal horizontalAlign='space-between' >
             {m.groupable && <Fluent.Dropdown data-test='groupby' label='Group by' selectedKey={groupByKeyB()} onChange={onGroupByChange} options={groupByOptions} styles={{ root: { width: 300 } }} />}
             {!!searchableKeys.length && <Fluent.TextField data-test='search' label='Search' onChange={onSearchChange} value={searchStrB()} styles={{ root: { width: '50%' } }} />}

--- a/ui/src/theme.ts
+++ b/ui/src/theme.ts
@@ -69,10 +69,7 @@ export const
   rgba = (r: U, g: U, b: U, a: F) => `rgba(${r},${g},${b},${a.toFixed(1)})`,
   gray = (b: U) => { const h = b.toString(16); return `#${h}${h}${h}` },
   centerMixin = () => ({ display: 'flex', alignItems: 'center', justifyContent: 'center' }),
-  displayMixin = (visible = true): React.CSSProperties => {
-    if (visible) return {}
-    return { display: 'none' }
-  }
+  displayMixin = (visible = true): React.CSSProperties => ({ overflow: visible ? 'inherit' : 'hidden', height: visible ? 'inherit' : 0, visibility: visible ? 'visible' : 'hidden' })
 
 const
   black: RGB = { r: 0, g: 0, b: 0 },


### PR DESCRIPTION
This PR allows controlled rerendering form components by adding a unique id to each form component that is created at python side. This is truly the only option from my point of view since python server is our single source of truth for the app state as a whole. This allows two cases we needed to cover:
* Do not rerender a form component if python instance is not changed itself - only a particular property (like visible for instance changed). This keeps the form component state as is and just updates the prop.
* Change the whole `items` array on card (wizard tour example). If the references in items list change, we want to destroy the old components and create new ones.

TODO: Add R generation also.

This would also allow us to keep state on component level in UI components - resolves https://github.com/h2oai/wave/issues/150 - I have checked with datepicker component for now and works just fine.

This unique id is considered an implementation detail and should not be exposed to app developers.