### PR TITLE
ML API for H2O-3

### DIFF
--- a/py/h2o_wave/core.py
+++ b/py/h2o_wave/core.py
@@ -28,6 +28,7 @@ class _Config:
         self.hub_address = _get_env('ADDRESS', 'http://127.0.0.1:10101')
         self.hub_access_key_id: str = _get_env('ACCESS_KEY_ID', 'access_key_id')
         self.hub_access_key_secret: str = _get_env('ACCESS_KEY_SECRET', 'access_key_secret')
+        self.h2o3_url = _get_env('H2O3_URL', '')
 
 
 _config = _Config()

--- a/py/h2o_wave/ml.py
+++ b/py/h2o_wave/ml.py
@@ -76,7 +76,7 @@ class WaveModelBackend:
             >>> model = build_model(...)
             >>> # Three rows and two columns:
             >>> model.predict([['ID', 'Letter'], [1, 'a'], [2, 'b'], [3, 'c']])
-            [(16.6,), (17.8,)]
+            [(16.6,), (17.8,), (18.9,)]
         """
 
         raise NotImplementedError()

--- a/py/h2o_wave/ml.py
+++ b/py/h2o_wave/ml.py
@@ -1,0 +1,224 @@
+import os.path
+import uuid
+from enum import Enum
+import tempfile
+from typing import Optional, Union, List, Tuple
+
+import datatable as dt
+import h2o
+from h2o.automl import H2OAutoML
+from h2o.estimators.estimator_base import H2OEstimator
+
+
+from .core import _config
+
+
+WaveModelBackendType = Enum('WaveModelBackendType', 'H2O3 DAI')
+WaveModelMetric = Enum('WaveModelMetric', 'AUTO AUC MSE RMSE MAE RMSLE DEVIANCE LOGLOSS AUCPR LIFT_TOP_GROUP'
+                                          'MISCLASSIFICATION MEAN_PER_CLASS_ERROR')
+DataSourceObj = Union[str, List[List]]
+
+
+def _make_id() -> str:
+    """Generate random id."""
+
+    return str(uuid.uuid4())
+
+
+class _DataSource:
+    """Helper class represents a various data sources that can be lazily transformed into another data type."""
+
+    def __init__(self, data: DataSourceObj):
+        self._data = data
+        self._h2o3_frame: Optional[h2o.H2OFrame] = None
+
+    def _to_h2o3_frame(self) -> h2o.H2OFrame:
+        if isinstance(self._data, str):
+            filename = self._data
+            if os.path.exists(filename):
+                return h2o.import_file(filename)
+            else:
+                raise ValueError('file not found')
+        elif isinstance(self._data, List):
+            return h2o.H2OFrame(python_obj=self._data, header=1)
+        raise ValueError('unknown data type')
+
+    @property
+    def h2o3_frame(self) -> h2o.H2OFrame:
+        if self._h2o3_frame is None:
+            self._h2o3_frame = self._to_h2o3_frame()
+        return self._h2o3_frame
+
+    @property
+    def filename(self) -> str:
+        if isinstance(self._data, str):
+            return self._data
+        elif isinstance(self._data, List):
+            raise NotImplementedError()
+        raise ValueError('unknown data type')
+
+
+class WaveModelBackend:
+    """Represents a common interface for a model backend. It references DAI or H2O-3 under the hood."""
+
+    def __init__(self, type_: WaveModelBackendType):
+        self.type = type_
+        """A wave model backend type represented by `h2o_wave.ml.WaveModelBackendType` enum. It's either DAI or H2O3."""
+
+    def predict(self, inputs: DataSourceObj, **kwargs) -> List[Tuple]:
+        """Predicts values based on inputs.
+        Args:
+            inputs: A python obj or filename. e.g. [['ID', 'Letter'], [1, 'a'], [2, 'b'], [3, 'c']] will create 3 rows
+                    and 2 columns.
+                    A header needs to be specified for the python obj.
+        Returns:
+            A list of tuples representing predicted values.
+        Examples:
+            >>> # Two rows and three columns:
+            >>> from h2o_wave.ml import build_model
+            >>> model = build_model(...)
+            >>> model.predict([[1, 12.3, 'aa', 32.5], [2, 15.6, 'bb', 89.9]])
+            [(16.6,), (17.8,)]
+        """
+
+        raise NotImplementedError()
+
+
+class _H2O3ModelBackend(WaveModelBackend):
+
+    INIT = False
+    MAX_RUNTIME_SECS = 60 * 60
+    MAX_MODELS = 20
+
+    def __init__(self, model: H2OEstimator):
+        super().__init__(WaveModelBackendType.H2O3)
+        self.model = model
+
+    @staticmethod
+    def _make_project_id() -> str:
+        """Generates random project id."""
+
+        # H2O3 project name cannot start with a number (no matter it's string).
+        u = _make_id()
+        return f'aml-{u}'
+
+    @classmethod
+    def _ensure(cls):
+        """Initializes h2o-3 if not before."""
+
+        if not cls.INIT:
+            if _config.h2o3_url != '':
+                h2o.init(url=_config.h2o3_url)
+            else:
+                h2o.init()
+            cls.INIT = True
+
+    @staticmethod
+    def build(filename: str, target: str, metric: WaveModelMetric, **aml_settings) -> WaveModelBackend:
+
+        _H2O3ModelBackend._ensure()
+
+        id_ = _H2O3ModelBackend._make_project_id()
+        aml = H2OAutoML(max_runtime_secs=aml_settings.get('max_runtime_secs', _H2O3ModelBackend.MAX_RUNTIME_SECS),
+                        max_models=aml_settings.get('max_models', _H2O3ModelBackend.MAX_MODELS),
+                        project_name=id_,
+                        stopping_metric=metric.name,
+                        sort_metric=metric.name)
+
+        if os.path.exists(filename):
+            frame = h2o.import_file(filename)
+        else:
+            raise ValueError('file not found')
+
+        cols = list(frame.columns)
+
+        try:
+            cols.remove(target)
+        except ValueError:
+            raise ValueError('no target column')
+
+        aml.train(x=cols, y=target, training_frame=frame)
+        return _H2O3ModelBackend(aml.leader)
+
+    @staticmethod
+    def get(id_: str) -> WaveModelBackend:
+        """Get a model identified by an AutoML project id.
+        H2O-3 needs to be running standalone for this to work.
+        """
+
+        _H2O3ModelBackend._ensure()
+
+        aml = h2o.automl.get_automl(id_)
+        return _H2O3ModelBackend(aml.leader)
+
+    def predict(self, data: DataSourceObj, **kwargs) -> List[Tuple]:
+
+        ds = _DataSource(data)
+        input_frame = ds.h2o3_frame
+        output_frame = self.model.predict(input_frame)
+
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            filename = os.path.join(tmp_dir_name, _make_id() + '.csv')
+            h2o.download_csv(output_frame, filename)
+            prediction = dt.fread(filename)
+            return prediction.to_tuples()
+
+
+def build_model(filename: str, target: str, metric: WaveModelMetric = WaveModelMetric.AUTO,
+                model_backend_type: Optional[WaveModelBackendType] = None, **kwargs) -> WaveModelBackend:
+    """Build a model.
+    If `model_backend_type` not specified the function will determine correct backend model based on a current
+    environment.
+
+    Args:
+        filename: A string containing the filename to a dataset.
+        target: A name of the target column.
+        metric: A metric to be used in building process specified by `h2o_wave.ml.WaveModelMetric`. Defaults to AUTO.
+        model_backend_type: Optionally a backend model type specified by `h2o_wave.ml.WaveModelBackendType`.
+        kwargs: Optional parameters passed to a backend model.
+    Returns:
+        A wave model.
+    """
+
+    if model_backend_type is not None:
+        if model_backend_type == WaveModelBackendType.H2O3:
+            return _H2O3ModelBackend.build(filename, target, metric, **kwargs)
+        raise NotImplementedError()
+
+    return _H2O3ModelBackend.build(filename, target, metric, **kwargs)
+
+
+def get_model(id_: str, model_type: Optional[WaveModelBackendType] = None) -> WaveModelBackend:
+    """Get a model that is already built on a backend.
+
+    Args:
+        id_: Identification of a model.
+        model_type: Optionally a model type specified by `h2o_wave.ml_WaveModelType`.
+    Returns:
+        A wave model.
+    """
+
+    if model_type is not None:
+        if model_type == WaveModelBackendType.H2O3:
+            return _H2O3ModelBackend.get(id_)
+        raise NotImplementedError()
+
+    return _H2O3ModelBackend.get(id_)
+
+
+def save_model(backend: WaveModelBackend, folder: str):
+    """Save a model to disk."""
+
+    if isinstance(backend, _H2O3ModelBackend):
+        h2o.download_model(backend.model, path=folder)
+    else:
+        raise NotImplementedError()
+
+
+def load_model(filename: str) -> WaveModelBackend:
+    """Load a model from a disk into the instance."""
+
+    _H2O3ModelBackend._ensure()
+
+    model = h2o.upload_model(path=filename)
+    return _H2O3ModelBackend(model)

