### PR TITLE
Rename Q8S environment variable Prefix to H2O_CLOUD

### DIFF
--- a/website/docs/enterprise/developer-guide.md
+++ b/website/docs/enterprise/developer-guide.md
@@ -96,7 +96,7 @@ string
 * `Env` - request for a literal value/secret to be injected into an instance at startup-time as an Env variable;
   repeated; see [Utilizing Secrets](#utilizing-secrets).
   * `Name` - name of the Env variable to the injected into the Python process;
-    names prefixed with `Q8S` are disallowed.
+    names prefixed with `H2O_CLOUD` are disallowed.
   * `Secret` - name of the shared secret to use; each secret can contain multiple key-value pairs;
     cannot be used together with `Value`.
   * `SecretKey` - name of the key within the secret to use; cannot be used together with `Value`.


### PR DESCRIPTION
Renaming the Q8S variable that we use to pass secrets to the wave-launcher, last piece I can see that uses those letters in the enterprise docs. 

https://github.com/h2oai/h2o-ai-cloud/pull/369 is the corresponding h2o-ai-cloud PR.