### PR TITLE
feat: add column headers to csv, remove row names, keep row cells only #248

### DIFF
--- a/ui/src/table.tsx
+++ b/ui/src/table.tsx
@@ -146,7 +146,7 @@ const
       : b > a ? 1 : -1
   },
   formatNum = (num: U) => num.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ","),
-  toCSV = (data: any[][]): S => data.map(row => {
+  toCSV = (data: unknown[][]): S => data.map(row => {
     const line = JSON.stringify(row)
     return line.substr(1, line.length - 2)
   }).join('\n')
@@ -247,7 +247,7 @@ export const
       download = () => {
         // TODO: Prompt a dialog for name, encoding, etc.
         const
-          data = toCSV(items.map(i => Object.values(i))),
+          data = toCSV([m.columns.map(({ label, name }) => label || name), ...m.rows.map(({ cells }) => cells)]),
           a = document.createElement('a'),
           blob = new Blob([data], { type: "octet/stream" }),
           url = window.URL.createObjectURL(blob)


### PR DESCRIPTION
Closes #248

* Added column names to downloaded CSV
* Removed row names, left row cells only as I consider names implementation detail.

@lo5 @geomodular please have a look at additional suggestions I pointed out in issue and let me know what you think about them.