--- a/py/h2o_wave/ml.py
+++ b/py/h2o_wave/ml.py
@@ -63,21 +63,19 @@ class WaveModelBackend:
 
     def __init__(self, type_: WaveModelBackendType):
         self.type = type_
-        """A wave model backend type represented by `h2o_wave.ml.WaveModelBackendType` enum. It's either DAI or H2O3."""
+        """A wave model backend type represented by `h2o_wave.ml.WaveModelBackendType` enum."""
 
     def predict(self, inputs: DataSourceObj, **kwargs) -> List[Tuple]:
         """Predicts values based on inputs.
         Args:
-            inputs: A python obj or filename. e.g. [['ID', 'Letter'], [1, 'a'], [2, 'b'], [3, 'c']] will create 3 rows
-                    and 2 columns.
-                    A header needs to be specified for the python obj.
+            inputs: A python obj or filename. A header needs to be specified for the python obj.
         Returns:
             A list of tuples representing predicted values.
         Examples:
-            >>> # Two rows and three columns:
             >>> from h2o_wave.ml import build_model
             >>> model = build_model(...)
-            >>> model.predict([[1, 12.3, 'aa', 32.5], [2, 15.6, 'bb', 89.9]])
+            >>> # Three rows and two columns:
+            >>> model.predict([['ID', 'Letter'], [1, 'a'], [2, 'b'], [3, 'c']])
             [(16.6,), (17.8,)]
         """
 
