### PR TITLE
docs: unify contribution guide #400

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,13 +1,10 @@
 # Contributor Code of Conduct
 
-As contributors and maintainers of this project, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches and other activities.
+This Code of Conduct provides community guidelines for a safe, respectful, productive, and collaborative place for any person who is willing to contribute to the H2O Wave community. It applies to all "collaborative space", which is defined as community communications channels (such as mailing lists, submitted patches, commit comments, etc.).
 
-We are committed to making participation in this project a harassment-free experience for everyone, regardless of the level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, age or religion.
+- Participants will be tolerant of opposing views.
+- Participants must ensure that their language and actions are free of personal attacks and disparaging personal remarks.
+- When interpreting the words and actions of others, participants should always assume good intentions.
+- Behaviour which can be reasonably considered harassment will not be tolerated.
 
-Examples of unacceptable behavior by participants include the use of sexual language or imagery, derogatory comments or personal attacks, trolling, public or private harassment, insults or other unprofessional conduct.
-
-Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues and other contributions that are not aligned to this Code of Conduct.
-
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting one or more of the project maintainers.
-
-This Code of Conduct is adapted from the [Contributor Covenant](http://contributor-covenant.org), version 1.0.0, available at [http://contributor-covenant.org/version/1/0/0/](http://contributor-covenant.org/version/1/0/0/).
+(Based on the [Ruby Code of Conduct](https://www.ruby-lang.org/en/conduct/).)

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -26,7 +26,7 @@ If you’ve identified an issue, first search through the list of existing issue
 
 If you want to fix a specific issue, it’s best to comment on the individual issue with your intent. However, we do not lock or assign issues except in cases where we have worked with the developer before. It’s best to strike up a conversation on the issue and discuss your proposed solution. The H2O Wave team can provide guidance that saves you time.
 
-Issues that are labeled **good first issue**, **low** or **medium** priority are great places to start.
+Issues that are labeled **good first issue**, **low** or **medium** priority are great places to start. Only issues that have assigned a milestone or are tagged with **help needed** / **good first issue** will be merged.
 
 ## Improving documentation and tutorials
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,53 +1,71 @@
-# Q Contributing Guide
+# Wave Contributing Guide
 
-Hi! We are really excited that you are interested in contributing to Q.
-Before submitting your contribution, please make sure to take a moment and read through the following guidelines:
+We appreciate all contributions. If you are planning to contribute back bug-fixes, please do so without any further discussion.
 
-- [Code of Conduct](https://github.com/h2oai/qd/tree/master/.github/CODE_OF_CONDUCT.md)
-- [Issue Reporting Guidelines](#issue-reporting-guidelines)
-- [Pull Request Guidelines](#pull-request-guidelines)
-- [Development Setup](#development-setup)
-- [Project Structure](#project-structure)
+If you plan to contribute new features, please first [open an issue](https://github.com/h2oai/wave/issues/new/choose) and discuss the feature with us. Sending a PR without discussion might end up resulting in a rejected PR because we might be taking the software in a different direction than you might be aware of.
 
-## Issue Reporting Guidelines
+(Based on the [PyTorch Contribution Guide](https://pytorch.org/docs/stable/community/contribution_guide.html).)
 
-- Bugs
-  - Provide detailed description.
-  - Provide OS version, Q version, browser name and version.
-  - Gif showing the problem is highly preferred.
-  - Code snippet causing the bug preferred.
-- Features
-  - Provide detailed description.
-  - Provide a reason / usecase why this feature is needed.
+## About open source development
 
-## Pull Request Guidelines
+If this is your first time contributing to an open source project, some aspects of the development process may seem unusual to you.
 
-- All development should be done in dedicated branches. **Do not submit PRs against the `master` branch.**
+- **There is no way to "claim" issues.** People often want to "claim" an issue when they decide to work on it, to ensure that there isn’t wasted work when someone else ends up working on it. This doesn’t really work too well in open source, since someone may decide to work on something, and end up not having time to do it. Feel free to give information in an advisory fashion, but at the end of the day, we will take running code and rough consensus.
 
-- Branch name should be named feat/issue-${ISSUE_NUMBER} or fix/issue-${ISSUE_NUMBER}. If your branch name ends with
-a number, our `githooks/commit-msg.js` will assume it is an issue number and append `#${ISSUE_NUMBER}` to your commit message
-automatically. This links the commit to the corresponding issue.
+- **There is a high bar for new functionality that is added.** Unlike in a corporate environment, where the person who wrote code implicitly "owns" it and can be expected to take care of it in the beginning of its lifetime, once a pull request is merged into an open source project, it immediately becomes the collective responsibility of all maintainers on the project. When we merge code, we are saying that we, the maintainers, are able to review subsequent changes and make a bugfix to the code. This naturally leads to a higher standard of contribution.
 
-- Work in the `src` folder and **DO NOT** checkin `dist` in the commits.
+## Proposing new features
 
-- It's OK to have multiple small commits as you work on the PR - GitHub will automatically squash it before merging.
+New feature ideas are best discussed on a specific issue. Please include as much information as you can, any accompanying data, and your proposed solution. The H2O Wave team and community frequently reviews new issues and comments where they think they can help. If you feel confident in your solution, go ahead and implement it.
 
-- Make sure `make test-ui-ci` passes. (see [development setup](#development-setup))
+## Reporting issues
 
-- If adding a new feature:
-  - Add accompanying test case.
-  - Provide a convincing reason to add this feature. Ideally, you should open a suggestion issue first and have it approved before working on it.
-  - Provide Closes #issue-number (e.g. Closes #11)
+If you’ve identified an issue, first search through the list of existing issues on the repo. If you are unable to find a similar issue, then create a new one. Supply as much information you can to reproduce the problematic behavior. Also, include any additional insights like the behavior you expect.
 
-- If fixing bug:
-  - Provide an explanation of what was the cause of the bug.
-  - Provide code changes description.
-  - Don't forget to provide a unit test to make sure it won't repeat in the future.
-  - Provide Closes #issue-number (e.g. Closes #11)
+## Implementing features
+
+If you want to fix a specific issue, it’s best to comment on the individual issue with your intent. However, we do not lock or assign issues except in cases where we have worked with the developer before. It’s best to strike up a conversation on the issue and discuss your proposed solution. The H2O Wave team can provide guidance that saves you time.
+
+Issues that are labeled **good first issue**, **low** or **medium** priority are great places to start.
+
+## Improving documentation and tutorials
+
+We aim to produce high quality documentation and tutorials. On rare occasions that content includes typos or bugs. If you find something you can fix, send us a pull request for consideration.
+
+## Submitting pull requests
+
+You can view a list of all [open issues](https://github.com/h2oai/wave/issues). Commenting on an issue is a great way to get the attention of the team. From here you can share your ideas and how you plan to resolve the issue.
+
+For more challenging issues, the team will provide feedback and direction for how to best solve the issue.
+
+If you’re not able to fix the issue yourself, commenting and sharing whether you can reproduce the issue can be useful for helping the team identify problem areas.
+
+## Improving code readability
+
+Improved code readability helps everyone. It is often better to submit a small number of pull requests that touch few files versus a large pull request that touches many files. Opening an issue related to your improvement is the best way to get started.
+
+## Adding test cases
+
+Additional test coverage is appreciated.  Help us make the codebase more robust.
+
+## Security vulnerabilities
+
+If you discover a security vulnerability within H2O Wave, please send an email to Prithvi Prabhu at prithvi@h2o.ai. All security vulnerabilities will be promptly addressed.
+
+## Code of Conduct
+
+This Code of Conduct provides community guidelines for a safe, respectful, productive, and collaborative place for any person who is willing to contribute to the H2O Wave community. It applies to all "collaborative space", which is defined as community communications channels (such as mailing lists, submitted patches, commit comments, etc.).
+
+- Participants will be tolerant of opposing views.
+- Participants must ensure that their language and actions are free of personal attacks and disparaging personal remarks.
+- When interpreting the words and actions of others, participants should always assume good intentions.
+- Behaviour which can be reasonably considered harassment will not be tolerated.
+
+(Based on the [Ruby Code of Conduct](https://www.ruby-lang.org/en/conduct/).)
 
 ## Development Setup
 
-You will need [Node.js](http://nodejs.org) **version 10+**, [Go](https://golang.org/) **version 10+**, [Python](https://www.python.org/) **version 3.7**
+You will need [Node.js](http://nodejs.org) **version 10+**, [Go](https://golang.org/) **version 1.13.10+**, [Python](https://www.python.org/) **version 3.7**
 After cloning the repo, run:
 
 ``` bash
@@ -56,16 +74,16 @@ make all
 
 After successful setup, you need to run:
 
-- Q server (Go server) with command
+- Wave server (Go server) with command
 
 ``` bash
 make run
 ```
 
-- Q app (this will run `tour.py`, but can be any app)
+- Wave app (this will run `tour.py`, but can be any app)
 
 ``` bash
-cd py && ./venv/bin/python examples/wizard.py
+cd py && ./venv/bin/python examples/tour.py
 ```
 
 - Hot reload webpack server (for easier UI development)
@@ -83,11 +101,10 @@ Commit messages must follow [Conventional commits](https://www.conventionalcommi
 - Lint commit message format.
 - Lint staged files based on their extension. Linting supported for `.ts`, `.tsx`, `.go`, `.py`, `.md` files.
 - Run accompanying unit tests if found.
-- Run Typescript compiler for typescript files.
 
 If any of these checks fails, the commit is aborted and you have to fix the errors first.
 
-Make sure your commit message also ends with an issue number (e.g. fix: Typo #11).
+Make sure your commit message also ends with an issue number e.g. `fix: Typo #11`. (Tip: If you name your branch name in format `something-#GITHUB_ISSUE_NUM`, the issue number will get appended automatically to your commit message.)
 
 ### Commonly used make targets
 
@@ -95,7 +112,7 @@ Make sure your commit message also ends with an issue number (e.g. fix: Typo #11
 # Compiles Typescript API to Python API.
 $ make generate
 
-# Starts Q server.
+# Starts Wave server.
 $ make run
 
 # Starts hot reload dev server for UI.
@@ -110,19 +127,19 @@ $ make run-cypress-bridge
 
 ## Project Structure
 
-- **`data`**: contains data created by a Q-app itself (e.g. file upload files)
+- **`data`**: contains data created by a Wave-app itself (e.g. file upload files)
 
 - **`docs`**: contains documentation page related files
+
+- **`website`**: documentation page source files
 
 - **`py`**: contains Python lib that is exported as a package
 
 - **`r`**: contains R lib that is exported as a package
 
-- **`site`**: contains new Vuepress-powered documentation site
+- **`tools`**: contains Typescript to Python generator
 
-- **`tools`**: contains Typescript to Python compiler
-
-- **`ui`**: contains UI components written in React + Typescrip that are later translated to Python
+- **`ui`**: contains UI components written in React + Typescript that are later translated to Python
   - **`config`** contains webpack configuration
   - **`eslint`** contains custom eslint rules for `ts` and `tsx` files
   It is required to run `npm ci` after changing `linter.js` in order for changes to take effect.

--- a/website/docs/contributing.md
+++ b/website/docs/contributing.md
@@ -28,7 +28,7 @@ If you’ve identified an issue, first search through the list of existing issue
 
 If you want to fix a specific issue, it’s best to comment on the individual issue with your intent. However, we do not lock or assign issues except in cases where we have worked with the developer before. It’s best to strike up a conversation on the issue and discuss your proposed solution. The H2O Wave team can provide guidance that saves you time.
 
-Issues that are labeled **good first issue**, **low** or **medium** priority are great places to start.
+Issues that are labeled **good first issue**, **low** or **medium** priority are great places to start. Only issues that have assigned a milestone or are tagged with **help needed** / **good first issue** will be merged.
 
 ## Improving documentation and tutorials
 

--- a/website/docs/contributing.md
+++ b/website/docs/contributing.md
@@ -9,6 +9,7 @@ If you plan to contribute new features, please first [open an issue](https://git
 (Based on the [PyTorch Contribution Guide](https://pytorch.org/docs/stable/community/contribution_guide.html).)
 
 ## About open source development
+
 If this is your first time contributing to an open source project, some aspects of the development process may seem unusual to you.
 
 - **There is no way to "claim" issues.** People often want to "claim" an issue when they decide to work on it, to ensure that there isn’t wasted work when someone else ends up working on it. This doesn’t really work too well in open source, since someone may decide to work on something, and end up not having time to do it. Feel free to give information in an advisory fashion, but at the end of the day, we will take running code and rough consensus.
@@ -16,33 +17,41 @@ If this is your first time contributing to an open source project, some aspects 
 - **There is a high bar for new functionality that is added.** Unlike in a corporate environment, where the person who wrote code implicitly "owns" it and can be expected to take care of it in the beginning of its lifetime, once a pull request is merged into an open source project, it immediately becomes the collective responsibility of all maintainers on the project. When we merge code, we are saying that we, the maintainers, are able to review subsequent changes and make a bugfix to the code. This naturally leads to a higher standard of contribution.
 
 ## Proposing new features
+
 New feature ideas are best discussed on a specific issue. Please include as much information as you can, any accompanying data, and your proposed solution. The H2O Wave team and community frequently reviews new issues and comments where they think they can help. If you feel confident in your solution, go ahead and implement it.
 
 ## Reporting issues
+
 If you’ve identified an issue, first search through the list of existing issues on the repo. If you are unable to find a similar issue, then create a new one. Supply as much information you can to reproduce the problematic behavior. Also, include any additional insights like the behavior you expect.
 
 ## Implementing features
+
 If you want to fix a specific issue, it’s best to comment on the individual issue with your intent. However, we do not lock or assign issues except in cases where we have worked with the developer before. It’s best to strike up a conversation on the issue and discuss your proposed solution. The H2O Wave team can provide guidance that saves you time.
 
-Issues that are labeled first-new-issue, low, or medium priority provide the best entrance point are great places to start.
+Issues that are labeled **good first issue**, **low** or **medium** priority are great places to start.
 
 ## Improving documentation and tutorials
+
 We aim to produce high quality documentation and tutorials. On rare occasions that content includes typos or bugs. If you find something you can fix, send us a pull request for consideration.
 
 ## Submitting pull requests
-You can view a list of all open issues [here](https://github.com/h2oai/wave/issues). Commenting on an issue is a great way to get the attention of the team. From here you can share your ideas and how you plan to resolve the issue.
+
+You can view a list of all [open issues](https://github.com/h2oai/wave/issues). Commenting on an issue is a great way to get the attention of the team. From here you can share your ideas and how you plan to resolve the issue.
 
 For more challenging issues, the team will provide feedback and direction for how to best solve the issue.
 
-If you’re not able to fix the issue itself, commenting and sharing whether you can reproduce the issue can be useful for helping the team identify problem areas.
+If you’re not able to fix the issue yourself, commenting and sharing whether you can reproduce the issue can be useful for helping the team identify problem areas.
 
 ## Improving code readability
-Improve code readability helps everyone. It is often better to submit a small number of pull requests that touch few files versus a large pull request that touches many files. Opening an issue related to your improvement is the best way to get started.
+
+Improved code readability helps everyone. It is often better to submit a small number of pull requests that touch few files versus a large pull request that touches many files. Opening an issue related to your improvement is the best way to get started.
 
 ## Adding test cases
+
 Additional test coverage is appreciated.  Help us make the codebase more robust.
 
 ## Security vulnerabilities
+
 If you discover a security vulnerability within H2O Wave, please send an email to Prithvi Prabhu at prithvi@h2o.ai. All security vulnerabilities will be promptly addressed.
 
 ## Code of Conduct
@@ -54,5 +63,85 @@ This Code of Conduct provides community guidelines for a safe, respectful, produ
 - When interpreting the words and actions of others, participants should always assume good intentions.
 - Behaviour which can be reasonably considered harassment will not be tolerated.
 
-
 (Based on the [Ruby Code of Conduct](https://www.ruby-lang.org/en/conduct/).)
+
+## Development Setup
+
+You will need [Node.js](http://nodejs.org) **version 10+**, [Go](https://golang.org/) **version 1.13.10+**, [Python](https://www.python.org/) **version 3.7**
+After cloning the repo, run:
+
+``` bash
+make all
+```
+
+After successful setup, you need to run:
+
+- Wave server (Go server) with command
+
+``` bash
+make run
+```
+
+- Wave app (this will run `tour.py`, but can be any app)
+
+``` bash
+cd py && ./venv/bin/python examples/tour.py
+```
+
+- Hot reload webpack server (for easier UI development)
+
+``` bash
+make run-ui
+```
+
+After that you can go to `http://localhost:10101/tour` (`http://localhost:3000/tour` if you enabled hot reload server).
+
+### Committing Changes
+
+Commit messages must follow [Conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). After commit, we have hooks in place that will:
+
+- Lint commit message format.
+- Lint staged files based on their extension. Linting supported for `.ts`, `.tsx`, `.go`, `.py`, `.md` files.
+- Run accompanying unit tests if found.
+
+If any of these checks fails, the commit is aborted and you have to fix the errors first.
+
+Make sure your commit message also ends with an issue number e.g. `fix: Typo #11`. (Tip: If you name your branch name in format `something-#GITHUB_ISSUE_NUM`, the issue number will get appended automatically to your commit message.)
+
+### Commonly used make targets
+
+``` bash
+# Compiles Typescript API to Python API.
+$ make generate
+
+# Starts Wave server.
+$ make run
+
+# Starts hot reload dev server for UI.
+$ make run-ui
+
+# Starts jest UI unit tests in watch mode.
+$ make test-ui-watch
+
+# Starts Cypress e2e server for python tests.
+$ make run-cypress-bridge
+```
+
+## Project Structure
+
+- **`data`**: contains data created by a Wave-app itself (e.g. file upload files)
+
+- **`docs`**: contains documentation page related files
+
+- **`website`**: documentation page source files
+
+- **`py`**: contains Python lib that is exported as a package
+
+- **`r`**: contains R lib that is exported as a package
+
+- **`tools`**: contains Typescript to Python generator
+
+- **`ui`**: contains UI components written in React + Typescript that are later translated to Python
+  - **`config`** contains webpack configuration
+  - **`eslint`** contains custom eslint rules for `ts` and `tsx` files
+  It is required to run `npm ci` after changing `linter.js` in order for changes to take effect.


### PR DESCRIPTION
* updated _CODE OF CONDUCT_ to the Ruby one @lo5 added
* Merged CONTRIBUTING.md with contribution page - left the social aspect of contribution page (+ fixed a few typos) and added dev setup to get you up and running from original CONTRIBUTING.md

Wondering whether we should delete `DEV.md` and link to newly merged `CONTRIBUTING.md` instead.

Closes #400