### PR TITLE
feat: allow submitting text phrases within markdown

### DIFF
--- a/py/examples/markdown_submit_text.py
+++ b/py/examples/markdown_submit_text.py
@@ -1,0 +1,13 @@
+# Markdown / Submit / Text
+# Use "?" to prefix the desired q.args.key that you want to have submitted after clicking a phrase.
+# ---
+from h2o_wave import site, ui, main
+
+page = site['/demo']
+
+page['example'] = ui.markdown_card(
+    box='1 1 3 -1',
+    title='I was made using markdown!',
+    content='The quick brown [fox](?fox) jumps over the lazy [dog](?dog).'
+)
+page.save()

--- a/py/examples/markdown_submit_text.py
+++ b/py/examples/markdown_submit_text.py
@@ -5,17 +5,21 @@
 from h2o_wave import main, app, Q, ui
 
 
+def get_form_items(clicked: str):
+    return [
+        ui.text(content='The quick brown [fox](?fox) jumps over the lazy [dog](?dog)'),
+        ui.text(content=f'Clicked: {clicked}'),
+    ]
+
+
 @app('/demo')
 async def serve(q: Q):
     if not q.client.initialized:
-        q.page['clicked'] = ui.form_card(box='1 1 3 2', items=[
-            ui.text(content='The quick brown [fox](?fox) jumps over the lazy [dog](?dog).'),
-            ui.text(content='Clicked: nothing'),
-        ])
+        q.page['example'] = ui.form_card(box='1 1 3 2', items=get_form_items('Nothing'))
         q.client.initialized = True
 
     if q.args.fox:
-        q.page['clicked'].items[1].text.content = 'Clicked: fox'
+        q.page['example'].items = get_form_items('fox')
     if q.args.dog:
-        q.page['clicked'].items[1].text.content = 'Clicked: dog'
+        q.page['example'].items = get_form_items('dog')
     await q.page.save()

--- a/py/examples/markdown_submit_text.py
+++ b/py/examples/markdown_submit_text.py
@@ -1,13 +1,21 @@
 # Markdown / Submit / Text
 # Use "?" to prefix the desired q.args.key that you want to have submitted after clicking a phrase.
 # ---
-from h2o_wave import site, ui, main
 
-page = site['/demo']
+from h2o_wave import main, app, Q, ui
 
-page['example'] = ui.markdown_card(
-    box='1 1 3 -1',
-    title='I was made using markdown!',
-    content='The quick brown [fox](?fox) jumps over the lazy [dog](?dog).'
-)
-page.save()
+
+@app('/demo')
+async def serve(q: Q):
+    if not q.client.initialized:
+        q.page['clicked'] = ui.form_card(box='1 1 3 2', items=[
+            ui.text(content='The quick brown [fox](?fox) jumps over the lazy [dog](?dog).'),
+            ui.text(content='Clicked: nothing'),
+        ])
+        q.client.initialized = True
+
+    if q.args.fox:
+        q.page['clicked'].items[1].text.content = 'Clicked: fox'
+    if q.args.dog:
+        q.page['clicked'].items[1].text.content = 'Clicked: dog'
+    await q.page.save()

--- a/py/examples/tour.conf
+++ b/py/examples/tour.conf
@@ -77,6 +77,7 @@ template.py
 template_data.py
 markdown.py
 markdown_data.py