@@ -105,7 +103,7 @@ class _H2O3ModelBackend(WaveModelBackend):
 
     @classmethod
     def _ensure(cls):
-        """Initializes h2o-3."""
+        """Initializes H2O-3."""
 
         if not cls.INIT:
             if _config.h2o3_url != '':
@@ -127,6 +125,7 @@ class _H2O3ModelBackend(WaveModelBackend):
 
     @classmethod
     def build(cls, filename: str, target: str, metric: WaveModelMetric, **aml_settings) -> WaveModelBackend:
+        """Builds an H2O-3 based model and returns it in a backend wrapper."""
 
         cls._ensure()
 
@@ -157,7 +156,7 @@ class _H2O3ModelBackend(WaveModelBackend):
 
     @classmethod
     def get(cls, id_: str) -> WaveModelBackend:
-        """Get a model identified by an AutoML project id.
+        """Gets a model identified by an AutoML project id.
         H2O-3 needs to be running standalone for this to work.
 
         Args:
@@ -172,6 +171,7 @@ class _H2O3ModelBackend(WaveModelBackend):
         return _H2O3ModelBackend(aml.leader)
 
     def predict(self, data: DataSourceObj, **kwargs) -> List[Tuple]:
+        """Predicts on a model."""
 
         ds = _DataSource(data)
         input_frame = ds.h2o3_frame
@@ -186,16 +186,17 @@ class _H2O3ModelBackend(WaveModelBackend):
 
 def build_model(filename: str, target: str, metric: WaveModelMetric = WaveModelMetric.AUTO,
                 model_backend_type: Optional[WaveModelBackendType] = None, **kwargs) -> WaveModelBackend:
-    """Build a model.
+    """Builds a model.
     If `model_backend_type` not specified the function will determine correct backend model based on a current
     environment.
 
     Args:
         filename: A string containing the filename to a dataset.
         target: A name of the target column.
-        metric: A metric to be used in building process specified by `h2o_wave.ml.WaveModelMetric`. Defaults to AUTO.
+        metric: A metric to be used during the building process specified by `h2o_wave.ml.WaveModelMetric`.
+                It Defaults to AUTO.
         model_backend_type: Optionally a backend model type specified by `h2o_wave.ml.WaveModelBackendType`.
-        kwargs: Optional parameters passed to a backend model.
+        kwargs: Optional parameters passed to the backend.
     Returns:
         A wave model.
     """
@@ -209,7 +210,7 @@ def build_model(filename: str, target: str, metric: WaveModelMetric = WaveModelM
 
 
 def get_model(id_: str, model_type: Optional[WaveModelBackendType] = None) -> WaveModelBackend:
-    """Get a model that can be addressed on a backend.
+    """Get a model that can be accessed on a backend.
 
     Args:
         id_: Identification of a model.

--- a/py/h2o_wave/ml.py
+++ b/py/h2o_wave/ml.py
@@ -104,7 +104,7 @@ class _H2O3ModelBackend(WaveModelBackend):
 
     @classmethod
     def _ensure(cls):
-        """Initializes h2o-3 if not before."""
+        """Initializes h2o-3."""
 
         if not cls.INIT:
             if _config.h2o3_url != '':
@@ -144,6 +144,11 @@ class _H2O3ModelBackend(WaveModelBackend):
     def get(id_: str) -> WaveModelBackend:
         """Get a model identified by an AutoML project id.
         H2O-3 needs to be running standalone for this to work.
