### PR TITLE
fix api/core#Expando with api/core/#Expando

### DIFF
--- a/website/docs/arguments.md
+++ b/website/docs/arguments.md
@@ -16,7 +16,7 @@ async def serve(q: Q):
     print(q.args.qux)
 ```
 
-:::tip api/core#Expando
+:::tip
 `q.args` is an [Expando](api/core/#Expando) instance, which means it behaves both like a dictionary and an object: `q.args['foo']` is the same as `q.args.foo`. `q.args.foo` is easier to read.
 :::
 

--- a/website/docs/arguments.md
+++ b/website/docs/arguments.md
@@ -16,8 +16,8 @@ async def serve(q: Q):
     print(q.args.qux)
 ```
 
-:::tip
-`q.args` is an [Expando](api/core#Expando) instance, which means it behaves both like a dictionary and an object: `q.args['foo']` is the same as `q.args.foo`. `q.args.foo` is easier to read.
+:::tip api/core#Expando
+`q.args` is an [Expando](api/core/#Expando) instance, which means it behaves both like a dictionary and an object: `q.args['foo']` is the same as `q.args.foo`. `q.args.foo` is easier to read.
 :::
 
 ## Interpreting arguments


### PR DESCRIPTION
Just add backslash to the right link.