### PR TITLE
chore: update github issue/bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,16 +7,20 @@ assignees: ''
 
 ---
 
-**Q SDK Version, OS**
+#### Wave SDK Version, OS
+
 (e.g. 4.2.0, Windows)
 
-**Actual behavior**
+#### Actual behavior
+
 (A clear and concise description of what happened.)
 
-**Expected behavior**
+#### Expected behavior
+
 (A clear and concise description of what you expected to happen.)
 
-**Steps To Reproduce**
+#### Steps To Reproduce
+
 1. Do this
 2. Do that
 3. Do something else

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,14 +7,18 @@ assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
+#### Is your feature request related to a problem? Please describe
+
 (A clear and concise description of what the problem is. Ex. I'm always frustrated when [...])
 
-**Describe the solution you'd like**
+#### Describe the solution you'd like
+
 (A clear and concise description of what you want to happen.)
 
-**Describe alternatives you've considered**
+#### Describe alternatives you've considered
+
 (A clear and concise description of any alternative solutions or features you've considered.)
 
-**Additional context**
+#### Additional context
+
 Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
* rename Q SDK to Wave SDK
* refactor to comply with markdown spec - use headings instead of text emphasis.