+
+        Args:
+            id_: Identification of the aml project on a running h2o-3 instance.
+        Returns:
+            A wave model.
         """
 
         _H2O3ModelBackend._ensure()
@@ -189,11 +194,11 @@ def build_model(filename: str, target: str, metric: WaveModelMetric = WaveModelM
 
 
 def get_model(id_: str, model_type: Optional[WaveModelBackendType] = None) -> WaveModelBackend:
-    """Get a model that is already built on a backend.
+    """Get a model that can be addressed on a backend.
 
     Args:
         id_: Identification of a model.
-        model_type: Optionally a model type specified by `h2o_wave.ml_WaveModelType`.
+        model_type: Optionally a model backend type specified by `h2o_wave.ml_WaveModelType`.
     Returns:
         A wave model.
     """
@@ -206,17 +211,29 @@ def get_model(id_: str, model_type: Optional[WaveModelBackendType] = None) -> Wa
     return _H2O3ModelBackend.get(id_)
 
 
-def save_model(backend: WaveModelBackend, folder: str):
-    """Save a model to disk."""
+def save_model(backend: WaveModelBackend, folder: str) -> str:
+    """Save a model to disk.
+
+    Args:
+       backend: A model backend produced by build_model.
+       folder: A directory where the saved model will be put to.
+    Returns:
+        Path to a saved model.
+    """
 
     if isinstance(backend, _H2O3ModelBackend):
-        h2o.download_model(backend.model, path=folder)
-    else:
-        raise NotImplementedError()
+        return h2o.download_model(backend.model, path=folder)
+    raise NotImplementedError()
 
 
 def load_model(filename: str) -> WaveModelBackend:
-    """Load a model from a disk into the instance."""
+    """Load a model from disk into the instance.
+
+    Args:
+        filename: Path to saved model.
+    Returns:
+        A wave model.
+    """
 
     _H2O3ModelBackend._ensure()
 

--- a/py/setup.py
+++ b/py/setup.py
@@ -34,6 +34,9 @@ setuptools.setup(
         'starlette==0.13.8',
         'uvicorn==0.12.2',
     ],
+    extras_require={
+        'ml': ['h2o==3.32.0.2', 'datatable==0.11.0'],
+    },
     entry_points=dict(
         console_scripts=["wave = h2o_wave.cli:main"]
     ),


### PR DESCRIPTION
If PR merged, `ML API` will be added to the Wave project. This is the first version of API based on `H2O-3` backend and it's capable of building the model, predicting *on instance*, loading and saving the binary model. `ML API` is independent part of a *Wave* with no internal connections between other Python modules.

## API

