### PR TITLE
docs: add shields to main readme

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,3 +1,5 @@
 {
-  "line-length": false
+  "line-length": false,
+  "no-inline-html": false,
+  "first-line-h1": false
 }

--- a/README.md
+++ b/README.md
@@ -1,8 +1,19 @@
-# H2O Wave
+<p align="center"><a href="https://vuejs.org" target="_blank" rel="noopener noreferrer"><img width='50%' src="assets/brand/wave-type-yellow.png" alt="Wave logo"></a></p>
 
-<img src='assets/brand/wave-type-yellow.png' width='50%'/>
-
-## Realtime Web Apps and Dashboards for Python
+<p align='center'>
+  <img alt="PyPI - Downloads" src="https://img.shields.io/pypi/dm/h2o-wave?color=FBE52B">
+  <img alt="PyPI - License" src="https://img.shields.io/pypi/l/h2o-wave?color=yellow">
+  <img alt="Discourse topics" src="https://img.shields.io/discourse/topics?server=https%3A%2F%2Fh2owave.h2o.ai%2F">
+  <img alt="PyPI" src="https://img.shields.io/pypi/v/h2o-wave?label=current-version">
+  <img alt="Twitter Follow" src="https://img.shields.io/twitter/follow/h2o_wave">
+</p>
+<p align='center'>
+  <img alt="PyPI - Python Version" src="https://img.shields.io/pypi/pyversions/h2o-wave?color=3677AF">
+  <img alt="Go version" src="https://img.shields.io/static/v1?label=golang&message=1.13.10&color=70C8D6">
+  <img alt="Node version" src="https://img.shields.io/static/v1?label=nodejs&message=14.4.0&color=73AB63">
+</p>
+<h1 align='center'>H2O Wave</h1>
+<h2 align='center'>Realtime Web Apps and Dashboards for Python</h2>
 
 H2O Wave is a software stack for building beautiful, low-latency, realtime, browser-based applications and dashboards entirely in Python without using HTML, Javascript, or CSS.
 


### PR DESCRIPTION
Added a few shields to readme that might be worth. Looking for opinions.

![image](https://user-images.githubusercontent.com/64769322/102500013-24a75300-407c-11eb-81d0-a6528d23a702.png)
vs
![image](https://user-images.githubusercontent.com/64769322/102500045-2d982480-407c-11eb-8b41-8fe07b8132a3.png)

Further possible Readme improvements - do not use links directly, but via `[](url)` to make it consistent.

Note that I golang and nodejs versions are hardcoded and simply taken from my machine, feel free to point out if we support lower versions as well.