### PR TITLE
feat: support tags/hashtags on examples to improve discovery #422

### DIFF
--- a/py/examples/background.py
+++ b/py/examples/background.py
@@ -1,5 +1,6 @@
 # Background Tasks
 # Use q.run() to execute functions in the background, in-process.
+# #background_tasks
 # ---
 import time
 import random

--- a/py/examples/background_executor.py
+++ b/py/examples/background_executor.py
@@ -1,5 +1,6 @@
 # Background Tasks / Executor
 # Use q.exec() to execute background functions using a thread-pool or process-pool.
+# #background_tasks #executor
 # ---
 import time
 import random

--- a/py/examples/background_progress.py
+++ b/py/examples/background_progress.py
@@ -1,5 +1,5 @@
 # Background Tasks / Progress
-# Execute background functions while incrementing a #progress bar
+# Execute background functions while incrementing a #progress bar.
 # #background_tasks
 # ---
 import time

--- a/py/examples/background_progress.py
+++ b/py/examples/background_progress.py
@@ -1,5 +1,6 @@
 # Background Tasks / Progress
-# Execute background functions while incrementing a progress bar
+# Execute background functions while incrementing a #progress bar
+# #background_tasks
 # ---
 import time
 import asyncio
@@ -10,7 +11,7 @@ from h2o_wave import main, app, Q, ui
 # A long-running that performs a blocking operation, in this case time.sleep()
 def blocking_function(secs) -> str:
     time.sleep(secs)  # Blocks!
-    return f'Download completed!'
+    return 'Download completed!'
 
 
 # An async function that displays a progress bar

--- a/py/examples/breadcrumbs.py
+++ b/py/examples/breadcrumbs.py
@@ -1,10 +1,10 @@
 # Breadcrumbs
-# Breadcrumbs should be used as a navigational aid in your app or site.
+# #Breadcrumbs should be used as a navigational aid in your app or site.
 # They indicate the current page’s location within a hierarchy and help
 # the user understand where they are in relation to the rest of that hierarchy.
 # They also afford one-click access to higher levels of that hierarchy.
 # Breadcrumbs are typically placed, in horizontal form, under the masthead
-# or navigation of an experience, above the primary content area.
+# or #navigation of an experience, above the primary content area.
 # ---
 from h2o_wave import main, app, Q, ui
 

--- a/py/examples/button.py
+++ b/py/examples/button.py
@@ -1,6 +1,6 @@
 # Form / Button
-# Use buttons to enable a user to commit a change or complete steps in a task.
-# form, buttons
+# Use #buttons to enable a user to commit a change or complete steps in a task.
+# #form
 # ---
 from h2o_wave import main, app, Q, ui
 

--- a/py/examples/button.py
+++ b/py/examples/button.py
@@ -1,5 +1,6 @@
 # Form / Button
 # Use buttons to enable a user to commit a change or complete steps in a task.
+# form, buttons
 # ---
 from h2o_wave import main, app, Q, ui
 

--- a/py/examples/buttons.py
+++ b/py/examples/buttons.py
@@ -1,6 +1,6 @@
 # Form / Buttons
-# Use the `ui.buttons()` function to group related buttons.
-# form, buttons
+# Use the `ui.buttons()` function to group related #buttons.
+# #form
 # ---
 from h2o_wave import main, app, Q, ui
 

--- a/py/examples/buttons.py
+++ b/py/examples/buttons.py
@@ -1,5 +1,6 @@
 # Form / Buttons
 # Use the `ui.buttons()` function to group related buttons.
+# form, buttons
 # ---
 from h2o_wave import main, app, Q, ui
 

--- a/py/examples/card_menu.py
+++ b/py/examples/card_menu.py
@@ -1,5 +1,6 @@
 # Context Menu
 # Display a context menu on a card.
+# #context_menu
 # ---
 import json
 from h2o_wave import main, app, Q, ui, data

--- a/py/examples/checkbox.py
+++ b/py/examples/checkbox.py
@@ -1,5 +1,6 @@
 # Form / Checkbox
 # Use checkboxes to switch between two mutually exclusive options.
+# #form #checkbox
 # ---
 from h2o_wave import main, app, Q, ui
 

--- a/py/examples/checklist.py
+++ b/py/examples/checklist.py
@@ -1,5 +1,6 @@
 # Form / Checklist
-# Use a checklist to group a set of related checkboxes.
+# Use a #checklist to group a set of related checkboxes.
+# #form
 # ---
 from h2o_wave import main, app, Q, ui
 

--- a/py/examples/choice_group.py
+++ b/py/examples/choice_group.py
@@ -1,5 +1,6 @@
 # Form / Choice Group
-# Use choice groups to let users select one option from two or more choices.
+# Use #choice groups to let users select one option from two or more choices.
+# #form #choice_group
 # ---
 from h2o_wave import main, app, Q, ui
 

--- a/py/examples/color_picker.py
+++ b/py/examples/color_picker.py
@@ -1,5 +1,6 @@
 # Form / Color Picker
 # Use a color picker to allow a user to select a color.
+# #form #color_picker
 # ---
 from h2o_wave import main, app, Q, ui
 

--- a/py/examples/combobox.py
+++ b/py/examples/combobox.py
@@ -1,5 +1,6 @@
 # Form / Combobox
 # Use comboboxes to allow users to either choose between available choices or indicate a choice by free-form editing.
+# #form #combobox
 # ---
 from h2o_wave import main, app, Q, ui
 

--- a/py/examples/counter_broadcast.py
+++ b/py/examples/counter_broadcast.py
@@ -1,6 +1,6 @@
 # Mode / Broadcast
-# Launch the server in broadcast mode to synchronize browser state across users.
-# Open `/demo` in multiple browsers and watch them synchronize in realtime.
+# Launch the server in #broadcast #mode to synchronize browser state across users.
+# Open `/demo` in multiple browsers and watch them synchronize in #realtime.
 # ---
 from h2o_wave import main, app, Q, ui, pack
 

--- a/py/examples/counter_broadcast.py
+++ b/py/examples/counter_broadcast.py
@@ -1,6 +1,6 @@
 # Mode / Broadcast
 # Launch the server in #broadcast #mode to synchronize browser state across users.
-# Open `/demo` in multiple browsers and watch them synchronize in #realtime.
+# Open `/demo` in multiple browsers and watch them synchronize in realtime.
 # ---
 from h2o_wave import main, app, Q, ui, pack
 

--- a/py/examples/counter_global.py
+++ b/py/examples/counter_global.py
@@ -1,8 +1,7 @@
 # Mode / Broadcast / Global
-# Launch the server in #broadcast #mode to synchronize browser #state across users.
+# Launch the server in #broadcast #mode to synchronize browser state across users.
 # Global variables can be used to manage state.
-# Open `/demo` in multiple browsers and watch them synchronize in #realtime.
-# #global_variables
+# Open `/demo` in multiple browsers and watch them synchronize in realtime.
 # ---
 from h2o_wave import main, app, Q, ui, pack
 

--- a/py/examples/counter_global.py
+++ b/py/examples/counter_global.py
@@ -1,6 +1,8 @@
 # Mode / Broadcast / Global
-# Launch the server in broadcast mode to synchronize browser state across users. Global variables can be used to manage state.
-# Open `/demo` in multiple browsers and watch them synchronize in realtime.
+# Launch the server in #broadcast #mode to synchronize browser #state across users.
+# Global variables can be used to manage state.
+# Open `/demo` in multiple browsers and watch them synchronize in #realtime.
+# #global_variables
 # ---
 from h2o_wave import main, app, Q, ui, pack
 

--- a/py/examples/counter_multicast.py
+++ b/py/examples/counter_multicast.py
@@ -1,6 +1,6 @@
 # Mode / Multicast
-# Launch the server in multicast mode to synchronize browser state across a user's clients.
-# Open `/demo` in multiple browsers and watch them synchronize in realtime.
+# Launch the server in #multicast #mode to synchronize browser #state across a user's clients.
+# Open `/demo` in multiple browsers and watch them synchronize in #realtime.
 # ---
 from h2o_wave import main, app, Q, ui, pack
 

--- a/py/examples/counter_multicast.py
+++ b/py/examples/counter_multicast.py
@@ -1,6 +1,6 @@
 # Mode / Multicast
-# Launch the server in #multicast #mode to synchronize browser #state across a user's clients.
-# Open `/demo` in multiple browsers and watch them synchronize in #realtime.
+# Launch the server in #multicast #mode to synchronize browser state across a user's clients.
+# Open `/demo` in multiple browsers and watch them synchronize in realtime.
 # ---
 from h2o_wave import main, app, Q, ui, pack
 

--- a/py/examples/counter_unicast.py
+++ b/py/examples/counter_unicast.py
@@ -1,5 +1,5 @@
 # Mode / Unicast
-# Launch the server in unicast mode and use `q.client` to manage client-local state.
+# Launch the server in #unicast #mode and use `q.client` to manage client-local #state.
 # ---
 from h2o_wave import main, app, Q, ui
 

--- a/py/examples/counter_unicast.py
+++ b/py/examples/counter_unicast.py
@@ -1,5 +1,5 @@
 # Mode / Unicast
-# Launch the server in #unicast #mode and use `q.client` to manage client-local #state.
+# Launch the server in #unicast #mode and use `q.client` to manage client-local state.
 # ---
 from h2o_wave import main, app, Q, ui
 

--- a/py/examples/dashboard.py
+++ b/py/examples/dashboard.py
@@ -1,5 +1,5 @@
 # Dashboard
-# Make a #dashboard using a multitude of cards and update them #live.
+# Make a #dashboard using a multitude of cards and update them live.
 # ---
 from faker import Faker
 import time

--- a/py/examples/dashboard.py
+++ b/py/examples/dashboard.py
@@ -1,5 +1,5 @@
 # Dashboard
-# Make a dashboard using a multitude of cards and update them live.
+# Make a #dashboard using a multitude of cards and update them #live.
 # ---
 from faker import Faker
 import time
@@ -8,7 +8,7 @@ from synth import FakePercent, FakeCategoricalSeries
 
 fake = Faker()
 
-light_theme_colors = '$red $pink $purple $violet $indigo $blue $azure $cyan $teal $mint $green $amber $orange $tangerine'.split()
+light_theme_colors = '$red $pink $purple $violet $indigo $blue $azure $cyan $teal $mint $green $amber $orange $tangerine'.split()  # noqa: E501
 dark_theme_colors = '$red $pink $blue $azure $cyan $teal $mint $green $lime $yellow $amber $orange $tangerine'.split()
 
 _color_index = -1

--- a/py/examples/date_picker.py
+++ b/py/examples/date_picker.py
@@ -1,5 +1,6 @@
 # Form / Date Picker
 # Use date pickers to allow users to pick dates.
+# #form #date_picker
 # ---
 from h2o_wave import main, app, Q, ui
 

--- a/py/examples/date_picker_trigger.py
+++ b/py/examples/date_picker_trigger.py
@@ -1,5 +1,5 @@
 # Form / Date Picker / Trigger
-# To handle #live changes to a date picker, enable the `trigger` attribute.
+# To handle live changes to a date picker, enable the `trigger` attribute.
 # #form #date_picker #trigger
 # ---
 from h2o_wave import main, app, Q, ui

--- a/py/examples/date_picker_trigger.py
+++ b/py/examples/date_picker_trigger.py
@@ -1,5 +1,6 @@
 # Form / Date Picker / Trigger
-# To handle live changes to a date picker, enable the `trigger` attribute.
+# To handle #live changes to a date picker, enable the `trigger` attribute.
+# #form #date_picker #trigger
 # ---
 from h2o_wave import main, app, Q, ui
 

--- a/py/examples/dropdown.py
+++ b/py/examples/dropdown.py
@@ -1,5 +1,6 @@
 # Form / Dropdown
 # Use dropdowns to allow users to choose between available choices.
+# #form #dropdown #choice
 # ---
 from h2o_wave import main, app, Q, ui
 

--- a/py/examples/file_upload.py
+++ b/py/examples/file_upload.py
@@ -1,5 +1,6 @@
 # Form / File Upload
-# Use a file upload component to allow users to upload files.
+# Use a file #upload component to allow users to upload files.
+# #form #file_upload
 # ---
 from h2o_wave import main, app, Q, ui
 

--- a/py/examples/flex.py
+++ b/py/examples/flex.py
@@ -1,5 +1,6 @@
 # Flex
 # Use a flex card to tile multiple child cards along one dimension, with optional wrapping.
+# #flex
 # ---
 import random
 
@@ -18,7 +19,7 @@ c = page.add('example', ui.flex_card(
     wrap='between',
     item_view='template',
     item_props=pack(dict(
-        content='<div style="width:15px; height:15px; border-radius: 50%; background-color:{{#if loss}}red{{else}}green{{/if}}" title="{{code}}"/>'
+        content='<div style="width:15px; height:15px; border-radius: 50%; background-color:{{#if loss}}red{{else}}green{{/if}}" title="{{code}}"/>'  # noqa: E501
     )),
     data=data('code loss', -10),
 ))

--- a/py/examples/form.py
+++ b/py/examples/form.py
@@ -1,5 +1,5 @@
 # Form
-# Use a form to collect data or show textual information.
+# Use a #form to collect data or show textual information.
 # ---
 from synth import FakeCategoricalSeries
 from h2o_wave import main, app, Q, ui, pack, data
@@ -34,7 +34,8 @@ n = 20
 
 
 # Generate random datum between 1 and 100
-def rnd(): return random.randint(1, 100)
+def rnd():
+    return random.randint(1, 100)
 
 
 @app('/demo')

--- a/py/examples/form_frame.py
+++ b/py/examples/form_frame.py
@@ -1,5 +1,5 @@
 # Form / Frame
-# Use a frame component in a form card to display HTML content inline.
+# Use a #frame component in a #form card to display #HTML content inline.
 # ---
 from h2o_wave import site, ui
 

--- a/py/examples/form_frame_path.py
+++ b/py/examples/form_frame_path.py
@@ -1,5 +1,5 @@
 # Form / Frame / Path
-# Use a frame component in a form card to display external web pages.
+# Use a #frame component in a #form card to display external web pages.
 # ---
 from h2o_wave import site, ui
 

--- a/py/examples/form_markup.py
+++ b/py/examples/form_markup.py
@@ -1,5 +1,6 @@
 # Form / Markup
-# Use a markup component to display formatted content using HTML.
+# Use a #markup component to display formatted content using #HTML.
+# #form
 # ---
 from h2o_wave import site, ui
 

--- a/py/examples/form_menu.py
+++ b/py/examples/form_menu.py
@@ -1,5 +1,6 @@
 # Form / Menu
 # Display context menus inside forms.
+# #form #context_menu
 # ---
 import json
 from h2o_wave import main, app, Q, ui, data

--- a/py/examples/form_template.py
+++ b/py/examples/form_template.py
@@ -1,5 +1,6 @@
 # Form / Template
-# Use a template component to render dynamic content using a HTML template.
+# Use a template component to render #dynamic content using a #HTML #template.
+# #form
 # ---
 from h2o_wave import site, pack, ui
 
