### PR TITLE
Replace asyncio.create_subprocess_exec() with python subprocess for tour

### DIFF
--- a/py/examples/tour.py
+++ b/py/examples/tour.py
@@ -35,7 +35,7 @@ class Example:
     async def start(self):
         # The environment passed into Popen must include SYSTEMROOT, otherwise Popen will fail when called
         # inside python during initialization if %PATH% is configured, but without %SYSTEMROOT%.
-        env = dict({'SYSTEMROOT': os.environ['SYSTEMROOT']}) if sys.platform.lower().startswith('win') else {}
+        env = {'SYSTEMROOT': os.environ['SYSTEMROOT']} if sys.platform.lower().startswith('win') else {}
         if self.is_app:
             self.process = subprocess.Popen(
                 [sys.executable, '-m', 'uvicorn', '--port', _app_port, f'examples.{self.name}:main'],


### PR DESCRIPTION
Windows do not support SelectorEventLoop. To support tour in all the platforms, replaced asyncio.create_subprocess_exec() with python subprocess. Fixes: https://github.com/h2oai/wave/issues/397

Verified on: Windows 10. python 3.7.9 and python 3.8.6, python 3.9.1, MacOS Catalina 10.15.5