- To build a model use [`build_model()`](https://github.com/h2oai/wave/blob/f43d5bd202f7b248064b81e23af3890d14fd03a2/py/h2o_wave/ml.py#L187).

- To predict on an backend instance use a method available to a built model: [`model.predict()`](https://github.com/h2oai/wave/blob/f43d5bd202f7b248064b81e23af3890d14fd03a2/py/h2o_wave/ml.py#L68).

- To save and load models use [`save_model()`](https://github.com/h2oai/wave/blob/f43d5bd202f7b248064b81e23af3890d14fd03a2/py/h2o_wave/ml.py#L230) and [`load_model()`](https://github.com/h2oai/wave/blob/f43d5bd202f7b248064b81e23af3890d14fd03a2/py/h2o_wave/ml.py#L245).

- To get a model from a running `H2O-3` instance (if any) use [`get_model()`](https://github.com/h2oai/wave/blob/f43d5bd202f7b248064b81e23af3890d14fd03a2/py/h2o_wave/ml.py#L212).

## Dependencies

`ML API` needs two packages to be able to operate inside the Python environment: `H2O` and `datatable`.

The `extras_require` was introduced inside the [`py/setup.py`](https://github.com/h2oai/wave/blob/f43d5bd202f7b248064b81e23af3890d14fd03a2/py/setup.py#L37). It separates dependencies from regular *Wave* using the `pip` brackets syntax. If extra parameter `ml` used the whole package plus the `ML API` dependencies will be installed.

For regular `pip` package:

```bash
pip install h2o-wave[ml]
```

For dev installation inside the `py/` directory:

```bash
pip install --editable .[ml]
```

## Examples

Full example with a histogram:
```python3
from h2o_wave import main, data, ui, site
from h2o_wave.ml import build_model

page = site['/prediction']

train_set = './creditcard_train_cat.csv'
test_set = './creditcard_test_cat.csv'

model = build_model(train_set, target='DEFAULT_PAYMENT_NEXT_MONTH')
prediction = model.predict(test_set)
# This will output: [(False, 0.8590936346577605, 0.14090636534223955), (True, 0.13186347630483963, 0.8681365236951604), (False, 0.7730244054420021, 0.22697559455799787), ...]

true_count = len([1 for p in prediction if p[0]])
false_count = len([1 for p in prediction if not p[0]])

v = page.add('example', ui.plot_card(
    box='1 1 4 5',
    title='Credit card category',
    data=data('category count', rows=[['First category', true_count], ['Second category', false_count]]),
    plot=ui.plot([ui.mark(type='interval', x='=category', y='=count', y_min=0)])
))

page.save()
```

Save model:
```python3
from h2o_wave.ml import build_model, save_model

model = build_model('./creditcard_train_cat.csv', target='DEFAULT_PAYMENT_NEXT_MONTH')
path = save_model(model, './')
```

Load model:
```python3
from h2o_wave.ml import load_model

model = load_model('./StackedEnsemble_AllModels_AutoML_20201209_155503')
prediction = model.predict('./Datasets/creditcard_test_cat.csv')
```

Predict using just one row:
```python3
from h2o_wave.ml import build_model

data = [["ID", "LIMIT_BAL", "SEX", "EDUCATION", "MARRIAGE", "AGE", "PAY_1", "PAY_2", "PAY_3", "PAY_4", "PAY_5", "PAY_6",
         "BILL_AMT1", "BILL_AMT2", "BILL_AMT3", "BILL_AMT4", "BILL_AMT5", "BILL_AMT6", "PAY_AMT1", "PAY_AMT2",
         "PAY_AMT3", "PAY_AMT4", "PAY_AMT5", "PAY_AMT6"],
        [24001, 50000, "male", "university", "single", 23, 2, 2, 0, 0, 0, 0, 51246, 49758, 48456, 44116, 21247, 20066, 8,
         2401, 2254, 2004, 704, 707]]

model = build_model('./creditcard_train_cat.csv', target='DEFAULT_PAYMENT_NEXT_MONTH')
prediction = model.predict(data)
# [(True, 0.31995987356563516, 0.6800401264343648)]
```


## Design decisions

### Datatable

`Datatable` is used to transform the prediction output from an H2O-3 [here](https://github.com/h2oai/wave/blob/f43d5bd202f7b248064b81e23af3890d14fd03a2/py/h2o_wave/ml.py#L183). The reason for this is to provide the same output interface both for H2O-3 and DAI having both saving the predictions on disk. H2O-3 has also another ways to obtain predictions and those are:
- Using Python object. This produces string values and we would end up with retyping directly in Python.
- Using `pandas` object. That introduces a new package.

`Datatable` seems like a good option considering DAI is saving predictions onto disk.

Another thing to mention; this is needed because predictions are made on instance. In case of a future `deploy_model()` the predictions will AFAIK be row based. But I think it's good to support both batch and row (instance vs deployed).

### Storing models

Saving and loading of a model is available in `ML API`. This functionality is temporary however as `save_model()` will became `deploy_model()` later, once we have a functional infrastructure in place with `H2O-3` support. The goal was to provide a way to store and load model for `H2O-3` instance.

Since the models are stored as binary models, the downside is also the incompatibility between the `H2O` versions.

### H2O-3 instance

`ML API` spawns own instance of `H2O-3` unless the `H2O_WAVE_H2O3_URL` ENV variable is specified. If specified, the running instance will be used. e.g.:

```bash
 H2O_WAVE_H2O3_URL=http://192.168.1.6:54321/ python3 examples/ml_ex.py
```

### Automatic conversion

The target column is checked for a type and changed appropriately using [this function](https://github.com/h2oai/wave/blob/f43d5bd202f7b248064b81e23af3890d14fd03a2/py/h2o_wave/ml.py#L116). The conversion to a categorical type is made for all `str` types and `int` types if unique values for a column is below `INT_TO_CAT_THRESHOLD` (set to 50).

For the future release the separate attribute setting *classification* vs *regression* might be a required addition (considering DAI).

## Notes

If desired, a DAI backend using the static instance of DAI can be added fairly quickly as well. The backend will be using the same interface with an exception of saving and loading models. `get_model()`, however, will be working.

Part of https://github.com/h2oai/h2o-ai-cloud/issues/139 and #342