@@ -15,7 +16,7 @@ menu = '''
 '''
 
 c = page.add('template_example', ui.form_card(
-    box=f'1 1 2 2',
+    box='1 1 2 2',
     items=[
         ui.template(
             content=menu,

--- a/py/examples/form_template.py
+++ b/py/examples/form_template.py
@@ -1,5 +1,5 @@
 # Form / Template
-# Use a template component to render #dynamic content using a #HTML #template.
+# Use a template component to render dynamic content using a #HTML #template.
 # #form
 # ---
 from h2o_wave import site, pack, ui

--- a/py/examples/frame.py
+++ b/py/examples/frame.py
@@ -1,5 +1,6 @@
 # Frame
-# Use a frame card to display HTML content.
+# Use a #frame card to display #HTML content.
+# #form
 # ---
 from h2o_wave import site, ui
 

--- a/py/examples/frame_path.py
+++ b/py/examples/frame_path.py
@@ -1,6 +1,5 @@
 # Frame / Path
 # Use a #frame card to display external web pages.
-# #path
 # ---
 from h2o_wave import site, ui
 

--- a/py/examples/frame_path.py
+++ b/py/examples/frame_path.py
@@ -1,5 +1,6 @@
 # Frame / Path
-# Use a frame card to display external web pages.
+# Use a #frame card to display external web pages.
+# #path
 # ---
 from h2o_wave import site, ui
 

--- a/py/examples/glider_gun.py
+++ b/py/examples/glider_gun.py
@@ -1,7 +1,6 @@
 # Graphics / Glider Gun
 # Use the #graphics API to play Conway's Game of Life - Gosper's Glider Gun
 # https://en.wikipedia.org/wiki/Conway%27s_Game_of_Life
-# #glider_gun #game_of_life
 # ---
 import time
 from copy import deepcopy

--- a/py/examples/glider_gun.py
+++ b/py/examples/glider_gun.py
@@ -1,6 +1,7 @@
 # Graphics / Glider Gun
-# Use the graphics API to play Conway's Game of Life - Gosper's Glider Gun
+# Use the #graphics API to play Conway's Game of Life - Gosper's Glider Gun
 # https://en.wikipedia.org/wiki/Conway%27s_Game_of_Life
+# #glider_gun #game_of_life
 # ---
 import time
 from copy import deepcopy

--- a/py/examples/graphics_clock.py
+++ b/py/examples/graphics_clock.py
@@ -1,5 +1,5 @@
 # Graphics / Clock
-# Use the graphics API to make a clock.
+# Use the #graphics API to make a #clock.
 # Source: https://codepen.io/dudleystorey/pen/HLBki
 # ---
 import time
@@ -22,7 +22,8 @@ page['example'] = ui.graphics_card(
 page.save()
 
 
-def rotate(deg): return f'rotate({deg} 50 50)'
+def rotate(deg):
+    return f'rotate({deg} 50 50)'
 
 
 scene = page['example'].scene

--- a/py/examples/graphics_clock.py
+++ b/py/examples/graphics_clock.py
@@ -1,5 +1,5 @@
 # Graphics / Clock
-# Use the #graphics API to make a #clock.
+# Use the #graphics API to make a clock.
 # Source: https://codepen.io/dudleystorey/pen/HLBki
 # ---
 import time

--- a/py/examples/graphics_hilbert.py
+++ b/py/examples/graphics_hilbert.py
@@ -1,5 +1,5 @@
 # Graphics / Hilbert
-# Use #turtle #graphics recursively to draw #Hilbert curves.
+# Use turtle #graphics recursively to draw Hilbert curves.
 # ---
 from h2o_wave import ui, main, app, Q, graphics as g
 

--- a/py/examples/graphics_hilbert.py
+++ b/py/examples/graphics_hilbert.py
@@ -1,5 +1,5 @@
 # Graphics / Hilbert
-# Use turtle graphics recursively to draw Hilbert curves.
+# Use #turtle #graphics recursively to draw #Hilbert curves.
 # ---
 from h2o_wave import ui, main, app, Q, graphics as g
 

--- a/py/examples/graphics_path.py
+++ b/py/examples/graphics_path.py
@@ -1,6 +1,5 @@
 # Graphics / Path
 # Use the #graphics API to draw a red square.
-# #path
 # ---
 from h2o_wave import site, ui, graphics as g
 

--- a/py/examples/graphics_path.py
+++ b/py/examples/graphics_path.py
@@ -1,5 +1,6 @@
 # Graphics / Path
-# Use the graphics API to draw a red square.
+# Use the #graphics API to draw a red square.
+# #path
 # ---
 from h2o_wave import site, ui, graphics as g
 

--- a/py/examples/graphics_primitives.py
+++ b/py/examples/graphics_primitives.py
@@ -1,5 +1,6 @@
 # Graphics / Primitives
-# Use the graphics module to render and update shapes.
+# Use the #graphics module to render and update shapes.
+# #primitives
 # ---
 
 from h2o_wave import site, ui, graphics as g

--- a/py/examples/graphics_primitives.py
+++ b/py/examples/graphics_primitives.py
@@ -1,6 +1,5 @@
 # Graphics / Primitives
 # Use the #graphics module to render and update shapes.
-# #primitives
 # ---
 
 from h2o_wave import site, ui, graphics as g

--- a/py/examples/graphics_spline.py
+++ b/py/examples/graphics_spline.py
@@ -1,6 +1,5 @@
 # Graphics / Spline
 # Use the #graphics module to render splines.
-# #spline
 # ---
 
 import random

--- a/py/examples/graphics_spline.py
+++ b/py/examples/graphics_spline.py
@@ -1,5 +1,6 @@
 # Graphics / Spline
-# Use the graphics module to render splines.
+# Use the #graphics module to render splines.
+# #spline
 # ---
 
 import random

--- a/py/examples/graphics_turtle.py
+++ b/py/examples/graphics_turtle.py
@@ -1,5 +1,5 @@
 # Graphics / Turtle
-# Use #turtle #graphics to draw paths.
+# Use turtle #graphics to draw paths.
 # Original example: https://docs.python.org/3/library/turtle.html
 # ---
 from h2o_wave import site, ui, graphics as g

--- a/py/examples/graphics_turtle.py
+++ b/py/examples/graphics_turtle.py
@@ -1,5 +1,5 @@
 # Graphics / Turtle
-# Use turtle graphics to draw paths.
+# Use #turtle #graphics to draw paths.
 # Original example: https://docs.python.org/3/library/turtle.html
 # ---
 from h2o_wave import site, ui, graphics as g

--- a/py/examples/grid.py
+++ b/py/examples/grid.py
@@ -1,5 +1,5 @@
 # Grid
-# Use a grid card to lay out multiple child cards in table form.
+# Use a #grid card to lay out multiple child cards in table form.
 # ---
 import random
 

--- a/py/examples/hash_routing.py
+++ b/py/examples/hash_routing.py
@@ -1,7 +1,9 @@
 # Routing
-# Use the browser's [location hash](https://developer.mozilla.org/en-US/docs/Web/API/Location/hash) for routing using URLs.
+# Use the browser's [location hash](https://developer.mozilla.org/en-US/docs/Web/API/Location/hash)
+# for #routing using URLs.
 #
 # The location hash can be accessed using `q.args['#']`.
+# #location_hash
 # ---
 from h2o_wave import main, app, Q, ui
 

--- a/py/examples/header.py
+++ b/py/examples/header.py
@@ -1,5 +1,5 @@
 # Header
-# Use a header card to display a page header.
+# Use a header card to display a page #header.
 # ---
 from h2o_wave import site, ui
 

--- a/py/examples/hello_world.py
+++ b/py/examples/hello_world.py
@@ -1,5 +1,6 @@
 # Hello World!
-# A simple example to get you started with Wave.
+# A #simple example to get you started with Wave.
+# #hello_world
 # ---
 # Import `Site` and the `ui` module from the `h2o_wave` package
 from h2o_wave import site, ui

--- a/py/examples/hello_world.py
+++ b/py/examples/hello_world.py
@@ -1,5 +1,5 @@
 # Hello World!
-# A #simple example to get you started with Wave.
+# A simple example to get you started with Wave.
 # #hello_world
 # ---
 # Import `Site` and the `ui` module from the `h2o_wave` package

--- a/py/examples/image.py
+++ b/py/examples/image.py
@@ -1,5 +1,5 @@
 # Image
-# Use an image card to display a base64-encoded image.
+# Use an image card to display a base64-encoded #image.
 # ---
 from h2o_wave import site, ui
 import io

--- a/py/examples/issue_tracker.py
+++ b/py/examples/issue_tracker.py
@@ -1,5 +1,6 @@
 # Issue Tracker
-# Implement a simple issue tracker using a table to create master-detail views.
+# Implement a simple issue tracker using a #table to create master-detail views.
+# #issue_tracker
 # ---
 from h2o_wave import main, app, Q, ui
 from faker import Faker

--- a/py/examples/issue_tracker.py
+++ b/py/examples/issue_tracker.py
@@ -1,6 +1,5 @@
 # Issue Tracker
 # Implement a simple issue tracker using a #table to create master-detail views.
-# #issue_tracker
 # ---
 from h2o_wave import main, app, Q, ui
 from faker import Faker

--- a/py/examples/label.py
+++ b/py/examples/label.py
@@ -1,5 +1,6 @@
 # Form / Label
-# Use labels to give a name to a component or a group of components in a form.
+# Use labels to give a name to a component or a group of components in a #form.
+# #label
 # ---
 from h2o_wave import site, ui
 

--- a/py/examples/layout.py
+++ b/py/examples/layout.py
@@ -1,5 +1,5 @@
 # Layout / Position
-# How to adjust the #position of cards on a page.
+# How to adjust the position of cards on a page.
 # #layout
 # ---
 

--- a/py/examples/layout.py
+++ b/py/examples/layout.py
@@ -1,5 +1,6 @@
 # Layout / Position
-# How to adjust the position of cards on a page.
+# How to adjust the #position of cards on a page.
+# #layout
 # ---
 
 from h2o_wave import site, ui

--- a/py/examples/layout_responsive.py
+++ b/py/examples/layout_responsive.py
@@ -1,5 +1,5 @@
 # Layout / Responsive
-# How to create a responsive layout.
+# How to create a #responsive #layout.
 # ---
 from h2o_wave import site, ui
 

--- a/py/examples/layout_size.py
+++ b/py/examples/layout_size.py
@@ -1,5 +1,5 @@
 # Layout / Size
-# How to adjust the size of cards on a page.
+# How to adjust the #size of cards on a page. #layout
 # ---
 
 from h2o_wave import site, ui

--- a/py/examples/layout_size.py
+++ b/py/examples/layout_size.py
@@ -1,5 +1,5 @@
 # Layout / Size
-# How to adjust the #size of cards on a page. #layout
+# How to adjust the size of cards on a page. #layout
 # ---
 
 from h2o_wave import site, ui

--- a/py/examples/link.py
+++ b/py/examples/link.py
@@ -1,5 +1,6 @@
 # Form / Link
-# Use links to allow navigation to internal and external URLs.
+# Use links to allow #navigation to internal and external URLs.
+# #form #link
 # ---
 from h2o_wave import site, ui
 

--- a/py/examples/list.py
+++ b/py/examples/list.py
@@ -1,5 +1,5 @@
 # Lists
-# Use list cards to lay out multiple child cards in the form of a list.
+# Use list cards to lay out multiple child cards in the form of a #list.
 # ---
 import random
 

--- a/py/examples/markdown.py
+++ b/py/examples/markdown.py
@@ -1,5 +1,5 @@
 # Markdown
-# Use a markdown card to display formatted content using markdown.
+# Use a markdown card to display formatted content using #markdown.
 # ---
 from h2o_wave import site, ui
 

--- a/py/examples/markdown_data.py
+++ b/py/examples/markdown_data.py
@@ -1,5 +1,5 @@
 # Markdown / Data
-# Display dynamic formatted content using markdown.
+# Display #dynamic formatted content using #markdown.
 # ---
 import time
 from h2o_wave import site, ui

--- a/py/examples/markdown_data.py
+++ b/py/examples/markdown_data.py
@@ -1,5 +1,5 @@
 # Markdown / Data
-# Display #dynamic formatted content using #markdown.
+# Display dynamic formatted content using #markdown.
 # ---
 import time
 from h2o_wave import site, ui

--- a/py/examples/markup.py
+++ b/py/examples/markup.py
@@ -1,5 +1,5 @@
 # Markup
-# Use a markup card to display formatted content using HTML.
+# Use a #markup card to display formatted content using #HTML.
 # ---
 from h2o_wave import site, ui
 

--- a/py/examples/message_bar.py
+++ b/py/examples/message_bar.py
@@ -1,5 +1,6 @@
 # Form / Message Bar
 # Use message bars to indicate relevant status information.
+# #form #message_bar
 # ---
 from h2o_wave import site, ui
 

--- a/py/examples/meta_dialog.py
+++ b/py/examples/meta_dialog.py
@@ -1,5 +1,5 @@
 # Meta / Dialog
-# Display a dialog.
+# Display a #dialog. #meta
 # ---
 from h2o_wave import main, app, Q, ui
 

--- a/py/examples/meta_icon.py
+++ b/py/examples/meta_icon.py
@@ -1,5 +1,5 @@
 # Meta / Icon
-# Set the browser window icon for a page
+# Set the browser window #icon for a page. #meta
 # ---
 from h2o_wave import site, ui
 

--- a/py/examples/meta_notification.py
+++ b/py/examples/meta_notification.py
@@ -1,5 +1,5 @@
 # Meta / Notification
-# Display a desktop notification.
+# Display a desktop #notification. #meta
 # ---
 import time
 

--- a/py/examples/meta_redirect.py
+++ b/py/examples/meta_redirect.py
@@ -1,5 +1,5 @@
 # Meta / Redirect
-# Redirect the page to a new URL or hash.
+# #Redirect the page to a new URL or hash. #meta
 # ---
 import time
 

--- a/py/examples/meta_refresh.py
+++ b/py/examples/meta_refresh.py
@@ -1,5 +1,6 @@
 # Meta / Refresh
-# Turn off live updates for static pages to conserve server resources.
+# Turn off #live updates for static pages to conserve server resources.
+# #meta #refresh
 # ---
 from h2o_wave import site, ui
 

--- a/py/examples/meta_refresh.py
+++ b/py/examples/meta_refresh.py
@@ -1,5 +1,5 @@
 # Meta / Refresh
-# Turn off #live updates for static pages to conserve server resources.
+# Turn off live updates for static pages to conserve server resources.
 # #meta #refresh
 # ---
 from h2o_wave import site, ui

--- a/py/examples/meta_title.py
+++ b/py/examples/meta_title.py
@@ -1,5 +1,5 @@
 # Meta / Title
-# Set the browser window #title for a page. #meta
+# Set the browser window title for a page. #meta
 # ---
 from h2o_wave import site, ui
 

--- a/py/examples/meta_title.py
+++ b/py/examples/meta_title.py
@@ -1,5 +1,5 @@
 # Meta / Title
-# Set the browser window title for a page
+# Set the browser window #title for a page. #meta
 # ---
 from h2o_wave import site, ui
 

--- a/py/examples/nav.py
+++ b/py/examples/nav.py
@@ -1,5 +1,5 @@
 # Nav
-# Use #nav cards to display #sidebar #navigation.
+# Use nav cards to display #sidebar #navigation.
 # ---
 from h2o_wave import main, app, Q, ui
 

--- a/py/examples/nav.py
+++ b/py/examples/nav.py
@@ -1,5 +1,5 @@
 # Nav
-# Use nav cards to display sidebar navigation.
+# Use #nav cards to display #sidebar #navigation.
 # ---
 from h2o_wave import main, app, Q, ui
 

--- a/py/examples/picker.py
+++ b/py/examples/picker.py
@@ -1,5 +1,6 @@
 # Form / Picker
 # Use pickers to allow users to select one or more choices, such as tags or files, from a list.
+# #form #picker #choice
 # ---
 from h2o_wave import main, app, Q, ui
 

--- a/py/examples/picker_selection.py
+++ b/py/examples/picker_selection.py
@@ -1,5 +1,6 @@
 # Form / Picker / Selection
-# Pre-select choices while displaying a picker.
+# Pre-select choices while displaying a #picker.
+# #form #selection #choice
 # ---
 from h2o_wave import main, app, Q, ui
 

--- a/py/examples/pixel_art.py
+++ b/py/examples/pixel_art.py
@@ -1,6 +1,6 @@
 # Pixel Art
 # A card that demonstrates collaborative editing in Wave.
-# Open `/demo` in multiple browsers and watch them synchronize in #realtime.
+# Open `/demo` in multiple browsers and watch them synchronize in realtime.
 # #collaboration
 # ---
 from h2o_wave import site, data, ui

--- a/py/examples/pixel_art.py
+++ b/py/examples/pixel_art.py
@@ -1,6 +1,7 @@
 # Pixel Art
-# A card that demonstrates collaborative editing in Q.
-# Open `/demo` in multiple browsers and watch them synchronize in realtime.
+# A card that demonstrates collaborative editing in Wave.
+# Open `/demo` in multiple browsers and watch them synchronize in #realtime.
+# #collaboration
 # ---
 from h2o_wave import site, data, ui
 

--- a/py/examples/plot_altair.py
+++ b/py/examples/plot_altair.py
@@ -1,5 +1,5 @@
 # Plot / Altair
-# Use Altair to create plot specifications for the Vega card.
+# Use #Altair to create #plot specifications for the #Vega card.
 # ---
 import altair
 from vega_datasets import data

--- a/py/examples/plot_app.py
+++ b/py/examples/plot_app.py
@@ -1,5 +1,5 @@
 # Plot / App
-# Make a plot from an app.
+# Make a #plot from an app.
 # ---
 from .synth import FakeMultiCategoricalSeries as F
 from h2o_wave import main, app, data, Q, ui

--- a/py/examples/plot_area.py
+++ b/py/examples/plot_area.py
@@ -1,5 +1,5 @@
 # Plot / Area
-# Make an area plot.
+# Make an #area #plot.
 # ---
 from synth import FakeTimeSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_area.py
+++ b/py/examples/plot_area.py
@@ -1,5 +1,5 @@
 # Plot / Area
-# Make an #area #plot.
+# Make an area #plot.
 # ---
 from synth import FakeTimeSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_area_groups.py
+++ b/py/examples/plot_area_groups.py
@@ -1,6 +1,5 @@
 # Plot / Area / Groups
-# Make an #area #plot showing multiple categories.
-# multiple_categories
+# Make an area #plot showing multiple categories.
 # ---
 from synth import FakeMultiTimeSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_area_groups.py
+++ b/py/examples/plot_area_groups.py
@@ -1,5 +1,6 @@
 # Plot / Area / Groups
-# Make an area plot showing multiple categories.
+# Make an #area #plot showing multiple categories.
+# multiple_categories
 # ---
 from synth import FakeMultiTimeSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_area_line.py
+++ b/py/examples/plot_area_line.py
@@ -1,5 +1,5 @@
 # Plot / Area + Line
-# Make an area plot with an additional line layer on top.
+# Make an #area #plot with an additional #line #layer on top.
 # ---
 from synth import FakeTimeSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_area_line.py
+++ b/py/examples/plot_area_line.py
@@ -1,5 +1,5 @@
 # Plot / Area + Line
-# Make an #area #plot with an additional #line #layer on top.
+# Make an area #plot with an additional line layer on top.
 # ---
 from synth import FakeTimeSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_area_line_groups.py
+++ b/py/examples/plot_area_line_groups.py
@@ -1,5 +1,6 @@
 # Plot / Area + Line / Groups
-# Make an combined area + line plot showing multiple categories.
+# Make an #combined #area + #line #plot showing multiple categories.
+# multiple_categories
 # ---
 from synth import FakeMultiTimeSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_area_line_groups.py
+++ b/py/examples/plot_area_line_groups.py
@@ -1,6 +1,5 @@
 # Plot / Area + Line / Groups
-# Make an #combined #area + #line #plot showing multiple categories.
-# multiple_categories
+# Make an combined area + line #plot showing multiple categories.
 # ---
 from synth import FakeMultiTimeSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_area_line_smooth.py
+++ b/py/examples/plot_area_line_smooth.py
@@ -1,5 +1,5 @@
 # Plot / Area + Line / Smooth
-# Make a combined #area + #line #plot using a #smooth #curve.
+# Make a combined area + line #plot using a smooth curve.
 # ---
 from synth import FakeTimeSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_area_line_smooth.py
+++ b/py/examples/plot_area_line_smooth.py
@@ -1,5 +1,5 @@
 # Plot / Area + Line / Smooth
-# Make a combined area + line plot using a smooth curve.
+# Make a combined #area + #line #plot using a #smooth #curve.
 # ---
 from synth import FakeTimeSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_area_negative.py
+++ b/py/examples/plot_area_negative.py
@@ -1,5 +1,5 @@
 # Plot / Area / Negative
-# Make an area plot showing positive and negative values.
+# Make an #area #plot showing positive and negative values.
 # ---
 from synth import FakeTimeSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_area_negative.py
+++ b/py/examples/plot_area_negative.py
@@ -1,5 +1,5 @@
 # Plot / Area / Negative
-# Make an #area #plot showing positive and negative values.
+# Make an area #plot showing positive and negative values.
 # ---
 from synth import FakeTimeSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_area_range.py
+++ b/py/examples/plot_area_range.py
@@ -1,5 +1,5 @@
 # Plot / Area / Range
-# Make an area plot representing a range (band) of values.
+# Make an #area #plot representing a range (band) of values.
 # ---
 import random
 

--- a/py/examples/plot_area_range.py
+++ b/py/examples/plot_area_range.py
@@ -1,5 +1,5 @@
 # Plot / Area / Range
-# Make an #area #plot representing a range (band) of values.
+# Make an area #plot representing a range (band) of values.
 # ---
 import random
 

--- a/py/examples/plot_area_smooth.py
+++ b/py/examples/plot_area_smooth.py
@@ -1,5 +1,5 @@
 # Plot / Area / Smooth
-# Make an area plot with a smooth curve.
+# Make an #area #plot with a #smooth #curve.
 # ---
 from synth import FakeTimeSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_area_smooth.py
+++ b/py/examples/plot_area_smooth.py
@@ -1,5 +1,5 @@
 # Plot / Area / Smooth
-# Make an #area #plot with a #smooth #curve.
+# Make an area #plot with a smooth curve.
 # ---
 from synth import FakeTimeSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_area_stacked.py
+++ b/py/examples/plot_area_stacked.py
@@ -1,5 +1,5 @@
 # Plot / Area / Stacked
-# Make a #stacked #area #plot.
+# Make a #stacked area #plot.
 # ---
 from synth import FakeMultiTimeSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_area_stacked.py
+++ b/py/examples/plot_area_stacked.py
@@ -1,5 +1,5 @@
 # Plot / Area / Stacked
-# Make a stacked area plot.
+# Make a #stacked #area #plot.
 # ---
 from synth import FakeMultiTimeSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_axis_title.py
+++ b/py/examples/plot_axis_title.py
@@ -1,5 +1,5 @@
 # Plot / Axis Titles
-# Display custom axis titles on a plot.
+# Display #custom axis titles on a #plot. #axis_title
 # ---
 from synth import FakeTimeSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_axis_title.py
+++ b/py/examples/plot_axis_title.py
@@ -1,5 +1,5 @@
 # Plot / Axis Titles
-# Display #custom axis titles on a #plot. #axis_title
+# Display custom axis titles on a #plot.
 # ---
 from synth import FakeTimeSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_bokeh.py
+++ b/py/examples/plot_bokeh.py
@@ -1,5 +1,5 @@
 # Plot / Bokeh
-# Use Bokeh to create plots.
+# Use #Bokeh to create plots. #plot
 # ---
 import numpy as np
 from bokeh.models import HoverTool

--- a/py/examples/plot_d3.py
+++ b/py/examples/plot_d3.py
@@ -1,5 +1,5 @@
 # Plot / D3.js
-# Create custom plots using D3.js.
+# Create #custom plots using #D3.js. #plot
 # ---
 import json
 import os.path

--- a/py/examples/plot_d3.py
+++ b/py/examples/plot_d3.py
@@ -1,5 +1,5 @@
 # Plot / D3.js
-# Create #custom plots using #D3.js. #plot
+# Create custom plots using D3.js. #plot
 # ---
 import json
 import os.path

--- a/py/examples/plot_events.py
+++ b/py/examples/plot_events.py
@@ -1,5 +1,5 @@
 # Plot / Events
-# Handle events on a plot card
+# Handle #events on a #plot card.
 # ---
 from h2o_wave import main, app, Q, ui, data
 

--- a/py/examples/plot_form.py
+++ b/py/examples/plot_form.py
@@ -1,5 +1,5 @@
 # Plot / Form
-# Display a plot inside a form.
+# Display a #plot inside a #form.
 # ---
 from synth import FakeCategoricalSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_histogram.py
+++ b/py/examples/plot_histogram.py
@@ -1,5 +1,5 @@
 # Plot / Histogram
-# Make a histogram.
+# Make a #histogram. #plot
 # ---
 from synth import FakeCategoricalSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_interval.py
+++ b/py/examples/plot_interval.py
@@ -1,5 +1,5 @@
 # Plot / Interval
-# Make a column plot.
+# Make a #column #plot. #interval
 # ---
 from synth import FakeCategoricalSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_interval.py
+++ b/py/examples/plot_interval.py
@@ -1,5 +1,5 @@
 # Plot / Interval
-# Make a #column #plot. #interval
+# Make a column #plot. #interval
 # ---
 from synth import FakeCategoricalSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_interval_annotation.py
+++ b/py/examples/plot_interval_annotation.py
@@ -1,5 +1,5 @@
 # Plot / Interval / Annotation
-# Add annotations to a column plot.
+# Add annotations to a #column #plot. #annotation #interval
 # ---
 from synth import FakeCategoricalSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_interval_annotation.py
+++ b/py/examples/plot_interval_annotation.py
@@ -1,5 +1,5 @@
 # Plot / Interval / Annotation
-# Add annotations to a #column #plot. #annotation #interval
+# Add annotations to a column #plot. #annotation #interval
 # ---
 from synth import FakeCategoricalSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_interval_annotation_transpose.py
+++ b/py/examples/plot_interval_annotation_transpose.py
@@ -1,5 +1,5 @@
 # Plot / Interval / Annotation / Transpose
-# Add annotations to a #bar #plot. #annotation #interval #transpose
+# Add annotations to a bar #plot. #annotation #interval
 # ---
 from synth import FakeCategoricalSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_interval_annotation_transpose.py
+++ b/py/examples/plot_interval_annotation_transpose.py
@@ -1,5 +1,5 @@
 # Plot / Interval / Annotation / Transpose
-# Add annotations to a bar plot.
+# Add annotations to a #bar #plot. #annotation #interval #transpose
 # ---
 from synth import FakeCategoricalSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_interval_groups.py
+++ b/py/examples/plot_interval_groups.py
@@ -1,5 +1,5 @@
 # Plot / Interval / Groups
-# Make a #grouped #column #plot. #interval
+# Make a grouped column #plot. #interval
 # ---
 from synth import FakeMultiCategoricalSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_interval_groups.py
+++ b/py/examples/plot_interval_groups.py
@@ -1,5 +1,5 @@
 # Plot / Interval / Groups
-# Make a grouped column plot.
+# Make a #grouped #column #plot. #interval
 # ---
 from synth import FakeMultiCategoricalSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_interval_groups_transpose.py
+++ b/py/examples/plot_interval_groups_transpose.py
@@ -1,5 +1,5 @@
 # Plot / Interval / Groups / Transpose
-# Make a grouped bar plot.
+# Make a #grouped #bar #plot. #interval #transpose
 # ---
 from synth import FakeMultiCategoricalSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_interval_groups_transpose.py
+++ b/py/examples/plot_interval_groups_transpose.py
@@ -1,5 +1,5 @@
 # Plot / Interval / Groups / Transpose
-# Make a #grouped #bar #plot. #interval #transpose
+# Make a grouped bar #plot. #interval
 # ---
 from synth import FakeMultiCategoricalSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_interval_helix.py
+++ b/py/examples/plot_interval_helix.py
@@ -1,5 +1,5 @@
 # Plot / Interval / Helix
-# Make a bar plot in helical coordinates.
+# Make a #bar #plot in helical coordinates. #interval #helix
 # ---
 from synth import FakeCategoricalSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_interval_helix.py
+++ b/py/examples/plot_interval_helix.py
@@ -1,5 +1,5 @@
 # Plot / Interval / Helix
-# Make a #bar #plot in helical coordinates. #interval #helix
+# Make a bar #plot in helical coordinates. #interval
 # ---
 from synth import FakeCategoricalSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_interval_labels.py
+++ b/py/examples/plot_interval_labels.py
@@ -1,5 +1,5 @@
 # Plot / Interval / Labels
-# Make a column plot with labels on each bar.
+# Make a #column #plot with #labels on each #bar. #interval
 # ---
 from synth import FakeCategoricalSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_interval_labels.py
+++ b/py/examples/plot_interval_labels.py
@@ -1,5 +1,5 @@
 # Plot / Interval / Labels
-# Make a #column #plot with #labels on each #bar. #interval
+# Make a column #plot with #label on each bar. #interval
 # ---
 from synth import FakeCategoricalSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_interval_labels.py
+++ b/py/examples/plot_interval_labels.py
@@ -1,5 +1,5 @@
 # Plot / Interval / Labels
-# Make a column #plot with #label on each bar. #interval
+# Make a column #plot with labels on each bar. #interval
 # ---
 from synth import FakeCategoricalSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_interval_polar.py
+++ b/py/examples/plot_interval_polar.py
@@ -1,5 +1,5 @@
 # Plot / Interval / Polar
-# Make a rose plot (a bar plot in polar coordinates).
+# Make a #rose #plot (a #bar plot in #polar coordinates). #interval
 # ---
 from synth import FakeCategoricalSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_interval_polar.py
+++ b/py/examples/plot_interval_polar.py
@@ -1,5 +1,5 @@
 # Plot / Interval / Polar
-# Make a #rose #plot (a #bar plot in #polar coordinates). #interval
+# Make a rose #plot (a bar plot in polar coordinates). #interval
 # ---
 from synth import FakeCategoricalSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_interval_polar_stacked.py
+++ b/py/examples/plot_interval_polar_stacked.py
@@ -1,5 +1,5 @@
 # Plot / Interval / Polar / Stacked
-# Make a #stacked #rose #plot (a stacked #bar plot in #polar coordinates). #interval
+# Make a #stacked rose #plot (a stacked bar plot in polar coordinates). #interval
 # ---
 from synth import FakeMultiCategoricalSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_interval_polar_stacked.py
+++ b/py/examples/plot_interval_polar_stacked.py
@@ -1,5 +1,5 @@
 # Plot / Interval / Polar / Stacked
-# Make a stacked rose plot (a stacked bar plot in polar coordinates).
+# Make a #stacked #rose #plot (a stacked #bar plot in #polar coordinates). #interval
 # ---
 from synth import FakeMultiCategoricalSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_interval_range.py
+++ b/py/examples/plot_interval_range.py
@@ -1,5 +1,6 @@
 # Plot / Interval / Range
-# Make a column plot with each bar representing high/low (or start/end) values. Transposing this produces a gantt plot.
+# Make a #column #plot with each #bar representing high/low (or start/end) values.
+# Transposing this produces a #gantt plot. #interval #range
 # ---
 import random
 

--- a/py/examples/plot_interval_range.py
+++ b/py/examples/plot_interval_range.py
@@ -1,6 +1,6 @@
 # Plot / Interval / Range
-# Make a #column #plot with each #bar representing high/low (or start/end) values.
-# Transposing this produces a #gantt plot. #interval #range
+# Make a column #plot with each bar representing high/low (or start/end) values.
+# Transposing this produces a gantt plot. #interval #range
 # ---
 import random
 

--- a/py/examples/plot_interval_range_transpose.py
+++ b/py/examples/plot_interval_range_transpose.py
@@ -1,5 +1,6 @@
 # Plot / Interval / Range / Transpose
-# Make a bar plot with each bar representing high/low (or start/end) values. Transposing this produces a gantt plot.
+# Make a #bar #plot with each bar representing high/low (or start/end) values. Transposing this produces a #gantt plot.
+# #transpose
 # ---
 import random
 

--- a/py/examples/plot_interval_range_transpose.py
+++ b/py/examples/plot_interval_range_transpose.py
@@ -1,6 +1,5 @@
 # Plot / Interval / Range / Transpose
-# Make a #bar #plot with each bar representing high/low (or start/end) values. Transposing this produces a #gantt plot.
-# #transpose
+# Make a bar #plot with each bar representing high/low (or start/end) values. Transposing this produces a gantt plot.
 # ---
 import random
 

--- a/py/examples/plot_interval_stacked.py
+++ b/py/examples/plot_interval_stacked.py
@@ -1,5 +1,5 @@
 # Plot / Interval / Stacked
-# Make a #stacked #column #plot. #interval
+# Make a #stacked column #plot. #interval
 # ---
 from synth import FakeMultiCategoricalSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_interval_stacked.py
+++ b/py/examples/plot_interval_stacked.py
@@ -1,5 +1,5 @@
 # Plot / Interval / Stacked
-# Make a stacked column plot.
+# Make a #stacked #column #plot. #interval
 # ---
 from synth import FakeMultiCategoricalSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_interval_stacked_grouped.py
+++ b/py/examples/plot_interval_stacked_grouped.py
@@ -1,5 +1,5 @@
 # Plot / Interval / Stacked / Grouped
-# Make a #column #plot with both #stacked and #grouped bars. #interval #bar
+# Make a column #plot with both #stacked and grouped bars. #interval
 # ---
 from synth import FakeMultiCategoricalSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_interval_stacked_grouped.py
+++ b/py/examples/plot_interval_stacked_grouped.py
@@ -1,5 +1,5 @@
 # Plot / Interval / Stacked / Grouped
-# Make a column plot with both stacked and grouped bars.
+# Make a #column #plot with both #stacked and #grouped bars. #interval #bar
 # ---
 from synth import FakeMultiCategoricalSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_interval_stacked_grouped_transpose.py
+++ b/py/examples/plot_interval_stacked_grouped_transpose.py
@@ -1,5 +1,5 @@
 # Plot / Interval / Stacked / Grouped / Transpose
-# Make a bar plot with both stacked and grouped bars.
+# Make a #bar #plot with both #stacked and #grouped bars. #interval #transpose
 # ---
 from synth import FakeMultiCategoricalSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_interval_stacked_grouped_transpose.py
+++ b/py/examples/plot_interval_stacked_grouped_transpose.py
@@ -1,5 +1,5 @@
 # Plot / Interval / Stacked / Grouped / Transpose
-# Make a #bar #plot with both #stacked and #grouped bars. #interval #transpose
+# Make a bar #plot with both #stacked and grouped bars. #interval
 # ---
 from synth import FakeMultiCategoricalSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_interval_stacked_transpose.py
+++ b/py/examples/plot_interval_stacked_transpose.py
@@ -1,5 +1,5 @@
 # Plot / Interval / Stacked / Transpose
-# Make a #stacked #bar #plot. #interval #transpose
+# Make a #stacked bar #plot. #interval
 # ---
 from synth import FakeMultiCategoricalSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_interval_stacked_transpose.py
+++ b/py/examples/plot_interval_stacked_transpose.py
@@ -1,5 +1,5 @@
 # Plot / Interval / Stacked / Transpose
-# Make a stacked bar plot.
+# Make a #stacked #bar #plot. #interval #transpose
 # ---
 from synth import FakeMultiCategoricalSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_interval_theta.py
+++ b/py/examples/plot_interval_theta.py
@@ -1,5 +1,5 @@
 # Plot / Interval / Theta
-# Make a "racetrack" plot (a bar plot in polar coordinates, transposed).
+# Make a "racetrack" #plot (a #bar plot in #polar coordinates, transposed). #racetrack #interval #theta
 # ---
 from synth import FakeMultiCategoricalSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_interval_theta.py
+++ b/py/examples/plot_interval_theta.py
@@ -1,5 +1,5 @@
 # Plot / Interval / Theta
-# Make a "racetrack" #plot (a #bar plot in #polar coordinates, transposed). #racetrack #interval #theta
+# Make a "racetrack" #plot (a bar plot in polar coordinates, transposed). #interval
 # ---
 from synth import FakeMultiCategoricalSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_interval_transpose.py
+++ b/py/examples/plot_interval_transpose.py
@@ -1,5 +1,5 @@
 # Plot / Interval / Transpose
-# Make a #bar #plot. #interval #transpose
+# Make a bar #plot. #interval
 # ---
 from synth import FakeCategoricalSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_interval_transpose.py
+++ b/py/examples/plot_interval_transpose.py
@@ -1,5 +1,5 @@
 # Plot / Interval / Transpose
-# Make a bar plot.
+# Make a #bar #plot. #interval #transpose
 # ---
 from synth import FakeCategoricalSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_line.py
+++ b/py/examples/plot_line.py
@@ -1,5 +1,5 @@
 # Plot / Line
-# Make a #line #plot.
+# Make a line #plot.
 # ---
 from synth import FakeTimeSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_line.py
+++ b/py/examples/plot_line.py
@@ -1,5 +1,5 @@
 # Plot / Line
-# Make a line plot.
+# Make a #line #plot.
 # ---
 from synth import FakeTimeSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_line_annotation.py
+++ b/py/examples/plot_line_annotation.py
@@ -1,5 +1,5 @@
 # Plot / Line / Annotation
-# Add annotations to a #line #plot. #annotation
+# Add annotations to a line #plot. #annotation
 # ---
 from synth import FakeTimeSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_line_annotation.py
+++ b/py/examples/plot_line_annotation.py
@@ -1,5 +1,5 @@
 # Plot / Line / Annotation
-# Add annotations to a line plot.
+# Add annotations to a #line #plot. #annotation
 # ---
 from synth import FakeTimeSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_line_groups.py
+++ b/py/examples/plot_line_groups.py
@@ -1,5 +1,5 @@
 # Plot / Line / Groups
-# Make a multi-series #line #plot. #multi_series
+# Make a multi-series line #plot. #multi_series
 # ---
 from synth import FakeMultiTimeSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_line_groups.py
+++ b/py/examples/plot_line_groups.py
@@ -1,5 +1,5 @@
 # Plot / Line / Groups
-# Make a multi-series line plot.
+# Make a multi-series #line #plot. #multi_series
 # ---
 from synth import FakeMultiTimeSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_line_labels.py
+++ b/py/examples/plot_line_labels.py
@@ -1,5 +1,5 @@
 # Plot / Line / Labels
-# Add #labels to a #line #plot.
+# Add #label to a line #plot.
 # ---
 from synth import FakeTimeSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_line_labels.py
+++ b/py/examples/plot_line_labels.py
@@ -1,5 +1,5 @@
 # Plot / Line / Labels
-# Add #label to a line #plot.
+# Add labels to a line #plot.
 # ---
 from synth import FakeTimeSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_line_labels.py
+++ b/py/examples/plot_line_labels.py
@@ -1,5 +1,5 @@
 # Plot / Line / Labels
-# Add labels to a line plot.
+# Add #labels to a #line #plot.
 # ---
 from synth import FakeTimeSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_line_labels_no_overlap.py
+++ b/py/examples/plot_line_labels_no_overlap.py
@@ -1,5 +1,5 @@
 # Plot / Line / Labels / Occlusion
-# Make a line plot with non-overlapping labels.
+# Make a #line #plot with non-overlapping #labels. #occlusion
 # ---
 from synth import FakeTimeSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_line_labels_no_overlap.py
+++ b/py/examples/plot_line_labels_no_overlap.py
@@ -1,5 +1,5 @@
 # Plot / Line / Labels / Occlusion
-# Make a line #plot with non-overlapping #label.
+# Make a line #plot with non-overlapping labels.
 # ---
 from synth import FakeTimeSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_line_labels_no_overlap.py
+++ b/py/examples/plot_line_labels_no_overlap.py
@@ -1,5 +1,5 @@
 # Plot / Line / Labels / Occlusion
-# Make a #line #plot with non-overlapping #labels. #occlusion
+# Make a line #plot with non-overlapping #label.
 # ---
 from synth import FakeTimeSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_line_labels_stroked.py
+++ b/py/examples/plot_line_labels_stroked.py
@@ -1,5 +1,6 @@
 # Plot / Line / Labels/ Stroked
 # Customize label rendering: add a subtle outline to labels to improve readability.
+# #plot #line #labels #custom #stroked
 # ---
 from synth import FakeTimeSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_line_labels_stroked.py
+++ b/py/examples/plot_line_labels_stroked.py
@@ -1,6 +1,6 @@
 # Plot / Line / Labels/ Stroked
 # Customize label rendering: add a subtle outline to labels to improve readability.
-# #plot #label
+# #plot
 # ---
 from synth import FakeTimeSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_line_labels_stroked.py
+++ b/py/examples/plot_line_labels_stroked.py
@@ -1,6 +1,6 @@
 # Plot / Line / Labels/ Stroked
 # Customize label rendering: add a subtle outline to labels to improve readability.
-# #plot #line #labels #custom #stroked
+# #plot #label
 # ---
 from synth import FakeTimeSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_line_smooth.py
+++ b/py/examples/plot_line_smooth.py
@@ -1,5 +1,5 @@
 # Plot / Line / Smooth
-# Make a line plot using a smooth curve.
+# Make a #line #plot using a #smooth #curve.
 # ---
 from synth import FakeTimeSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_line_smooth.py
+++ b/py/examples/plot_line_smooth.py
@@ -1,5 +1,5 @@
 # Plot / Line / Smooth
-# Make a #line #plot using a #smooth #curve.
+# Make a line #plot using a smooth curve.
 # ---
 from synth import FakeTimeSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_matplotlib.py
+++ b/py/examples/plot_matplotlib.py
@@ -1,5 +1,6 @@
 # Plot / Matplotlib
-# Use matplotlib to create plots. Also demonstrates how to provide live control over plots.
+# Use #matplotlib to create plots. Also demonstrates how to provide live control over plots.
+# #plot #live
 # ---
 import uuid
 import os

--- a/py/examples/plot_matplotlib.py
+++ b/py/examples/plot_matplotlib.py
@@ -1,6 +1,6 @@
 # Plot / Matplotlib
 # Use #matplotlib to create plots. Also demonstrates how to provide live control over plots.
-# #plot #live
+# #plot
 # ---
 import uuid
 import os

--- a/py/examples/plot_path.py
+++ b/py/examples/plot_path.py
@@ -1,5 +1,5 @@
 # Plot / Path
-# Make a #path #plot.
+# Make a path #plot.
 # ---
 from synth import FakeScatter
 from h2o_wave import site, data, ui

--- a/py/examples/plot_path.py
+++ b/py/examples/plot_path.py
@@ -1,5 +1,5 @@
 # Plot / Path
-# Make a path plot.
+# Make a #path #plot.
 # ---
 from synth import FakeScatter
 from h2o_wave import site, data, ui

--- a/py/examples/plot_path_point.py
+++ b/py/examples/plot_path_point.py
@@ -1,5 +1,5 @@
 # Plot / Path / Point
-# Make a path plot with an additional layer of points.
+# Make a #path #plot with an additional #layer of points. #point
 # ---
 from synth import FakeScatter
 from h2o_wave import site, data, ui

--- a/py/examples/plot_path_point.py
+++ b/py/examples/plot_path_point.py
@@ -1,5 +1,5 @@
 # Plot / Path / Point
-# Make a #path #plot with an additional #layer of points. #point
+# Make a path #plot with an additional layer of points.
 # ---
 from synth import FakeScatter
 from h2o_wave import site, data, ui

--- a/py/examples/plot_path_smooth.py
+++ b/py/examples/plot_path_smooth.py
@@ -1,5 +1,5 @@
 # Plot / Path / Smooth
-# Make a #path #plot with a #smooth #curve.
+# Make a path #plot with a smooth curve.
 # ---
 from synth import FakeScatter
 from h2o_wave import site, data, ui

--- a/py/examples/plot_path_smooth.py
+++ b/py/examples/plot_path_smooth.py
@@ -1,5 +1,5 @@
 # Plot / Path / Smooth
-# Make a path plot with a smooth curve.
+# Make a #path #plot with a #smooth #curve.
 # ---
 from synth import FakeScatter
 from h2o_wave import site, data, ui

--- a/py/examples/plot_plotly.py
+++ b/py/examples/plot_plotly.py
@@ -1,5 +1,6 @@
 # Plot / Plotly
-# Use plotly to create plots. Also demonstrates how to provide live control over plots.
+# Use #plotly to create plots. Also demonstrates how to provide #live control over plots.
+# #plot
 # ---
 
 import numpy as np

--- a/py/examples/plot_plotly.py
+++ b/py/examples/plot_plotly.py
@@ -1,5 +1,5 @@
 # Plot / Plotly
-# Use #plotly to create plots. Also demonstrates how to provide #live control over plots.
+# Use #plotly to create plots. Also demonstrates how to provide live control over plots.
 # #plot
 # ---
 

--- a/py/examples/plot_point.py
+++ b/py/examples/plot_point.py
@@ -1,5 +1,5 @@
 # Plot / Point
-# Make a #scatterplot. #plot #point
+# Make a scatterplot. #plot
 # ---
 from synth import FakeScatter
 from h2o_wave import site, data, ui

--- a/py/examples/plot_point.py
+++ b/py/examples/plot_point.py
@@ -1,5 +1,5 @@
 # Plot / Point
-# Make a scatterplot.
+# Make a #scatterplot. #plot #point
 # ---
 from synth import FakeScatter
 from h2o_wave import site, data, ui

--- a/py/examples/plot_point_annotation.py
+++ b/py/examples/plot_point_annotation.py
@@ -1,6 +1,6 @@
 # Plot / Point / Annotation
 # Add annotations (points, lines and regions) to a #plot.
-# #annotation #point #line #region
+# #annotation
 # ---
 from synth import FakeScatter
 from h2o_wave import site, data, ui

--- a/py/examples/plot_point_annotation.py
+++ b/py/examples/plot_point_annotation.py
@@ -1,5 +1,6 @@
 # Plot / Point / Annotation
-# Add annotations (points, lines and regions) to a plot.
+# Add annotations (points, lines and regions) to a #plot.
+# #annotation #point #line #region
 # ---
 from synth import FakeScatter
 from h2o_wave import site, data, ui

--- a/py/examples/plot_point_custom.py
+++ b/py/examples/plot_point_custom.py
@@ -1,5 +1,6 @@
 # Plot / Point / Custom
-# Customize a plot's fill/stroke color, size and opacity.
+# Customize a plot's fill/stroke #color, #size and #opacity.
+# #custom #plot #fill #stroke #point
 # ---
 import random
 

--- a/py/examples/plot_point_custom.py
+++ b/py/examples/plot_point_custom.py
@@ -1,6 +1,6 @@
 # Plot / Point / Custom
-# Customize a plot's fill/stroke #color, #size and #opacity.
-# #custom #plot #fill #stroke #point
+# Customize a plot's fill/stroke color, size and opacity.
+# #plot
 # ---
 import random
 

--- a/py/examples/plot_point_groups.py
+++ b/py/examples/plot_point_groups.py
@@ -1,5 +1,6 @@
 # Plot / Point / Groups
-# Make a scatterplot with categories encoded as colors.
+# Make a #scatterplot with categories encoded as colors.
+# #plot #point #color #multiple_categories
 # ---
 from synth import FakeScatter
 from h2o_wave import site, data, ui

--- a/py/examples/plot_point_groups.py
+++ b/py/examples/plot_point_groups.py
@@ -1,6 +1,6 @@
 # Plot / Point / Groups
-# Make a #scatterplot with categories encoded as colors.
-# #plot #point #color #multiple_categories
+# Make a scatterplot with categories encoded as colors.
+# #plot
 # ---
 from synth import FakeScatter
 from h2o_wave import site, data, ui

--- a/py/examples/plot_point_map.py
+++ b/py/examples/plot_point_map.py
@@ -1,7 +1,7 @@
 # Plot / Point / Map
 # Make a #plot to compare quantities across categories. Similar to a heatmap,
 # but using size-encoding instead of color-encoding.
-# #point #map #size #multiple_categories
+# #map
 # ---
 from synth import FakeSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_point_map.py
+++ b/py/examples/plot_point_map.py
@@ -1,5 +1,7 @@
 # Plot / Point / Map
-# Make a plot to compare quantities across categories. Similar to a heatmap, but using size-encoding instead of color-encoding.
+# Make a #plot to compare quantities across categories. Similar to a heatmap,
+# but using size-encoding instead of color-encoding.
+# #point #map #size #multiple_categories
 # ---
 from synth import FakeSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_point_shapes.py
+++ b/py/examples/plot_point_shapes.py
@@ -1,6 +1,6 @@
 # Plot / Point / Shapes
-# Make a #scatterplot with categories encoded as mark shapes.
-# #shape #plot #multiple_categories
+# Make a scatterplot with categories encoded as mark shapes.
+# #plot
 # ---
 from synth import FakeScatter
 from h2o_wave import site, data, ui

--- a/py/examples/plot_point_shapes.py
+++ b/py/examples/plot_point_shapes.py
@@ -1,5 +1,6 @@
 # Plot / Point / Shapes
-# Make a scatterplot with categories encoded as mark shapes.
+# Make a #scatterplot with categories encoded as mark shapes.
+# #shape #plot #multiple_categories
 # ---
 from synth import FakeScatter
 from h2o_wave import site, data, ui

--- a/py/examples/plot_point_sizes.py
+++ b/py/examples/plot_point_sizes.py
@@ -1,6 +1,6 @@
 # Plot / Point / Sizes
-# Make a #scatterplot with mark sizes mapped to a continuous variable (a "bubble plot").
-# #bubble_plot #plot #size
+# Make a scatterplot with mark sizes mapped to a continuous variable (a "bubble plot").
+# #plot
 # ---
 import random
 

--- a/py/examples/plot_point_sizes.py
+++ b/py/examples/plot_point_sizes.py
@@ -1,5 +1,6 @@
 # Plot / Point / Sizes
-# Make a scatterplot with mark sizes mapped to a continuous variable (a "bubble plot").
+# Make a #scatterplot with mark sizes mapped to a continuous variable (a "bubble plot").
+# #bubble_plot #plot #size
 # ---
 import random
 

--- a/py/examples/plot_polygon.py
+++ b/py/examples/plot_polygon.py
@@ -1,5 +1,5 @@
 # Plot / Polygon
-# Make a #heatmap. #plot #polygon
+# Make a heatmap. #plot
 # ---
 from synth import FakeSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_polygon.py
+++ b/py/examples/plot_polygon.py
@@ -1,5 +1,5 @@
 # Plot / Polygon
-# Make a heatmap.
+# Make a #heatmap. #plot #polygon
 # ---
 from synth import FakeSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_step.py
+++ b/py/examples/plot_step.py
@@ -1,5 +1,5 @@
 # Plot / Line / Step
-# Make a #line #plot with a #step #curve.
+# Make a line #plot with a step curve.
 # ---
 from synth import FakeTimeSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_step.py
+++ b/py/examples/plot_step.py
@@ -1,5 +1,5 @@
 # Plot / Line / Step
-# Make a line plot with a step curve.
+# Make a #line #plot with a #step #curve.
 # ---
 from synth import FakeTimeSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_step_after.py
+++ b/py/examples/plot_step_after.py
@@ -1,5 +1,5 @@
 # Plot / Line / Step / After
-# Make a line plot with a step-after curve.
+# Make a #line #plot with a step-after #curve. #step_after
 # ---
 from synth import FakeTimeSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_step_after.py
+++ b/py/examples/plot_step_after.py
@@ -1,5 +1,5 @@
 # Plot / Line / Step / After
-# Make a #line #plot with a step-after #curve. #step_after
+# Make a line #plot with a step-after curve.
 # ---
 from synth import FakeTimeSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_step_before.py
+++ b/py/examples/plot_step_before.py
@@ -1,5 +1,5 @@
 # Plot / Line / Step / Before
-# Make a #line #plot with a step-before #curve. #step_before
+# Make a line #plot with a step-before curve.
 # ---
 from synth import FakeTimeSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_step_before.py
+++ b/py/examples/plot_step_before.py
@@ -1,5 +1,5 @@
 # Plot / Line / Step / Before
-# Make a line plot with a step-before curve.
+# Make a #line #plot with a step-before #curve. #step_before
 # ---
 from synth import FakeTimeSeries
 from h2o_wave import site, data, ui

--- a/py/examples/plot_vegalite.py
+++ b/py/examples/plot_vegalite.py
@@ -1,5 +1,5 @@
 # Plot / Vega-lite
-# Make a plot using Vega-lite.
+# Make a #plot using Vega-lite. #vega_lite
 # ---
 from h2o_wave import site, data, ui
 

--- a/py/examples/plot_vegalite.py
+++ b/py/examples/plot_vegalite.py
@@ -1,5 +1,5 @@
 # Plot / Vega-lite
-# Make a #plot using Vega-lite. #vega_lite
+# Make a #plot using Vega-lite. #vega
 # ---
 from h2o_wave import site, data, ui
 

--- a/py/examples/plot_vegalite_form.py
+++ b/py/examples/plot_vegalite_form.py
@@ -1,5 +1,5 @@
 # Plot / Vega-lite / Form
-# Display a Vega-lite plot inside a form card
+# Display a Vega-lite #plot inside a #form card. #vega_lite
 # ---
 from h2o_wave import site, data, ui
 import random
@@ -30,7 +30,8 @@ def poll():
 
 
 # Generate random datum between 1 and 100
-def rnd(): return random.randint(1, 100)
+def rnd():
+    return random.randint(1, 100)
 
 
 page['example'] = ui.form_card(

--- a/py/examples/plot_vegalite_form.py
+++ b/py/examples/plot_vegalite_form.py
@@ -1,5 +1,5 @@
 # Plot / Vega-lite / Form
-# Display a Vega-lite #plot inside a #form card. #vega_lite
+# Display a Vega-lite #plot inside a #form card. #vega
 # ---
 from h2o_wave import site, data, ui
 import random

--- a/py/examples/plot_vegalite_update.py
+++ b/py/examples/plot_vegalite_update.py
@@ -1,5 +1,5 @@
 # Plot / Vega-lite / Update
-# Periodically update a Vega-lite plot.
+# Periodically #update a Vega-lite #plot. #vega_lite #live
 # ---
 from h2o_wave import site, data, ui
 import random
@@ -20,7 +20,8 @@ spec = '''
 
 
 # Generate random datum between 1 and 100
-def rnd(): return random.randint(1, 100)
+def rnd():
+    return random.randint(1, 100)
 
 
 # Get data rows for our plot.

--- a/py/examples/plot_vegalite_update.py
+++ b/py/examples/plot_vegalite_update.py
@@ -1,5 +1,5 @@
 # Plot / Vega-lite / Update
-# Periodically #update a Vega-lite #plot. #vega_lite #live
+# Periodically update a Vega-lite #plot. #vega
 # ---
 from h2o_wave import site, data, ui
 import random

--- a/py/examples/progress.py
+++ b/py/examples/progress.py
@@ -1,5 +1,6 @@
 # Form / Progress
-# Use a progress bar to indicate completion status of an operation.
+# Use a #progress bar to indicate completion #status of an operation.
+# #form
 # ---
 from h2o_wave import site, ui
 

--- a/py/examples/progress.py
+++ b/py/examples/progress.py
@@ -1,5 +1,5 @@
 # Form / Progress
-# Use a #progress bar to indicate completion #status of an operation.
+# Use a #progress bar to indicate completion status of an operation.
 # #form
 # ---
 from h2o_wave import site, ui

--- a/py/examples/progress_update.py
+++ b/py/examples/progress_update.py
@@ -1,5 +1,6 @@
 # Form / Progress / Updating
-# Update a progress bar's completion status periodically.
+# #Update a #progress bar's completion #status periodically.
+# #form
 # ---
 import time
 

--- a/py/examples/progress_update.py
+++ b/py/examples/progress_update.py
@@ -1,5 +1,5 @@
 # Form / Progress / Updating
-# #Update a #progress bar's completion #status periodically.
+# Update a #progress bar's completion status periodically.
 # #form
 # ---
 import time

--- a/py/examples/range_slider.py
+++ b/py/examples/range_slider.py
@@ -1,5 +1,6 @@
 # Form / Range Slider
-# Use a range slider to allow users to select a value range (from, to).
+# Use a #range #slider to allow users to select a value range (from, to).
+# #form
 # ---
 from h2o_wave import main, app, Q, ui
 

--- a/py/examples/repeat.py
+++ b/py/examples/repeat.py
@@ -1,5 +1,5 @@
 # Repeat
-# Use a repeat card to render a card repeatedly.
+# Use a #repeat card to render a card repeatedly.
 # ---
 import random
 

--- a/py/examples/separator.py
+++ b/py/examples/separator.py
@@ -1,5 +1,6 @@
 # Form / Separator
-# Use a separator to visually separate content into groups.
+# Use a #separator to visually separate content into groups.
+# #form
 # ---
 from h2o_wave import site, ui
 

--- a/py/examples/site_async.py
+++ b/py/examples/site_async.py
@@ -1,6 +1,6 @@
 # Site / Async
-# #Update any page on a site from within an app using an `AsyncSite` instance.
-# #site #async
+# Update any page on a site from within an app using an `AsyncSite` instance.
+# #site
 # ---
 from .synth import FakePercent
 from h2o_wave import Q, app, main, ui, AsyncSite

--- a/py/examples/site_async.py
+++ b/py/examples/site_async.py
@@ -1,5 +1,6 @@
 # Site / Async
-# Update any page on a site from within an app using an `AsyncSite` instance.
+# #Update any page on a site from within an app using an `AsyncSite` instance.
+# #site #async
 # ---
 from .synth import FakePercent
 from h2o_wave import Q, app, main, ui, AsyncSite

--- a/py/examples/slider.py
+++ b/py/examples/slider.py
@@ -1,5 +1,6 @@
 # Form / Slider
-# Use a slider to allow users to set a value within a specific range.
+# Use a #slider to allow users to set a value within a specific range.
+# #form
 # ---
 from h2o_wave import main, app, Q, ui
 

--- a/py/examples/spinbox.py
+++ b/py/examples/spinbox.py
@@ -1,5 +1,6 @@
 # Form / Spinbox
-# Use a spinbox to allow users to incrementally adjust a value in small steps.
+# Use a #spinbox to allow users to incrementally adjust a value in small steps.
+# #form
 # ---
 from h2o_wave import main, app, Q, ui
 

--- a/py/examples/stat_large.py
+++ b/py/examples/stat_large.py
@@ -1,6 +1,6 @@
 # Stat / Large
 # Create a stat card displaying a primary value, an auxiliary value and a caption.
-# #stat_card #large
+# #stat_card
 # ---
 import time
 

--- a/py/examples/stat_large.py
+++ b/py/examples/stat_large.py
@@ -1,5 +1,6 @@
 # Stat / Large
 # Create a stat card displaying a primary value, an auxiliary value and a caption.
+# #stat_card #large
 # ---
 import time
 
@@ -13,7 +14,7 @@ page = site['/demo']
 fake = Faker()
 f = FakePercent()
 val, pc = f.next()
-c = page.add(f'example', ui.large_stat_card(
+c = page.add('example', ui.large_stat_card(
     box='1 1 2 2',
     title=fake.cryptocurrency_name(),
     value='=${{intl qux minimum_fraction_digits=2 maximum_fraction_digits=2}}',

--- a/py/examples/stat_large_bar.py
+++ b/py/examples/stat_large_bar.py
@@ -1,5 +1,7 @@
 # Stat / Bar / Large
-# Create a large captioned card displaying a primary value, an auxiliary value and a progress bar, with captions for each value.
+# Create a large captioned card displaying a primary value, an auxiliary value and a progress bar,
+# with captions for each value.
+# #stat_card #progress #large
 # ---
 import time
 
@@ -13,7 +15,7 @@ page = site['/demo']
 fake = Faker()
 f = FakePercent()
 val, pc = f.next()
-c = page.add(f'example', ui.large_bar_stat_card(
+c = page.add('example', ui.large_bar_stat_card(
     box='1 1 2 2',
     title=fake.cryptocurrency_name(),
     value='=${{intl foo minimum_fraction_digits=2 maximum_fraction_digits=2}}',

--- a/py/examples/stat_large_bar.py
+++ b/py/examples/stat_large_bar.py
@@ -1,7 +1,7 @@
 # Stat / Bar / Large
 # Create a large captioned card displaying a primary value, an auxiliary value and a progress bar,
 # with captions for each value.
-# #stat_card #progress #large
+# #stat_card #progress
 # ---
 import time
 

--- a/py/examples/stat_small.py
+++ b/py/examples/stat_small.py
@@ -1,5 +1,6 @@
 # Stat / Small
 # Create a stat card displaying a single value.
+# #stat_card #small
 # ---
 import time
 

--- a/py/examples/stat_small.py
+++ b/py/examples/stat_small.py
@@ -1,6 +1,6 @@
 # Stat / Small
 # Create a stat card displaying a single value.
-# #stat_card #small
+# #stat_card
 # ---
 import time
 

--- a/py/examples/stat_small_series_area.py
+++ b/py/examples/stat_small_series_area.py
@@ -1,6 +1,6 @@
 # Stat / Series / Small / Area
-# Create a #small stat card displaying a primary value and a series plot.
-# #stat_card #area #series
+# Create a small stat card displaying a primary value and a series plot.
+# #stat_card #series
 # ---
 import time
 

--- a/py/examples/stat_small_series_area.py
+++ b/py/examples/stat_small_series_area.py
@@ -1,5 +1,6 @@
 # Stat / Series / Small / Area
-# Create a small stat card displaying a primary value and a series plot.
+# Create a #small stat card displaying a primary value and a series plot.
+# #stat_card #area #series
 # ---
 import time
 

--- a/py/examples/stat_small_series_interval.py
+++ b/py/examples/stat_small_series_interval.py
@@ -1,5 +1,5 @@
 # Stat / Series / Small / Interval
-# Create a #small stat card displaying a primary value and a series plot.
+# Create a small stat card displaying a primary value and a series plot.
 # #stat_card #interval #series
 # ---
 import time

--- a/py/examples/stat_small_series_interval.py
+++ b/py/examples/stat_small_series_interval.py
@@ -1,5 +1,6 @@
 # Stat / Series / Small / Interval
-# Create a small stat card displaying a primary value and a series plot.
+# Create a #small stat card displaying a primary value and a series plot.
+# #stat_card #interval #series
 # ---
 import time
 
@@ -13,7 +14,7 @@ page = site['/demo']
 fake = Faker()
 f = FakeCategoricalSeries()
 cat, val, pc = f.next()
-c = page.add(f'example', ui.small_series_stat_card(
+c = page.add('example', ui.small_series_stat_card(
     box='1 1 1 1',
     title=fake.cryptocurrency_name(),
     value='=${{intl qux minimum_fraction_digits=2 maximum_fraction_digits=2}}',

--- a/py/examples/stat_tall_gauge.py
+++ b/py/examples/stat_tall_gauge.py
@@ -1,5 +1,5 @@
 # Stat / Gauge / Tall
-# Create a #tall stat card displaying a primary value, an auxiliary value and a #progress #gauge.
+# Create a tall stat card displaying a primary value, an auxiliary value and a #progress gauge.
 # #stat_card
 # ---
 import time

--- a/py/examples/stat_tall_gauge.py
+++ b/py/examples/stat_tall_gauge.py
@@ -1,5 +1,6 @@
 # Stat / Gauge / Tall
-# Create a tall stat card displaying a primary value, an auxiliary value and a progress gauge.
+# Create a #tall stat card displaying a primary value, an auxiliary value and a #progress #gauge.
+# #stat_card
 # ---
 import time
 
@@ -13,7 +14,7 @@ page = site['/demo']
 fake = Faker()
 f = FakePercent()
 val, pc = f.next()
-c = page.add(f'example', ui.tall_gauge_stat_card(
+c = page.add('example', ui.tall_gauge_stat_card(
     box='1 1 1 2',
     title=fake.cryptocurrency_name(),
     value='=${{intl foo minimum_fraction_digits=2 maximum_fraction_digits=2}}',

--- a/py/examples/stat_tall_series_area.py
+++ b/py/examples/stat_tall_series_area.py
@@ -1,6 +1,6 @@
 # Stat / Series / Tall / Area
-# Create a #tall stat card displaying a primary value, an auxiliary value and a #series plot.
-# #stat_card #area
+# Create a tall stat card displaying a primary value, an auxiliary value and a #series plot.
+# #stat_card
 # ---
 import time
 

--- a/py/examples/stat_tall_series_area.py
+++ b/py/examples/stat_tall_series_area.py
@@ -1,5 +1,6 @@
 # Stat / Series / Tall / Area
-# Create a tall stat card displaying a primary value, an auxiliary value and a series plot.
+# Create a #tall stat card displaying a primary value, an auxiliary value and a #series plot.
+# #stat_card #area
 # ---
 import time
 

--- a/py/examples/stat_tall_series_interval.py
+++ b/py/examples/stat_tall_series_interval.py
@@ -1,5 +1,5 @@
 # Stat / Series / Tall / Interval
-# Create a #tall stat card displaying a primary value, an auxiliary value and a #series plot.
+# Create a tall stat card displaying a primary value, an auxiliary value and a #series plot.
 # #stat_card #interval
 # ---
 import time

--- a/py/examples/stat_tall_series_interval.py
+++ b/py/examples/stat_tall_series_interval.py
@@ -1,5 +1,6 @@
 # Stat / Series / Tall / Interval
-# Create a tall stat card displaying a primary value, an auxiliary value and a series plot.
+# Create a #tall stat card displaying a primary value, an auxiliary value and a #series plot.
+# #stat_card #interval
 # ---
 import time
 
@@ -13,7 +14,7 @@ page = site['/demo']
 fake = Faker()
 f = FakeCategoricalSeries()
 cat, val, pc = f.next()
-c = page.add(f'example', ui.tall_series_stat_card(
+c = page.add('example', ui.tall_series_stat_card(
     box='1 1 1 2',
     title=fake.cryptocurrency_name(),
     value='=${{intl qux minimum_fraction_digits=2 maximum_fraction_digits=2}}',

--- a/py/examples/stat_wide_bar.py
+++ b/py/examples/stat_wide_bar.py
@@ -1,5 +1,5 @@
 # Stat / Bar / Wide
-# Create a #wide stat card displaying a primary value, an auxiliary value and a #progress bar.
+# Create a wide stat card displaying a primary value, an auxiliary value and a #progress bar.
 # #stat_card
 # ---
 import time

--- a/py/examples/stat_wide_bar.py
+++ b/py/examples/stat_wide_bar.py
@@ -1,5 +1,6 @@
 # Stat / Bar / Wide
-# Create a wide stat card displaying a primary value, an auxiliary value and a progress bar.
+# Create a #wide stat card displaying a primary value, an auxiliary value and a #progress bar.
+# #stat_card
 # ---
 import time
 
@@ -13,7 +14,7 @@ page = site['/demo']
 fake = Faker()
 f = FakePercent()
 val, pc = f.next()
-c = page.add(f'example', ui.wide_bar_stat_card(
+c = page.add('example', ui.wide_bar_stat_card(
     box='1 1 2 1',
     title=fake.cryptocurrency_name(),
     value='=${{intl foo minimum_fraction_digits=2 maximum_fraction_digits=2}}',

--- a/py/examples/stat_wide_gauge.py
+++ b/py/examples/stat_wide_gauge.py
@@ -1,5 +1,6 @@
 # Stat / Gauge / Wide
-# Create a wide stat card displaying a primary value, an auxiliary value and a progress gauge.
+# Create a #wide stat card displaying a primary value, an auxiliary value and a #progress #gauge.
+# #stat_card
 # ---
 import time
 
@@ -13,7 +14,7 @@ page = site['/demo']
 fake = Faker()
 f = FakePercent()
 val, pc = f.next()
-c = page.add(f'example', ui.wide_gauge_stat_card(
+c = page.add('example', ui.wide_gauge_stat_card(
     box='1 1 2 1',
     title=fake.cryptocurrency_name(),
     value='=${{intl foo minimum_fraction_digits=2 maximum_fraction_digits=2}}',

--- a/py/examples/stat_wide_gauge.py
+++ b/py/examples/stat_wide_gauge.py
@@ -1,5 +1,5 @@
 # Stat / Gauge / Wide
-# Create a #wide stat card displaying a primary value, an auxiliary value and a #progress #gauge.
+# Create a wide stat card displaying a primary value, an auxiliary value and a #progress gauge.
 # #stat_card
 # ---
 import time

--- a/py/examples/stat_wide_series_area.py
+++ b/py/examples/stat_wide_series_area.py
@@ -1,6 +1,6 @@
 # Stat / Series / Wide / Area
-# Create a #wide stat card displaying a primary value, an auxiliary value and a #series plot.
-# #stat_card #area
+# Create a wide stat card displaying a primary value, an auxiliary value and a #series plot.
+# #stat_card
 # ---
 import time
 

--- a/py/examples/stat_wide_series_area.py
+++ b/py/examples/stat_wide_series_area.py
@@ -1,5 +1,6 @@
 # Stat / Series / Wide / Area
-# Create a wide stat card displaying a primary value, an auxiliary value and a series plot.
+# Create a #wide stat card displaying a primary value, an auxiliary value and a #series plot.
+# #stat_card #area
 # ---
 import time
 

--- a/py/examples/stat_wide_series_interval.py
+++ b/py/examples/stat_wide_series_interval.py
@@ -1,5 +1,5 @@
 # Stat / Series / Wide / Interval
-# Create a #wide stat card displaying a primary value, an auxiliary value and a #series plot.
+# Create a wide stat card displaying a primary value, an auxiliary value and a #series plot.
 # #stat_card #interval
 # ---
 import time

--- a/py/examples/stat_wide_series_interval.py
+++ b/py/examples/stat_wide_series_interval.py
@@ -1,5 +1,6 @@
 # Stat / Series / Wide / Interval
-# Create a wide stat card displaying a primary value, an auxiliary value and a series plot.
+# Create a #wide stat card displaying a primary value, an auxiliary value and a #series plot.
+# #stat_card #interval
 # ---
 import time
 
@@ -13,7 +14,7 @@ page = site['/demo']
 fake = Faker()
 f = FakeCategoricalSeries()
 cat, val, pc = f.next()
-c = page.add(f'example', ui.wide_series_stat_card(
+c = page.add('example', ui.wide_series_stat_card(
     box='1 1 2 1',
     title=fake.cryptocurrency_name(),
     value='=${{intl qux minimum_fraction_digits=2 maximum_fraction_digits=2}}',

--- a/py/examples/stepper.py
+++ b/py/examples/stepper.py
@@ -1,5 +1,6 @@
 # Form / Stepper
-# Use Stepper to show progress through numbered steps.
+# Use #Stepper to show #progress through numbered steps.
+# #form
 # ---
 from h2o_wave import main, app, Q, ui
 

--- a/py/examples/swatch_picker.py
+++ b/py/examples/swatch_picker.py
@@ -1,5 +1,6 @@
 # Form / Swatch Picker
 # Use a swatch picker to allow users to choose a from a specific set of colors.
+# #swatch_picker #form
 # ---
 from h2o_wave import main, app, Q, ui
 

--- a/py/examples/tab.py
+++ b/py/examples/tab.py
@@ -1,5 +1,5 @@
 # Tab
-# Use tab cards to display tabs on a page.
+# Use tab cards to display #tabs on a page.
 # ---
 from h2o_wave import main, app, Q, ui
 

--- a/py/examples/tab_delete.py
+++ b/py/examples/tab_delete.py
@@ -1,6 +1,7 @@
 # Tabs / Navigation
 # Navigate between two or more tabs.
 # Delete the cards when switching between tabs.
+# #tabs #navigation
 # ---
 from h2o_wave import main, app, Q, ui
 

--- a/py/examples/tab_link.py
+++ b/py/examples/tab_link.py
@@ -1,6 +1,7 @@
 # Tab / Links
-# Use tab cards to display tabs on a page.
+# Use tab cards to display #tabs on a page.
 # This examples render tabs styled as links.
+# #link
 # ---
 from h2o_wave import main, app, Q, ui
 

--- a/py/examples/tab_routing.py
+++ b/py/examples/tab_routing.py
@@ -1,6 +1,6 @@
 # Routing / Tabs
 # This example demonstrates how you can observe and handle changes to the browser's
-# [location hash](https://developer.mozilla.org/en-US/docs/Web/API/Location/hash)
+# [location hash](https://developer.mozilla.org/en-US/docs/Web/API/Location/hash).
 #
 # The location hash can be accessed using `q.args['#']`.
 # #routing #tabs

--- a/py/examples/tab_routing.py
+++ b/py/examples/tab_routing.py
@@ -3,7 +3,7 @@
 # [location hash](https://developer.mozilla.org/en-US/docs/Web/API/Location/hash)
 #
 # The location hash can be accessed using `q.args['#']`.
-# routing, tabs
+# #routing #tabs
 # ---
 from h2o_wave import main, app, Q, ui
 

--- a/py/examples/tab_routing.py
+++ b/py/examples/tab_routing.py
@@ -3,7 +3,7 @@
 # [location hash](https://developer.mozilla.org/en-US/docs/Web/API/Location/hash)
 #
 # The location hash can be accessed using `q.args['#']`.
-#
+# routing, tabs
 # ---
 from h2o_wave import main, app, Q, ui
 

--- a/py/examples/table.py
+++ b/py/examples/table.py
@@ -5,7 +5,7 @@ import random
 
 from faker import Faker
 
-from h2o_wave import app, Q, ui
+from h2o_wave import main, app, Q, ui
 
 fake = Faker()
 

--- a/py/examples/table.py
+++ b/py/examples/table.py
@@ -1,9 +1,11 @@
 # Table
-# Use a table to display tabular data.
+# Use a #table to display tabular data.
 # ---
 import random
+
 from faker import Faker
-from h2o_wave import main, app, Q, ui
+
+from h2o_wave import app, Q, ui
 
 fake = Faker()
 
@@ -56,8 +58,8 @@ async def serve(q: Q):
             rows=[ui.table_row(
                 name=issue.id,
                 cells=[issue.text, issue.status, issue.notifications, issue.icon,
-                  str(issue.views), issue.progress, issue.created]
-                ) for issue in issues],
+                       str(issue.views), issue.progress, issue.created]
+            ) for issue in issues],
             groupable=True,
             downloadable=True,
             resettable=True,

--- a/py/examples/table_download.py
+++ b/py/examples/table_download.py
@@ -1,5 +1,6 @@
 # Table / Download
 # Allow downloading a table's data as CSV file.
+# #table #download
 # ---
 import random
 from faker import Faker

--- a/py/examples/table_filter.py
+++ b/py/examples/table_filter.py
@@ -1,5 +1,6 @@
 # Table / Filter
 # Enable filtering values for specific columns.
+# #table #filter
 # ---
 import random
 from faker import Faker

--- a/py/examples/table_filter.py
+++ b/py/examples/table_filter.py
@@ -1,6 +1,6 @@
 # Table / Filter
 # Enable filtering values for specific columns.
-# #table #filter
+# #table
 # ---
 import random
 from faker import Faker

--- a/py/examples/table_filter_backend.py
+++ b/py/examples/table_filter_backend.py
@@ -1,5 +1,6 @@
 # Table / Filter / Backend
 # Filter table using Python
+# #table #filter #backend
 # ---
 import pandas as pd
 from faker import Faker

--- a/py/examples/table_filter_backend.py
+++ b/py/examples/table_filter_backend.py
@@ -1,6 +1,6 @@
 # Table / Filter / Backend
-# Filter table using Python
-# #table #filter #backend
+# Filter table using Python.
+# #table
 # ---
 import pandas as pd
 from faker import Faker

--- a/py/examples/table_groupby.py
+++ b/py/examples/table_groupby.py
@@ -1,5 +1,6 @@
 # Table / Group by
 # Allow grouping a table by column values.
+# #table #group_by
 # ---
 import random
 from faker import Faker

--- a/py/examples/table_groupby.py
+++ b/py/examples/table_groupby.py
@@ -1,6 +1,6 @@
 # Table / Group by
 # Allow grouping a table by column values.
-# #table #group_by
+# #table
 # ---
 import random
 from faker import Faker

--- a/py/examples/table_markdown.py
+++ b/py/examples/table_markdown.py
@@ -1,5 +1,5 @@
 # Table / Markdown
-# Display a table using markdown.
+# Display a #table using #markdown.
 # ---
 from h2o_wave import site, ui
 

--- a/py/examples/table_markdown_pandas.py
+++ b/py/examples/table_markdown_pandas.py
@@ -1,5 +1,5 @@
 # Table / Markdown / Pandas
-# Display a pandas dataframe as a markdown table.
+# Display a #pandas #dataframe as a #markdown #table.
 # ---
 from h2o_wave import site, ui
 import pandas as pd

--- a/py/examples/table_search.py
+++ b/py/examples/table_search.py
@@ -1,5 +1,5 @@
 # Table / Search
-# Enable searching a table across specific columns.
+# Enable searching a #table across specific columns. #search
 # ---
 import random
 from faker import Faker

--- a/py/examples/table_select.py
+++ b/py/examples/table_select.py
@@ -1,5 +1,5 @@
 # Table / Preselection
-# Use a #table as an advanced multi-select. Specify row names in 'values' for #preselection.
+# Use a #table as an advanced multi-select. Specify row names in 'values' for #selection.
 # ---
 from faker import Faker
 from h2o_wave import main, app, Q, ui

--- a/py/examples/table_select.py
+++ b/py/examples/table_select.py
@@ -1,5 +1,5 @@
 # Table / Preselection
-# Use a table as an advanced multi-select. Specify rownames in 'values' for preselection.
+# Use a #table as an advanced multi-select. Specify row names in 'values' for #preselection.
 # ---
 from faker import Faker
 from h2o_wave import main, app, Q, ui

--- a/py/examples/table_sort.py
+++ b/py/examples/table_sort.py
@@ -1,6 +1,5 @@
 # Table / Sort
 # Allow sorting a #table by specific columns.
-# #sort
 # ---
 import random
 from faker import Faker

--- a/py/examples/table_sort.py
+++ b/py/examples/table_sort.py
@@ -1,5 +1,6 @@
 # Table / Sort
-# Allow sorting a table by specific columns.
+# Allow sorting a #table by specific columns.
+# #sort
 # ---
 import random
 from faker import Faker

--- a/py/examples/tabs.py
+++ b/py/examples/tabs.py
@@ -1,5 +1,6 @@
 # Form / Tabs
-# Use tabs within a form to navigate between two or more distinct content categories.
+# Use #tabs within a #form to navigate between two or more distinct content categories.
+# #navigation
 # ---
 from h2o_wave import main, app, Q, ui
 

--- a/py/examples/template.py
+++ b/py/examples/template.py
@@ -1,5 +1,5 @@
 # Template
-# Use a #template card to render #dynamic content using a #HTML template.
+# Use a #template card to render dynamic content using a #HTML template.
 # ---
 from h2o_wave import site, pack, ui
 

--- a/py/examples/template.py
+++ b/py/examples/template.py
@@ -1,5 +1,5 @@
 # Template
-# Use a template card to render dynamic content using a HTML template.
+# Use a #template card to render #dynamic content using a #HTML template.
 # ---
 from h2o_wave import site, pack, ui
 
@@ -15,7 +15,7 @@ menu = '''
 '''
 
 c = page.add('template_example', ui.template_card(
-    box=f'1 1 2 2',
+    box='1 1 2 2',
     title='Menu',
     content=menu,
     data=pack(dict(dishes=[

--- a/py/examples/template_data.py
+++ b/py/examples/template_data.py
@@ -1,6 +1,5 @@
 # Template / Data
-# #Update a #template card's #data periodically.
-# #live
+# Update a #template card's data periodically.
 # ---
 import time
 import random

--- a/py/examples/template_data.py
+++ b/py/examples/template_data.py
@@ -1,5 +1,6 @@
 # Template / Data
-# Update a template card's data periodically.
+# #Update a #template card's #data periodically.
+# #live
 # ---
 import time
 import random
@@ -17,7 +18,7 @@ menu = '''
 '''
 
 menu_card = page.add('template_example', ui.template_card(
-    box=f'1 1 2 2',
+    box='1 1 2 2',
     title='Surge-priced Menu',
     content=menu,
     data=dict(dishes=[
@@ -29,7 +30,8 @@ menu_card = page.add('template_example', ui.template_card(
 page.save()
 
 
-def rand_price(): return f'${random.randrange(0, 4)}.{random.randrange(10, 99)}'
+def rand_price():
+    return f'${random.randrange(0, 4)}.{random.randrange(10, 99)}'
 
 
 dishes = menu_card.data.dishes

--- a/py/examples/text.py
+++ b/py/examples/text.py
@@ -1,5 +1,5 @@
 # Form / Text
-# Use markdown in a text component to display formatted content within a form.
+# Use #markdown in a #text component to display formatted content within a #form.
 # ---
 from h2o_wave import site, ui
 

--- a/py/examples/text_sizes.py
+++ b/py/examples/text_sizes.py
@@ -1,6 +1,6 @@
 # Form / Text / Sizes
-# Use #text #size variants to display formatted text using predefined font sizes.
-# #form #font_size
+# Use #text size variants to display formatted text using predefined font sizes.
+# #form
 # ---
 from h2o_wave import site, ui
 

--- a/py/examples/text_sizes.py
+++ b/py/examples/text_sizes.py
@@ -1,5 +1,6 @@
 # Form / Text / Sizes
-# Use text size variants to display formatted text using predefined font sizes.
+# Use #text #size variants to display formatted text using predefined font sizes.
+# #form #font_size
 # ---
 from h2o_wave import site, ui
 

--- a/py/examples/textbox.py
+++ b/py/examples/textbox.py
@@ -1,5 +1,6 @@
 # Form / Textbox
-# Use a textbox to allow users to provide text inputs.
+# Use a #textbox to allow users to provide text inputs.
+# #form
 # ---
 from h2o_wave import main, app, Q, ui
 

--- a/py/examples/textbox_trigger.py
+++ b/py/examples/textbox_trigger.py
@@ -1,5 +1,6 @@
 # Form / Textbox / Trigger
-# To handle live changes to a textbox, enable the `trigger` attribute.
+# To handle #live changes to a #textbox, enable the `trigger` attribute.
+# #form #trigger
 # ---
 from h2o_wave import main, app, Q, ui
 

--- a/py/examples/textbox_trigger.py
+++ b/py/examples/textbox_trigger.py
@@ -1,5 +1,5 @@
 # Form / Textbox / Trigger
-# To handle #live changes to a #textbox, enable the `trigger` attribute.
+# To handle live changes to a #textbox, enable the `trigger` attribute.
 # #form #trigger
 # ---
 from h2o_wave import main, app, Q, ui

--- a/py/examples/todo.py
+++ b/py/examples/todo.py
@@ -1,6 +1,5 @@
 # To-do List App
-# A #simple multi-user To-do list #application.
-# #multi_user
+# A simple multi-user To-do list application.
 # ---
 from h2o_wave import main, app, Q, ui
 from typing import List

--- a/py/examples/todo.py
+++ b/py/examples/todo.py
@@ -1,5 +1,6 @@
 # To-do List App
-# A simple multi-user To-do list application.
+# A #simple multi-user To-do list #application.
+# #multi_user
 # ---
 from h2o_wave import main, app, Q, ui
 from typing import List

--- a/py/examples/toggle.py
+++ b/py/examples/toggle.py
@@ -1,5 +1,6 @@
 # Form / Toggle
-# Use a toggle to present users with two mutually exclusive options (to turn settings on and off).
+# Use a #toggle to present users with two mutually exclusive options (to turn settings on and off).
+# #form
 # ---
 from h2o_wave import main, app, Q, ui
 

--- a/py/examples/toolbar.py
+++ b/py/examples/toolbar.py
@@ -1,5 +1,6 @@
 # Toolbar
 # Use toolbars to provide commands that operate on the content of a page.
+# #toolbar #command
 # ---
 from h2o_wave import main, app, Q, ui
 

--- a/py/examples/toolbar_routing.py
+++ b/py/examples/toolbar_routing.py
@@ -3,7 +3,7 @@
 # [location hash](https://developer.mozilla.org/en-US/docs/Web/API/Location/hash)
 #
 # The location hash can be accessed using `q.args['#']`.
-#
+# routing, toolbar
 # ---
 from h2o_wave import main, app, Q, ui
 

--- a/py/examples/toolbar_routing.py
+++ b/py/examples/toolbar_routing.py
@@ -3,7 +3,7 @@
 # [location hash](https://developer.mozilla.org/en-US/docs/Web/API/Location/hash)
 #
 # The location hash can be accessed using `q.args['#']`.
-# routing, toolbar
+# #routing #toolbar
 # ---
 from h2o_wave import main, app, Q, ui
 

--- a/py/examples/toolbar_routing.py
+++ b/py/examples/toolbar_routing.py
@@ -1,6 +1,6 @@
 # Routing / Toolbar
 # This example demonstrates how you can observe and handle changes to the browser's
-# [location hash](https://developer.mozilla.org/en-US/docs/Web/API/Location/hash)
+# [location hash](https://developer.mozilla.org/en-US/docs/Web/API/Location/hash).
 #
 # The location hash can be accessed using `q.args['#']`.
 # #routing #toolbar

--- a/py/examples/upload.py
+++ b/py/examples/upload.py
@@ -1,5 +1,5 @@
 # Uploads
-# Upload files to the Wave server.
+# #Upload files to the Wave server.
 # ---
 import os
 from h2o_wave import site, ui

--- a/py/examples/upload_async.py
+++ b/py/examples/upload_async.py
@@ -1,6 +1,6 @@
 # Uploads / Async
 # Upload files from an interactive app.
-# #upload #async
+# #upload
 # ---
 
 

--- a/py/examples/upload_async.py
+++ b/py/examples/upload_async.py
@@ -1,5 +1,6 @@
 # Uploads / Async
 # Upload files from an interactive app.
+# #upload #async
 # ---
 
 

--- a/py/examples/upload_download.py
+++ b/py/examples/upload_download.py
@@ -1,5 +1,6 @@
 # Uploads / Download
 # Accept files from the user and downloads them locally.
+# #upload #download
 # ---
 
 

--- a/py/examples/upload_frame.py
+++ b/py/examples/upload_frame.py
@@ -1,5 +1,5 @@
 # Uploads / Frame
-# To display content > 2MB in frame cards, first upload the content and then use it in a frame card.
+# To display content > 2MB in #frame cards, first #upload the content and then use it in a frame card.
 # ---
 import os
 import uuid

--- a/py/examples/upload_ui.py
+++ b/py/examples/upload_ui.py
@@ -1,5 +1,6 @@
 # Uploads / UI
 # Accept files from the user.
+# #upload #form
 # ---
 
 

--- a/py/examples/wizard.py
+++ b/py/examples/wizard.py
@@ -1,5 +1,5 @@
 # Wizard
-# Create a multi-step wizard using form cards.
+# Create a multi-step #wizard using #form cards.
 # ---
 from h2o_wave import Q, ui, main, app, cypress, Cypress
 

--- a/py/sync_examples.py
+++ b/py/sync_examples.py
@@ -131,13 +131,13 @@ def parse_tags(description: str) -> Tuple[str, List[str]]:
     """
     hashtag_regex_pattern = r"(\s+)#(\w*[a-zA-Z]+\w*)\b"
     pattern = re.compile(hashtag_regex_pattern)
-    matches = pattern.findall(description)
+    matches = pattern.findall(' ' + description)
 
     # Retrieve tags from the matches
     tags = sorted(list(set([x[-1].lower() for x in matches])))
 
     # Remove the '#' before the tags in description
-    new_d = pattern.sub(r'\1\2', description)
+    new_d = pattern.sub(r'\1\2', ' ' + description)
 
     # Remove the last line in description if it has only tags
     *lines, last_line = new_d.strip().splitlines()

--- a/py/sync_examples.py
+++ b/py/sync_examples.py
@@ -113,11 +113,13 @@ def load_example(filename: str) -> Example:
 
 def make_toc(examples: List[Example]):
     return '''---
-title: Contents
-slug: /examples
+title: All Examples
+slug: /examples/all
 ---
 
-''' + '\n'.join([f'- [{e.title}](examples/{e.slug}): {e.subtitle}' for e in examples])
+import useBaseUrl from '@docusaurus/useBaseUrl';
+
+''' + '\n\n'.join([f"- <a href={{useBaseUrl('docs/examples/{e.slug}')}}>{e.title}</a>: {e.subtitle}" for e in examples])
 
 
 def make_gallery_thumbnail(e: Example):
@@ -175,11 +177,12 @@ def main():
             print(f'*** ALERT: no thumbnail found for example "{e.slug}"')
 
     example_items = [dict(slug=e.slug) for e in examples]
-    example_items.insert(0, dict(slug='examples-tags'))
     example_items.insert(0, dict(slug='index'))
+    example_items.insert(1, dict(slug='all'))
+    example_items.insert(2, dict(slug='examples-tags'))
     write_file(os.path.join(website_dir, 'examples.js'), f'module.exports={json.dumps(example_items)}')
-    # write_file(os.path.join(example_md_dir, 'index.md'), make_toc(examples))
     write_file(os.path.join(example_md_dir, 'index.md'), make_gallery(examples))
+    write_file(os.path.join(example_md_dir, 'all.md'), make_toc(examples))
     write_file(os.path.join(example_md_dir, 'examples-tags.md'), make_examples_by_keyword(examples))
 
 

--- a/py/sync_examples.py
+++ b/py/sync_examples.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os.path
 import json
+import os.path
+from collections import defaultdict
 from typing import List
 
 example_dir = os.path.realpath(os.path.join(os.path.dirname(__file__), 'examples'))
@@ -21,19 +22,45 @@ website_dir = os.path.realpath(os.path.join(os.path.dirname(__file__), os.pardir
 
 
 class Example:
-    def __init__(self, filename: str, title: str, description: str, code: str):
+    def __init__(self, filename: str, title: str, description: str, keywords: List[str], code: str):
         self.name = os.path.splitext(filename)[0]
         self.slug = self.name.replace('_', '-')
         self.filename = filename
         self.title = title
         self.subtitle = description.split('\n')[0].strip()
         self.description = description
+        self.keywords = keywords
         self.code = code
 
     def to_md(self):
-        return f"""---
+        if self.keywords:
+            keywords = '\n'.join(['  - ' + x for x in self.keywords])
+            keyword_tags = []
+            for k in self.keywords:
+                keyword_tags.append(f"<a href={{useBaseUrl('docs/examples/examples-tags#{k}')}}>{k}</a>")
+            keywords_links = '  '.join(keyword_tags)
+            header = f"""---
+title: {self.title}
+keywords:
+{keywords}
+---
+
+import useBaseUrl from '@docusaurus/useBaseUrl';
+
+        """
+            footer = f"""
+
+**Tags**:  {keywords_links}
+
+            """
+        else:
+            header = f"""---
 title: {self.title}
 ---
+        """
+            footer = ""
+
+        body = f"""
 
 {self.description}
 
@@ -43,6 +70,7 @@ title: {self.title}
 {self.code}
 ```
         """
+        return header + body + footer
 
 
 def read_lines(p: str) -> List[str]:
@@ -65,12 +93,22 @@ def strip_comment(line: str) -> str:
     return line.strip(" #")
 
 
+def get_keywords_if_available(line: str) -> List[str]:
+    keywords = [x.strip() for x in line.split(',')]
+    period_in_line = '.' in line
+    spaces_in_keywords = any([' ' in x for x in keywords])
+    if period_in_line or spaces_in_keywords:
+        return []
+    return keywords
+
+
 def load_example(filename: str) -> Example:
     contents = read_file(os.path.join(example_dir, filename))
     parts = contents.split('---', maxsplit=1)
     header, code = parts[0].strip().splitlines(), parts[1].strip()
     title, description = strip_comment(header[0]), [strip_comment(x) for x in header[1:]]
-    return Example(filename, title, '\n'.join(description), code)
+    keywords = get_keywords_if_available(description[-2])
+    return Example(filename, title, '\n'.join(description), keywords, code)
 
 
 def make_toc(examples: List[Example]):
@@ -96,6 +134,32 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 ''' + '\n' + '\n\n'.join([make_gallery_thumbnail(e) for e in examples])
 
 
+def make_keyword_group(keyword: str, examples: List[Example]) -> str:
+    sub_heading = f"### {keyword}\n"
+    example_links = []
+    for e in examples:
+        example_links.append(f"<a href={{useBaseUrl('docs/examples/{e.slug}')}}>{e.title}</a>")
+    return sub_heading + '  '.join(example_links) + '\n'
+
+
+def index_examples(examples: List[Example]):
+    keywords_dict = defaultdict(list)
+    for e in examples:
+        for k in e.keywords:
+            keywords_dict[k].append(e)
+    return sorted(keywords_dict.items())
+
+
+def make_examples_by_keyword(examples: List[Example]):
+    keywords = index_examples(examples)
+    return '''---
+title: Tags
+---
+
+import useBaseUrl from '@docusaurus/useBaseUrl';
+''' + '\n' + '\n\n'.join([make_keyword_group(k, e) for k, e in keywords])
+
+
 def main():
     filenames = [line.strip() for line in read_lines(os.path.join(example_dir, 'tour.conf')) if
                  not line.strip().startswith('#')]
@@ -111,10 +175,12 @@ def main():
             print(f'*** ALERT: no thumbnail found for example "{e.slug}"')
 
     example_items = [dict(slug=e.slug) for e in examples]
+    example_items.insert(0, dict(slug='examples-tags'))
     example_items.insert(0, dict(slug='index'))
     write_file(os.path.join(website_dir, 'examples.js'), f'module.exports={json.dumps(example_items)}')
     # write_file(os.path.join(example_md_dir, 'index.md'), make_toc(examples))
     write_file(os.path.join(example_md_dir, 'index.md'), make_gallery(examples))
+    write_file(os.path.join(example_md_dir, 'examples-tags.md'), make_examples_by_keyword(examples))
 
 
 if __name__ == '__main__':

--- a/py/sync_examples.py
+++ b/py/sync_examples.py
@@ -14,35 +14,36 @@
 
 import json
 import os.path
+import re
 from collections import defaultdict
-from typing import List
+from typing import List, Tuple
 
 example_dir = os.path.realpath(os.path.join(os.path.dirname(__file__), 'examples'))
 website_dir = os.path.realpath(os.path.join(os.path.dirname(__file__), os.pardir, 'website'))
 
 
 class Example:
-    def __init__(self, filename: str, title: str, description: str, keywords: List[str], code: str):
+    def __init__(self, filename: str, title: str, description: str, tags: List[str], code: str):
         self.name = os.path.splitext(filename)[0]
         self.slug = self.name.replace('_', '-')
         self.filename = filename
         self.title = title
         self.subtitle = description.split('\n')[0].strip()
         self.description = description
-        self.keywords = keywords
+        self.tags = tags
         self.code = code
 
     def to_md(self):
-        if self.keywords:
-            keywords = '\n'.join(['  - ' + x for x in self.keywords])
-            keyword_tags = []
-            for k in self.keywords:
-                keyword_tags.append(f"<a href={{useBaseUrl('docs/examples/examples-tags#{k}')}}>{k}</a>")
-            keywords_links = '  '.join(keyword_tags)
+        if self.tags:
+            tags_meta = '\n'.join(['  - ' + x for x in self.tags])
+            links = []
+            for t in self.tags:
+                links.append(f"<a href={{useBaseUrl('docs/examples/tags#{t}')}}>{t}</a>")
+            tags_links = '  '.join(links)
             header = f"""---
 title: {self.title}
 keywords:
-{keywords}
+{tags_meta}
 ---
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
@@ -50,7 +51,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
         """
             footer = f"""
 
-**Tags**:  {keywords_links}
+**Tags**:  {tags_links}
 
             """
         else:
@@ -90,16 +91,73 @@ def write_file(p: str, txt: str) -> str:
 
 
 def strip_comment(line: str) -> str:
-    return line.strip(" #")
+    """Returns the content of a line without '#' and ' ' characters
+
+    remove leading '#', but preserve '#' that is part of a tag
+    example:
+    >>> '# #hello '.strip('#').strip()
+    '#hello'
+    """
+    return line.strip('#').strip()
 
 
-def get_keywords_if_available(line: str) -> List[str]:
-    keywords = [x.strip() for x in line.split(',')]
-    period_in_line = '.' in line
-    spaces_in_keywords = any([' ' in x for x in keywords])
-    if period_in_line or spaces_in_keywords:
-        return []
-    return keywords
+def parse_tags(description: str) -> Tuple[str, List[str]]:
+    """Creates tags from description.
+
+    Accepts a description containing tags and returns a (new_description, tags) tuple.
+
+    The convention for tags:
+    1. Any valid twitter hashtag
+
+    For example, accept a description in any of the following forms
+
+    1. Use a checklist to group a set of related checkboxes. #form #checkbox #checklist
+
+    2. Use a checklist to group a set of related checkboxes.
+       #form #checkbox #checklist
+
+    3. Use a #checklist to group a set of related checkboxes.
+       #form #checkbox
+
+    and return
+    ('Use a checklist to group a set of related checkboxes.', ['checkbox', 'checklist', 'form']). The list of tags will
+    be sorted and all tags will be converted to lowercase.
+
+    Args:
+        description: Complete description of an example.
+    Returns:
+        A tuple of new_description and a sorted list of tags. new_description is created by removing the '#' characters
+        from the description.
+    """
+    hashtag_regex_pattern = r"(\s+)#(\w*[a-zA-Z]+\w*)\b"
+    pattern = re.compile(hashtag_regex_pattern)
+    matches = pattern.findall(description)
+
+    # Retrieve tags from the matches
+    tags = sorted(list(set([x[-1].lower() for x in matches])))
+
+    # Remove the '#' before the tags in description
+    new_d = pattern.sub(r'\1\2', description)
+
+    # Remove the last line in description if it has only tags
+    *lines, last_line = new_d.strip().splitlines()
+    last_line_has_tags_only = len(last_line.strip()) > 1 and all([x.strip().lower() in tags for x in last_line.split()])
+    if last_line_has_tags_only:
+        # Return all lines except the last line
+        return '\n'.join(lines), tags
+
+    # Remove the last sentence if it has only tags
+    *sentences, last_sentence = last_line.split('. ')
+    last_sentence_has_tags_only = len(last_sentence.strip()) > 1 and all(
+        [x.strip().lower() in tags for x in last_sentence.split()])
+    if last_sentence_has_tags_only:
+        # Return all lines and all sentences in the last line except the last sentence
+        lines.extend(sentences)
+        return '\n'.join(lines) + '.', tags
+
+    # Return the complete description
+    lines.append(last_line)
+    return '\n'.join(lines), tags
 
 
 def load_example(filename: str) -> Example:
@@ -107,8 +165,8 @@ def load_example(filename: str) -> Example:
     parts = contents.split('---', maxsplit=1)
     header, code = parts[0].strip().splitlines(), parts[1].strip()
     title, description = strip_comment(header[0]), [strip_comment(x) for x in header[1:]]
-    keywords = get_keywords_if_available(description[-2])
-    return Example(filename, title, '\n'.join(description), keywords, code)
+    new_description, tags = parse_tags('\n'.join(description))
+    return Example(filename, title, new_description, tags, code)
 
 
 def make_toc(examples: List[Example]):
@@ -136,8 +194,8 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 ''' + '\n' + '\n\n'.join([make_gallery_thumbnail(e) for e in examples])
 
 
-def make_keyword_group(keyword: str, examples: List[Example]) -> str:
-    sub_heading = f"### {keyword}\n"
+def make_tag_group(tag: str, examples: List[Example]) -> str:
+    sub_heading = f'### {tag}\n'
     example_links = []
     for e in examples:
         example_links.append(f"<a href={{useBaseUrl('docs/examples/{e.slug}')}}>{e.title}</a>")
@@ -145,21 +203,22 @@ def make_keyword_group(keyword: str, examples: List[Example]) -> str:
 
 
 def index_examples(examples: List[Example]):
-    keywords_dict = defaultdict(list)
+    tags_dict = defaultdict(list)
     for e in examples:
-        for k in e.keywords:
-            keywords_dict[k].append(e)
-    return sorted(keywords_dict.items())
+        for t in e.tags:
+            tags_dict[t].append(e)
+    return sorted(tags_dict.items())
 
 
-def make_examples_by_keyword(examples: List[Example]):
-    keywords = index_examples(examples)
+def make_examples_by_tag(examples: List[Example]):
+    tags = index_examples(examples)
     return '''---
-title: Tags
+title: Examples by Tag
+slug: /examples/tags
 ---
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
-''' + '\n' + '\n\n'.join([make_keyword_group(k, e) for k, e in keywords])
+''' + '\n' + '\n\n'.join([make_tag_group(t, e) for t, e in tags])
 
 
 def main():
@@ -179,11 +238,11 @@ def main():
     example_items = [dict(slug=e.slug) for e in examples]
     example_items.insert(0, dict(slug='index'))
     example_items.insert(1, dict(slug='all'))
-    example_items.insert(2, dict(slug='examples-tags'))
+    example_items.insert(2, dict(slug='tags'))
     write_file(os.path.join(website_dir, 'examples.js'), f'module.exports={json.dumps(example_items)}')
     write_file(os.path.join(example_md_dir, 'index.md'), make_gallery(examples))
     write_file(os.path.join(example_md_dir, 'all.md'), make_toc(examples))
-    write_file(os.path.join(example_md_dir, 'examples-tags.md'), make_examples_by_keyword(examples))
+    write_file(os.path.join(example_md_dir, 'tags.md'), make_examples_by_tag(examples))
 
 
 if __name__ == '__main__':

--- a/py/sync_examples.py
+++ b/py/sync_examples.py
@@ -207,7 +207,8 @@ def index_examples(examples: List[Example]):
     for e in examples:
         for t in e.tags:
             tags_dict[t].append(e)
-    return sorted(tags_dict.items())
+    # Sort all tags and examples under each tag alphabetically
+    return sorted([(t, sorted(e, key=lambda x: x.title)) for t, e in tags_dict.items()])
 
 
 def make_examples_by_tag(examples: List[Example]):


### PR DESCRIPTION
Closes #422 

1. Added a new page `Tags` between `Gallery` and `Hello World!`
2. The `tags` are subheadings on this page, sorted alphabetically. Under each `tag`, links to the examples with those tags are available.
3. Added a `Tags` field under each example with tags. These tags are links that link back to the Tags page mentioned above.
4. Added `keywords` metadata in the header of the each generated `.md` file. Docusaurus [markdown headers](https://v2.docusaurus.io/docs/markdown-features#markdown-headers) provide only `keywords` under Docs and `tags` under Blog.
5. In the python example files, tags can be provided as the last line of description.
6. Tags line can not have `.` in it. Tags must be `,` separated. A tag can not contain spaces.

ToDo:
1. Comment the code
2. Add tags to all remaining examples.

@lo5, If you like this implementation, I will go ahead and complete the ToDos listed above.

example:

`buttons.py`

```py
# Form / Buttons
# Use the `ui.buttons()` function to group related buttons.
# form, buttons
# ---
from h2o_wave import main, app, Q, ui
```

`buttons.md`

```md
---
title: Form / Buttons
keywords:
  - form
  - buttons
---
```

![wave_docs_examples_tags](https://user-images.githubusercontent.com/16831326/103091836-476cc680-45aa-11eb-8634-3c160ba766b9.png)

![wave_docs_examples_buttons_tags](https://user-images.githubusercontent.com/16831326/103091843-4cca1100-45aa-11eb-85f6-427a9b605474.png)

