### PR TITLE
Forward refresh token to python client

### DIFF
--- a/client.go
+++ b/client.go
@@ -48,19 +48,20 @@ var (
 
 // Client represent a websocket (UI) client.
 type Client struct {
-	id          string          // unique id
-	addr        string          // remote address
-	username    string          // username, or "default-user"
-	subject     string          // oidc subject identifier
-	accessToken string          // oidc access token
-	broker      *Broker         // broker
-	conn        *websocket.Conn // connection
-	routes      []string        // watched routes
-	data        chan []byte     // send data
+	id           string          // unique id
+	addr         string          // remote address
+	username     string          // username, or "default-user"
+	subject      string          // oidc subject identifier
+	accessToken  string          // oidc access token
+	refreshToken string          // oidc refresh token
+	broker       *Broker         // broker
+	conn         *websocket.Conn // connection
+	routes       []string        // watched routes
+	data         chan []byte     // send data
 }
 
-func newClient(addr, username, subject, accessToken string, broker *Broker, conn *websocket.Conn) *Client {
-	return &Client{uuid.New().String(), addr, username, subject, accessToken, broker, conn, nil, make(chan []byte, 256)}
+func newClient(addr, username, subject, accessToken, refreshToken string, broker *Broker, conn *websocket.Conn) *Client {
+	return &Client{uuid.New().String(), addr, username, subject, accessToken, refreshToken, broker, conn, nil, make(chan []byte, 256)}
 }
 
 func (c *Client) listen() {
@@ -188,11 +189,12 @@ func (c *Client) quit() {
 }
 
 var (
-	usernameHeader    = []byte("u:")
-	subjectHeader     = []byte("s:")
-	clientIDHeader    = []byte("c:")
-	accessTokenHeader = []byte("a:")
-	queryBodySep      = []byte("\n\n")
+	usernameHeader     = []byte("u:")
+	subjectHeader      = []byte("s:")
+	clientIDHeader     = []byte("c:")
+	accessTokenHeader  = []byte("a:")
+	refreshTokenHeader = []byte("r:")
+	queryBodySep       = []byte("\n\n")
 )
 
 func (c *Client) format(data []byte) []byte {
@@ -212,6 +214,10 @@ func (c *Client) format(data []byte) []byte {
 
 	buf.Write(accessTokenHeader)
 	buf.WriteString(c.accessToken)
+	buf.WriteByte('\n')
+
+	buf.Write(refreshTokenHeader)
+	buf.WriteString(c.refreshToken)
 	buf.Write(queryBodySep)
 
 	buf.Write(data)


### PR DESCRIPTION
If PR merged, the OIDC `refresh` token will be propagated to python client the same way as other properties. This change is needed because of API for DAI and MLops which require `refresh` token to be able to handle long running tasks.

The token is accessible in `q.auth.refresh_token`.

Closes #365 