### PR TITLE
Update blocking overlay for css only solution

### DIFF
--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import * as Fluent from '@fluentui/react'
-import { box, on, WaveErrorCode, WaveEventType } from 'h2o-wave'
+import { box, WaveErrorCode, WaveEventType } from 'h2o-wave'
 import React from 'react'
 import { stylesheet } from 'typestyle'
 import Dialog from './dialog'
@@ -53,7 +53,7 @@ const
       left: 0, top: 0, right: 0, bottom: 0,
       opacity: 0.8,
       zIndex: 1,
-      transition: 'opacity 1s 500ms',
+      transition: 'opacity 500ms 500ms',
     },
     notFoundOverlay: {
       display: 'flex',
@@ -65,10 +65,9 @@ const
 const
   BusyOverlay = bond(() => {
     const
-      spinB = box(false),
       render = () => (
         <div className={busyB() ? css.busyOverlay : css.freeOverlay}>
-          <Fluent.Spinner className={css.centerFullHeight} style={{ opacity: spinB() ? 0.8 : 0 }} label='Loading...' size={Fluent.SpinnerSize.large} />
+          <Fluent.Spinner className={css.centerFullHeight} label='Loading...' size={Fluent.SpinnerSize.large} />
         </div>
       )
     return { render, busyB }

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -52,7 +52,7 @@ const
       position: 'fixed',
       left: 0, top: 0, right: 0, bottom: 0,
       opacity: 0.8,
-      zIndex: 1,
+      zIndex: 999,
       transition: 'opacity 500ms 500ms',
     },
     notFoundOverlay: {

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -43,12 +43,17 @@ const
       color: cssVar('$text'),
     },
     freeOverlay: {
-      display: 'none',
       position: 'fixed',
       left: 0, top: 0, right: 0, bottom: 0,
+      opacity: 0,
+      zIndex: -1,
     },
     busyOverlay: {
-      display: 'block',
+      position: 'fixed',
+      left: 0, top: 0, right: 0, bottom: 0,
+      opacity: 0.8,
+      zIndex: 1,
+      transition: 'opacity 1s 500ms',
     },
     notFoundOverlay: {
       display: 'flex',
@@ -59,25 +64,14 @@ const
 
 const
   BusyOverlay = bond(() => {
-    let
-      spinTimeout = 0
     const
-      spinDelay = 500, // ms
       spinB = box(false),
       render = () => (
-        <div className={busyB() ? clas(css.freeOverlay, css.busyOverlay) : css.freeOverlay}>
+        <div className={busyB() ? css.busyOverlay : css.freeOverlay}>
           <Fluent.Spinner className={css.centerFullHeight} style={{ opacity: spinB() ? 0.8 : 0 }} label='Loading...' size={Fluent.SpinnerSize.large} />
         </div>
       )
-    on(busyB, busy => {
-      window.clearTimeout(spinTimeout)
-      if (busy) {
-        spinTimeout = window.setTimeout(() => spinB(true), spinDelay)
-      } else {
-        spinB(false)
-      }
-    })
-    return { render, busyB, spinB }
+    return { render, busyB }
   }),
   NotFoundOverlay = bond(() => {
     const


### PR DESCRIPTION
If PR merged, blocking overlay will be updated of css solution.

The original solution worked but had opacity transition to non-blocking overlay as well. i.e.: if no blocking state on server happened in 2s+, user would have experienced the same - correct transition.

This PR separates classes and prevents transition mixing.

Continuation of #17 and #236