### PR TITLE
Pass access token to the Python client

### DIFF
--- a/client.go
+++ b/client.go
@@ -34,18 +34,19 @@ var (
 
 // Client represent a websocket (UI) client.
 type Client struct {
-	id       string          // unique id
-	addr     string          // remote address
-	username string          // username, or "default-user"
-	subject  string          // oidc subject identifier
-	broker   *Broker         // broker
-	conn     *websocket.Conn // connection
-	routes   []string        // watched routes
-	data     chan []byte     // send data
+	id          string          // unique id
+	addr        string          // remote address
+	username    string          // username, or "default-user"
+	subject     string          // oidc subject identifier
+	accessToken string          // oidc access token
+	broker      *Broker         // broker
+	conn        *websocket.Conn // connection
+	routes      []string        // watched routes
+	data        chan []byte     // send data
 }
 
-func newClient(addr, username, subject string, broker *Broker, conn *websocket.Conn) *Client {
-	return &Client{uuid.New().String(), addr, username, subject, broker, conn, nil, make(chan []byte, 256)}
+func newClient(addr, username, subject, accessToken string, broker *Broker, conn *websocket.Conn) *Client {
+	return &Client{uuid.New().String(), addr, username, subject, accessToken, broker, conn, nil, make(chan []byte, 256)}
 }
 
 func (c *Client) listen() {
@@ -173,10 +174,11 @@ func (c *Client) quit() {
 }
 
 var (
-	usernameHeader = []byte("u:")
-	subjectHeader  = []byte("s:")
-	clientIDHeader = []byte("c:")
-	queryBodySep   = []byte("\n\n")
+	usernameHeader    = []byte("u:")
+	subjectHeader     = []byte("s:")
+	clientIDHeader    = []byte("c:")
+	accessTokenHeader = []byte("a:")
+	queryBodySep      = []byte("\n\n")
 )
 
 func (c *Client) format(data []byte) []byte {
@@ -192,6 +194,10 @@ func (c *Client) format(data []byte) []byte {
 
 	buf.Write(clientIDHeader)
 	buf.WriteString(c.id)
+	buf.WriteByte('\n')
+
+	buf.Write(accessTokenHeader)
+	buf.WriteString(c.accessToken)
 	buf.Write(queryBodySep)
 
 	buf.Write(data)

--- a/py/h2o_wave/server.py
+++ b/py/h2o_wave/server.py
@@ -50,11 +50,13 @@ class Auth:
     Represents authentication information for a given query context. Carries valid information only if single sign on is enabled.
     """
 
-    def __init__(self, username: str, subject: str):
+    def __init__(self, username: str, subject: str, access_token: str):
         self.username = username
         """The username of the user."""
         self.subject = subject
         """A unique identifier for the user."""
+        self.access_token = access_token
+        """The access token of the user."""
 
 
 class Query:
@@ -236,7 +238,7 @@ class _App:
         return PlainTextResponse('', background=BackgroundTask(self._process, b.decode('utf-8')))
 
     async def _process(self, query: str):
-        username, subject, client_id, args = _parse_query(query)
+        username, subject, client_id, access_token, args = _parse_query(query)
         logger.debug(f'user: {username}, client: {client_id}')
         logger.debug(args)
         app_state, user_state, client_state = self._state
@@ -254,7 +256,7 @@ class _App:
             app_state=app_state,
             user_state=_session_for(user_state, username),
             client_state=_session_for(client_state, client_id),
-            auth=Auth(username, subject),
+            auth=Auth(username, subject, access_token),
             args=Expando(args_state),
             events=Expando(events_state),
         )
@@ -287,13 +289,14 @@ class _App:
         pickle.dump(state, open('h2o_wave.state', 'wb'))
 
 
-def _parse_query(query: str) -> Tuple[str, str, str, str]:
+def _parse_query(query: str) -> Tuple[str, str, str, str, str]:
     username = ''
     subject = ''
     client_id = ''
+    access_token = ''
 
     # format:
-    # u:username\ns:subject\nc:client_id\n\nbody
+    # u:username\ns:subject\nc:client_id\na:access_token\n\nbody
 
     head, body = query.split('\n\n', maxsplit=1)
     for line in head.splitlines():
@@ -306,8 +309,10 @@ def _parse_query(query: str) -> Tuple[str, str, str, str]:
                 subject = v
             elif k == 'c':
                 client_id = v
+            elif k == 'a':
+                access_token = v
 
-    return username, subject, client_id, body
+    return username, subject, client_id, access_token, body
 
 
 class _Main:


### PR DESCRIPTION
If PR merged, the access token will be passed along with username and subject ID to Python client.

## Notes
- The implementation follows the same practices as with passing a subject ID.
- If OIDC turned off the empty string is passed.
- The access token will always be valid as we have this merged already: https://github.com/h2oai/wave/pull/292 which refreshes token if necessary.
- Token is accessible through `q.auth.access_token`.
- We should keep in mind this token might time out if a Python response is dealing with a blocking and a time consuming job (which is completely ok). In that case it would be good to design UI in a way so after a long running job there is other user action that will naturally produce a fresh token.

Closes #315 