### PR TITLE
Add new plotting example(s) directly from dataframe

### DIFF
--- a/py/examples/plot_dataframe.py
+++ b/py/examples/plot_dataframe.py
@@ -8,39 +8,44 @@ import numpy as np
 page = site['/demo']
 
 n = 100
-df = pd.DataFrame({'length': np.random.rand(n),
-                   'width': np.random.rand(n),
-                   'data_type': np.random.choice(a=['Train', 'Test'], size=n, p=[0.8, 0.2])
-                   })
+df = pd.DataFrame(dict(
+    length=np.random.rand(n),
+    width=np.random.rand(n),
+    data_type=np.random.choice(a=['Train', 'Test'], size=n, p=[0.8, 0.2])
+))
 
 # Plot two numeric columns by each other and color based on a third, categorical column
-v = page.add('scatter', ui.plot_card(
+page['scatter'] = ui.plot_card(
     box='1 1 4 5',
     title='Scatter Plot from Dataframe',
     data=data(
         fields=df.columns.tolist(),
-        rows=df.values.tolist()
+        rows=df.values.tolist(),
+        pack=True,
     ),
-    plot=ui.plot(marks=[ui.mark(type='point',
-                                x='=length', x_title='Length',
-                                y='=width',  y_title='Width',
-                                color='=data_type', shape='circle',
-                                )])
-))
+    plot=ui.plot(marks=[ui.mark(
+        type='point',
+        x='=length', x_title='Length',
+        y='=width', y_title='Width',
+        color='=data_type', shape='circle',
+    )])
+)
 
 # Aggregate the data in pandas and plot a bar chart of the average value of one column by some other column
 df_agg = df.groupby(['data_type']).mean().reset_index()
-v = page.add('bar', ui.plot_card(
-    box='1 5 4 5',
+page['bar'] = ui.plot_card(
+    box='1 6 4 5',
     title='Bar Plot from Aggregated Dataframe',
     data=data(
         fields=df_agg.columns.tolist(),
-        rows=df_agg.values.tolist()
+        rows=df_agg.values.tolist(),
+        pack=True,
     ),
-    plot=ui.plot(marks=[ui.mark(type='interval',
-                                x='=data_type', x_title='Modeling Data Type',
-                                y='=length',  y_title='Length',
-                                )])
-))
+    plot=ui.plot(marks=[ui.mark(
+        type='interval',
+        x='=data_type', x_title='Modeling Data Type',
+        y='=length', y_title='Length',
+    )])
+)
 
 page.save()

--- a/py/examples/plot_dataframe.py
+++ b/py/examples/plot_dataframe.py
@@ -1,0 +1,46 @@
+# Plot / Dataframe
+# Examples of how to format pandas data when plotting
+# ---
+from h2o_wave import site, data, ui
+import pandas as pd
+import numpy as np
+
+page = site['/demo']
+
+n = 100
+df = pd.DataFrame({'length': np.random.rand(n),
+                   'width': np.random.rand(n),
+                   'data_type': np.random.choice(a=['Train', 'Test'], size=n, p=[0.8, 0.2])
+                   })
+
+# Plot two numeric columns by each other and color based on a third, categorical column
+v = page.add('scatter', ui.plot_card(
+    box='1 1 4 5',
+    title='Scatter Plot from Dataframe',
+    data=data(
+        fields=df.columns.tolist(),
+        rows=df.values.tolist()
+    ),
+    plot=ui.plot(marks=[ui.mark(type='point',
+                                x='=length', x_title='Length',
+                                y='=width',  y_title='Width',
+                                color='=data_type', shape='circle',
+                                )])
+))
+
+# Aggregate the data in pandas and plot a bar chart of the average value of one column by some other column
+df_agg = df.groupby(['data_type']).mean().reset_index()
+v = page.add('bar', ui.plot_card(
+    box='1 5 4 5',
+    title='Bar Plot from Aggregated Dataframe',
+    data=data(
+        fields=df_agg.columns.tolist(),
+        rows=df_agg.values.tolist()
+    ),
+    plot=ui.plot(marks=[ui.mark(type='interval',
+                                x='=data_type', x_title='Modeling Data Type',
+                                y='=length',  y_title='Length',
+                                )])
+))
+
+page.save()

--- a/py/examples/tour.conf
+++ b/py/examples/tour.conf
@@ -139,6 +139,7 @@ plot_axis_title.py
 plot_form.py
 plot_app.py
 plot_events.py
+plot_dataframe.py
 plot_vegalite.py
 plot_vegalite_update.py
 plot_vegalite_form.py


### PR DESCRIPTION
Addresses question from discourse with a new example that shows how you can use `df.values.tolist()` with Wave's `data` class to easily visualize data from a dataframe. I included two examples in a single file which should help people get started: one with visualizing ALL the data and one where you are aggregting in pandas and visualizing some trend. 

Hopefully this + the more advanced plot examples using Faker will help pandas folks get started. 

This would be the first example using `data(fields, rows)` vs. `data(fields, size)`