+markdown_submit_text.py
 markup.py
 nav.py
 toolbar.py

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -151,6 +151,7 @@ const
       },
       dispose = () => {
         window.removeEventListener('hashchange', onHashChanged)
+        window.removeEventListener('md-link-click', onMdLinkClick)
       }
 
     return { init, render, dispose, contentB, themeB }

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -101,10 +101,11 @@ const
   }),
   App = bond(() => {
     const
-      onHashChanged = () => {
+      onHashChanged = () => wave.push(),
+      onMdLinkClick = ({ detail }: any) => {
+        wave.args[detail] = true
         wave.push()
       },
-      onMdLinkClick = ({ detail }: any) => wave.args[detail] = true,
       init = () => {
         listen()
         window.addEventListener('hashchange', onHashChanged)

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -104,9 +104,11 @@ const
       onHashChanged = () => {
         wave.push()
       },
+      onMdLinkClick = ({ detail }: any) => qd.args[detail] = true,
       init = () => {
         listen()
         window.addEventListener('hashchange', onHashChanged)
+        window.addEventListener('md-link-click', onMdLinkClick)
       },
       render = () => {
         const e = contentB()

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -104,7 +104,7 @@ const
       onHashChanged = () => {
         wave.push()
       },
-      onMdLinkClick = ({ detail }: any) => qd.args[detail] = true,
+      onMdLinkClick = ({ detail }: any) => wave.args[detail] = true,
       init = () => {
         listen()
         window.addEventListener('hashchange', onHashChanged)

--- a/ui/src/markdown.test.tsx
+++ b/ui/src/markdown.test.tsx
@@ -12,24 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { render } from '@testing-library/react'
-import * as T from 'h2o-wave'
+import { fireEvent, render } from '@testing-library/react'
 import React from 'react'
-import { View } from './markdown'
-
-const
-  name = 'markdown',
-  markdown_props: T.Model<any> = {
-    name,
-    state: { content: '' },
-    changed: T.box(false)
-  }
+import { Markdown } from './markdown'
 
 describe('Markdown.tsx', () => {
 
-  it('Renders data-test attr', () => {
-    const { queryByTestId } = render(<View {...markdown_props} />)
-    expect(queryByTestId(name)).toBeInTheDocument()
-  })
+  // Jest JSDOM does not support event system, so we can only check if the event was dispatched.
+  it('Dispatches a custom event when link prefixed with "?"', () => {
+    const dispatchEventMock = jest.fn()
+    window.dispatchEvent = dispatchEventMock
+    const { getByText } = render(<Markdown source='The quick brown [fox](?fox) jumps over the lazy [dog](dog).' />)
 
+    fireEvent.click(getByText('fox'))
+    expect(dispatchEventMock).toHaveBeenCalled()
+
+    dispatchEventMock.mockClear()
+    fireEvent.click(getByText('dog'))
+    expect(dispatchEventMock).not.toHaveBeenCalled()
+  })
 })

--- a/ui/src/markdown.tsx
+++ b/ui/src/markdown.tsx
@@ -66,9 +66,7 @@ const
 
 export const
   markdown = MarkdownIt({ html: true, linkify: true, typographer: true, }),
-  markdownSafe = MarkdownIt({ typographer: true, linkify: true }),
-  Markdown = ({ source }: { source: S }) => <div className={clas(css.markdown, 'wave-markdown')} dangerouslySetInnerHTML={{ __html: markdown.render(source) }} />,
-  MarkdownSafe = ({ source }: { source: S }) => <div className={clas(css.markdown, 'wave-markdown')} dangerouslySetInnerHTML={{ __html: markdownSafe.render(source) }} />
+  Markdown = ({ source }: { source: S }) => <div className={clas(css.markdown, 'wave-markdown')} dangerouslySetInnerHTML={{ __html: markdown.render(source) }} />
 
 markdown.renderer.rules.text = (tokens: Token[], idx: U, options: MarkdownIt.Options, env: any, self: Renderer) => {
   const

--- a/ui/src/markdown.tsx
+++ b/ui/src/markdown.tsx
@@ -68,6 +68,7 @@ export const
   markdown = MarkdownIt({ html: true, linkify: true, typographer: true, }),
   Markdown = ({ source }: { source: S }) => <div className={clas(css.markdown, 'wave-markdown')} dangerouslySetInnerHTML={{ __html: markdown.render(source) }} />
 
+const defaultRenderer = markdown.renderer.rules.text
 markdown.renderer.rules.text = (tokens: Token[], idx: U, options: MarkdownIt.Options, env: any, self: Renderer) => {
   const
     linkOpenToken = tokens[idx + 1],
@@ -75,7 +76,7 @@ markdown.renderer.rules.text = (tokens: Token[], idx: U, options: MarkdownIt.Opt
 
   // Onclick has to be inlined otherwise a global function would be needed. Custom event is handled at App.tsx. Return false prevents navigation behavior.
   if (hrefAttr?.startsWith('?')) linkOpenToken.attrPush(['onclick', `window.dispatchEvent(new CustomEvent("md-link-click", {detail:"${hrefAttr.substring(1)}" }));return false`])
-  return markdown.renderer.rules.text!(tokens, idx, options, env, self)
+  return defaultRenderer!(tokens, idx, options, env, self)
 }
 
 /**


### PR DESCRIPTION
This PR intercepts `markdown-it` text rendering process and adds an `onclick` listener if the href attribute is prefixed with `?`. The listener code is inlined, otherwise it would require a globally available function. Apart from the fact that globals in general are not a good idea, it would be of no use since webpack changes function names during prod build, so the strings would not match either way.

This solution proposes use of custom events, both dispatched and listened on `window` object.

Closes #293