### PR TITLE
feat: searchable documentation #309

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -19,6 +19,11 @@ module.exports = {
     prism: {
       additionalLanguages: ['toml'],
     },
+    algolia: {
+      apiKey: '1ff399df2912b1f87d8b235fa995fce6',
+      indexName: 'wave',
+      contextualSearch: true,
+    },
     navbar: {
       title: 'H2O Wave',
       logo: {

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -158,3 +158,33 @@ a.thumbnail > div:hover {
 .notice a {
   color: var(--h2o-accent-color);
 }
+
+html[data-theme="dark"] .DocSearch {
+  --docsearch-text-color: var(--ifm-font-color-base);
+  --docsearch-muted-color: var(--ifm-color-secondary-darkest);
+  --docsearch-container-background: rgba(47, 55, 69, 0.7);
+  /* Modal */
+  --docsearch-modal-background: var(--ifm-background-color);
+  --docsearch-modal-shadow: inset 1px 1px 0 0 var(--ifm-color-emphasis-100),
+    0 3px 8px 0 #000309;
+  /* Search box */
+  --docsearch-searchbox-background: var(--ifm-background-color);
+  --docsearch-searchbox-focus-background: var(--ifm-color-black);
+  /* Hit */
+  --docsearch-hit-color: var(--ifm-font-color-base);
+  --docsearch-hit-active-color: var(--ifm-color-black);
+  --docsearch-hit-background: var(--ifm-color-emphasis-100);
+  /* Footer */
+  --docsearch-footer-background: var(--ifm-background-surface-color);
+  --docsearch-footer-shadow: inset 0 1px 0 0 var(--ifm-color-emphasis-200),
+    0 -4px 8px 0 rgba(0, 0, 0, 0.2);
+  /* Keys */
+  --docsearch-key-gradient: linear-gradient(
+    -26.5deg,
+    var(--ifm-color-emphasis-200) 0%,
+    var(--ifm-color-emphasis-100) 100%
+  );
+  --docsearch-key-shadow: inset 0 -2px 0 0 var(--ifm-color-emphasis-100),
+    inset 0 0 1px 1px var(--ifm-color-emphasis-200),
+    0 2px 2px 0 rgba(3, 4, 9, 0.3);
+}


### PR DESCRIPTION
fixes #309

- [x] Added Algolia config.
- [x] Updated CSS for `dark-theme` to fix readability in the search window, and removed default blue accents on buttons and shadows.

#### Notes:
- Using Algolia with Docusaurus2 is surprisingly simple. [Link to Docusaurus' config](https://github.com/facebook/docusaurus/blob/2791ccc4cfb6581a33e36c6d018d098daf403ce4/website/docusaurus.config.js#L268)
- By default, the `dark-theme` readability in the search box isn't good. Used the defaults from [Docusaurus docs](https://v2.docusaurus.io/docs/search#styling-your-algolia-search) and improved it. Tried to follow the [Infima](https://v2.docusaurus.io/docs/styling-layout#styling-your-site-with-infima) design pattern.

#### Video of the output:

https://user-images.githubusercontent.com/16831326/103168260-6eafd780-47e6-11eb-9794-2b2c151b5c67.mp4

