### PR TITLE
Update cypress script to support for wave 0.9

### DIFF
--- a/test/cypress.py
+++ b/test/cypress.py
@@ -180,7 +180,6 @@ def main():
         "--app-module",
         help="python module with wave app",
         type=str,
-        default="src.app",
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
Wave CLI was introduced with wave 0.9 and now `wave run` command can be used to run wave apps in development mode. This change address the updates required for `cypress.py` script to be compatible with wave 0.9.

- Add wave `wave run` command to run the wave apps for testing
- Change wave executable from `./wave` to `./waved`