### PR TITLE
make tour.py examples popen use current system encoding settings

### DIFF
--- a/py/examples/tour.py
+++ b/py/examples/tour.py
@@ -39,7 +39,10 @@ class Example:
         if self.is_app:
             self.process = subprocess.Popen(
                 [sys.executable, '-m', 'uvicorn', '--port', _app_port, f'examples.{self.name}:main'],
-                env=dict(H2O_WAVE_EXTERNAL_ADDRESS=f'http://{_app_host}:{_app_port}', **env))
+                env=os.environ.update(
+                    dict(H2O_WAVE_EXTERNAL_ADDRESS=f'http://{_app_host}:{_app_port}', **env)
+                )
+            )
         else:
             self.process = subprocess.Popen([sys.executable, os.path.join(example_dir, self.filename)], env=env)
 


### PR DESCRIPTION
To resolve:

```
~$ wave run --no-reload examples.tour
----------------------------------------
 Welcome to the H2O Wave Interactive Tour!

 Go to http://localhost:10101/tour
----------------------------------------
INFO:     Started server process [23590]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
INFO:     127.0.0.1:36606 - "POST / HTTP/1.1" 200 OK
INFO:     127.0.0.1:36606 - "POST / HTTP/1.1" 200 OK
INFO:     127.0.0.1:36606 - "POST / HTTP/1.1" 200 OK
Traceback (most recent call last):
  File "/usr/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/achraf/wave/wave-0.10.0-linux-amd64/env/lib/python3.6/site-packages/uvicorn/__main__.py", line 4, in <module>
    uvicorn.main()
  File "/home/achraf/wave/wave-0.10.0-linux-amd64/env/lib/python3.6/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/home/achraf/wave/wave-0.10.0-linux-amd64/env/lib/python3.6/site-packages/click/core.py", line 760, in main
    _verify_python3_env()
  File "/home/achraf/wave/wave-0.10.0-linux-amd64/env/lib/python3.6/site-packages/click/_unicodefun.py", line 133, in _verify_python3_env
    " mitigation steps.{}".format(extra)
RuntimeError: Click will abort further execution because Python 3 was configured to use ASCII as encoding for the environment. Consult https://click.palletsprojects.com/python3/ for mitigation steps.

This system supports the C.UTF-8 locale which is recommended. You might be able to resolve your issue by exporting the following environment variables:

    export LC_ALL=C.UTF-8
    export LANG=C.UTF-8
```

Make tour.py child processes (examples) use current system env.