### PR TITLE
feat: allow nav items to specify icons #253

### DIFF
--- a/py/examples/nav.py
+++ b/py/examples/nav.py
@@ -5,6 +5,8 @@ from h2o_wave import site, ui
 
 page = site['/demo']
 
+github_logo_url = 'https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png'
+
 page['tabs'] = ui.nav_card(
     box='1 1 2 5',
     items=[
@@ -14,8 +16,8 @@ page['tabs'] = ui.nav_card(
             ui.nav_item(name='#menu/eggs', label='Eggs'),
         ]),
         ui.nav_group('Help', items=[
-            ui.nav_item(name='#about', label='About'),
-            ui.nav_item(name='#support', label='Support'),
+            ui.nav_item(name='#about', label='About', icon='Help'),
+            ui.nav_item(name='#support', label='Support', icon=github_logo_url),
         ])
     ],
 )

--- a/py/h2o_wave/types.py
+++ b/py/h2o_wave/types.py
@@ -5068,11 +5068,14 @@ class NavItem:
             self,
             name: str,
             label: str,
+            icon: Optional[str] = None,
     ):
         self.name = name
         """The name of this item. Prefix the name with a '#' to trigger hash-change navigation."""
         self.label = label
         """The label to display."""
+        self.icon = icon
+        """The icon to be displayed left of the label. Available values are icon names and image urls."""
 
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""
@@ -5083,6 +5086,7 @@ class NavItem:
         return _dump(
             name=self.name,
             label=self.label,
+            icon=self.icon,
         )
 
     @staticmethod
@@ -5094,11 +5098,14 @@ class NavItem:
         __d_label: Any = __d.get('label')
         if __d_label is None:
             raise ValueError('NavItem.label is required.')
+        __d_icon: Any = __d.get('icon')
         name: str = __d_name
         label: str = __d_label
+        icon: Optional[str] = __d_icon
         return NavItem(
             name,
             label,
+            icon,
         )
 
 

--- a/py/h2o_wave/ui.py
+++ b/py/h2o_wave/ui.py
@@ -2335,18 +2335,21 @@ def meta_card(
 def nav_item(
         name: str,
         label: str,
+        icon: Optional[str] = None,
 ) -> NavItem:
     """Create a navigation item.
 
     Args:
         name: The name of this item. Prefix the name with a '#' to trigger hash-change navigation.
         label: The label to display.
+        icon: The icon to be displayed left of the label. Available values are icon names and image urls.
     Returns:
         A `h2o_wave.types.NavItem` instance.
     """
     return NavItem(
         name,
         label,
+        icon,
     )
 
 

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -2651,15 +2651,19 @@ ui_meta_card <- function(
 #'
 #' @param name The name of this item. Prefix the name with a '#' to trigger hash-change navigation.
 #' @param label The label to display.
+#' @param icon The icon to be displayed left of the label. Available values are icon names and image urls.
 #' @return A NavItem instance.
 ui_nav_item <- function(
   name,
-  label) {
+  label,
+  icon = NULL) {
   .guard_scalar("name", "character", name)
   .guard_scalar("label", "character", label)
+  .guard_scalar("icon", "character", icon)
   .o <- list(
     name=name,
-    label=label)
+    label=label,
+    icon=icon)
   class(.o) <- append(class(.o), c(.h2oq_obj, "h2oq_NavItem"))
   return(.o)
 }

--- a/ui/src/nav.test.tsx
+++ b/ui/src/nav.test.tsx
@@ -68,4 +68,19 @@ describe('Nav.tsx', () => {
     expect(window.location.hash).toBe(hashName)
   })
 
+  it('Renders image as icon when specified', () => {
+    const props = { ...navProps }
+    props.state.items[0].items[0].icon = 'https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png'
+    const { container } = render(<View {...props} />)
+
+    expect(container.querySelector('.ms-Image')).toBeInTheDocument()
+  })
+  it('Renders icon when specified', () => {
+    const props = { ...navProps }
+    props.state.items[0].items[0].icon = 'Home'
+    const { container } = render(<View {...props} />)
+
+    expect(container.querySelector('.ms-Icon')).toBeInTheDocument()
+  })
+
 })

--- a/ui/src/nav.tsx
+++ b/ui/src/nav.tsx
@@ -1,7 +1,7 @@
-import { INavLink, INavLinkGroup, Nav } from '@fluentui/react'
+import * as Fluent from '@fluentui/react'
 import React from 'react'
 import { cards } from './layout'
-import { bond, Card, S, qd } from './qd'
+import { bond, Card, qd, S } from './qd'
 
 /** Create a navigation item. */
 interface NavItem {
@@ -9,6 +9,8 @@ interface NavItem {
   name: S
   /** The label to display. */
   label: S
+  /** The icon to be displayed left of the label. Available values are icon names and image urls. */
+  icon?: S
 }
 
 /** Create a group of navigation items. */
@@ -29,23 +31,40 @@ export const
   View = bond(({ name, state, changed }: Card<State>) => {
     const
       render = () => {
-        const groups = state.items.map((g): INavLinkGroup => ({
-          name: g.label,
-          links: g.items.map(({ name, label }): INavLink => ({
-            key: name,
-            name: label,
-            url: '',
-            onClick: () => {
-              if (name.startsWith('#')) {
-                window.location.hash = name.substr(1)
-                return
+        const
+          onRenderLink = (props?: Fluent.INavLink, defaultRender?: (props?: Fluent.INavLink) => JSX.Element | null) => {
+            if (!defaultRender || !props) return null
+
+            const isFluentIcon = !/.+\..+/.test(props.customIcon)
+            if (!isFluentIcon) delete props.iconProps?.iconName
+
+            return (
+              <Fluent.Stack horizontal verticalAlign='center' horizontalAlign='space-between'>
+                {!isFluentIcon && <Fluent.Image src={props.customIcon} width={24} height={24} styles={{ root: { marginRight: 6 } }} />}
+                {defaultRender(props)}
+              </Fluent.Stack>
+            )
+          },
+          groups = state.items.map((g): Fluent.INavLinkGroup => ({
+            name: g.label,
+            links: g.items.map(({ name, label, icon }): Fluent.INavLink => ({
+              key: name,
+              name: label,
+              url: '',
+              customIcon: icon,
+              iconProps: { iconName: icon },
+              onClick: () => {
+                if (name.startsWith('#')) {
+                  window.location.hash = name.substr(1)
+                  return
+                }
+                qd.args[name] = true
+                qd.sync()
               }
-              qd.args[name] = true
-              qd.sync()
-            }
+            })
+            )
           }))
-        }))
-        return <div data-test={name}><Nav groups={groups} /></div>
+        return <div data-test={name}><Fluent.Nav groups={groups} onRenderLink={onRenderLink} /></div>
       }
     return { render, changed }
   })


### PR DESCRIPTION
Support for custom images within `NavItem`. The solution proposed in the issue could not be implemented because the `imgProps` are just config values, but `INavlink` doesn't provide a built in way for passing images.

![image](https://user-images.githubusercontent.com/64769322/97559380-a87a8280-19dd-11eb-8e97-f6e00abde7c3.png)


My proposed solution is building a custom render function to add the image ourselves if necessary. I am not really a fan of this approach though. A cleaner way would be to allow app developers register their own icons via meta card. These would be then available by the name they chose. This would allow using FontAwesome or icon8 icons. The advantage of this would be having a standardized way of adding new icons that would be available throughout all components, not just `NavItem` as it is currently.

However, if this solution is good enough, I can push it on top of `0.8.1` release after approval.

Closes #253