### PR TITLE
fix: API section of the docs has mismatched sidebar and index items

### DIFF
--- a/py/h2o_wave/__init__.py
+++ b/py/h2o_wave/__init__.py
@@ -40,5 +40,4 @@ __pdoc__ = {
     'cli': False,
     'db': False,
     'ide': False,
-    'ui_ext': False,
 }

--- a/py/h2o_wave/__init__.py
+++ b/py/h2o_wave/__init__.py
@@ -34,3 +34,11 @@ from .server import listen, Q, app, main
 from .db import TeleDBError, TeleDB
 from .types import *
 from .test import cypress, Cypress
+
+
+__pdoc__ = {
+    'cli': False,
+    'db': False,
+    'ide': False,
+    'ui_ext': False,
+}

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -55,11 +55,12 @@ module.exports = {
     'API': [
       'api/index',
       'api/core',
-      'api/graphics',
-      'api/server',
-      'api/test',
-      'api/types',
       'api/ui',
+      'api/ui_ext',
+      'api/server',
+      'api/graphics',
+      'api/types',
+      'api/test',
     ],
   },
 };

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -55,11 +55,11 @@ module.exports = {
     'API': [
       'api/index',
       'api/core',
-      'api/ui',
-      'api/server',
       'api/graphics',
-      'api/types',
+      'api/server',
       'api/test',
+      'api/types',
+      'api/ui',
     ],
   },
 };


### PR DESCRIPTION
fixes #455 

- [x] added `__pdoc__` dict to `py/h2o_wave/__init__.py` to ignore unreleased submodules. Relevant [pdoc3 documentation](https://pdoc3.github.io/pdoc/doc/pdoc/#overriding-docstrings-with-__pdoc__)
- [x] Fixed the order of topics in the sidebar to match the api index page.