### PR TITLE
Flex layout fixes

### DIFF
--- a/py/demo/dashboard_grey.py
+++ b/py/demo/dashboard_grey.py
@@ -15,7 +15,7 @@ async def show_grey_dashboard(q: Q):
                     ui.zone('top', direction=ui.ZoneDirection.ROW, size='25%'),
                     ui.zone('middle', direction=ui.ZoneDirection.ROW, size='25%'),
                     ui.zone('middle2', direction=ui.ZoneDirection.ROW, size='25%'),
-                    ui.zone('bottom', direction=ui.ZoneDirection.ROW, size='25%'),
+                    ui.zone('bottom', direction=ui.ZoneDirection.ROW, size='20%'),
                 ]),
                 ui.zone('footer', size='0'),
             ]

--- a/py/demo/dashboard_grey.py
+++ b/py/demo/dashboard_grey.py
@@ -15,7 +15,7 @@ async def show_grey_dashboard(q: Q):
                     ui.zone('top', direction=ui.ZoneDirection.ROW, size='25%'),
                     ui.zone('middle', direction=ui.ZoneDirection.ROW, size='25%'),
                     ui.zone('middle2', direction=ui.ZoneDirection.ROW, size='25%'),
-                    ui.zone('bottom', direction=ui.ZoneDirection.ROW, size='20%'),
+                    ui.zone('bottom', direction=ui.ZoneDirection.ROW, size='25%'),
                 ]),
                 ui.zone('footer', size='0'),
             ]

--- a/ui/src/parts/microarea.tsx
+++ b/ui/src/parts/microarea.tsx
@@ -15,8 +15,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-asserted-optional-chain */
 import * as d3 from 'd3'
 import React from 'react'
-import { F, S, debounce } from '../qd'
-import { px } from '../theme'
+import { debounce, F, S } from '../qd'
 
 interface Props {
   data: any[]
@@ -69,9 +68,8 @@ export const MicroArea = ({ value, color, data, zeroValue, curve }: Props) => {
           .y1(d => scaleY(d[value]))
           .curve(fcurve)
 
-      ref.current.style.maxHeight = px(height)
       setContent(
-        <svg viewBox={`0 0 ${width} ${height}`}>
+        <svg viewBox={`0 0 ${width} ${height}`} style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 }}>
           <path d={ar(data) as S} fill={color} fillOpacity='0.1' strokeLinejoin='round' strokeLinecap='round'></path>
           <path d={ln(data) as S} fill='none' stroke={color} strokeWidth='1.5' strokeLinejoin='round' strokeLinecap='round'></path>
         </svg>
@@ -85,5 +83,5 @@ export const MicroArea = ({ value, color, data, zeroValue, curve }: Props) => {
   }, [])
   React.useLayoutEffect(renderViz, [value, color, data, zeroValue, curve])
 
-  return <div ref={ref} style={{ width: '100%', height: '100%' }}>{content}</div>
+  return <div ref={ref} style={{ width: '100%', height: '100%', display: 'flex', position: 'relative', flexGrow: 1 }}>{content}</div>
 }

--- a/ui/src/parts/microarea.tsx
+++ b/ui/src/parts/microarea.tsx
@@ -48,9 +48,10 @@ export const MicroArea = ({ value, color, data, zeroValue, curve }: Props) => {
     }, [data, zeroValue]),
     [content, setContent] = React.useState<JSX.Element | null>(null),
     renderViz = () => {
+      if (!ref.current) return
+
       const
-        width = ref.current?.clientWidth!,
-        height = ref.current?.clientHeight!,
+        { width, height } = ref.current.getBoundingClientRect(),
         scaleX = d3.scaleLinear().domain([0, data.length - 1]).range([0, width]),
         scaleY = d3.scaleLinear().domain([minY, maxY]).range([height, 2]),
         fcurve = curves[curve] || d3.curveLinear,
@@ -68,7 +69,7 @@ export const MicroArea = ({ value, color, data, zeroValue, curve }: Props) => {
           .y1(d => scaleY(d[value]))
           .curve(fcurve)
 
-      if (ref.current) ref.current.style.maxHeight = px(height)
+      ref.current.style.maxHeight = px(height)
       setContent(
         <svg viewBox={`0 0 ${width} ${height}`}>
           <path d={ar(data) as S} fill={color} fillOpacity='0.1' strokeLinejoin='round' strokeLinecap='round'></path>

--- a/ui/src/parts/microarea.tsx
+++ b/ui/src/parts/microarea.tsx
@@ -15,6 +15,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-asserted-optional-chain */
 import * as d3 from 'd3'
 import React from 'react'
+import { stylesheet } from 'typestyle'
 import { debounce, F, S } from '../qd'
 
 interface Props {
@@ -32,6 +33,15 @@ const curves: Record<S, d3.CurveFactory> = {
   'step-after': d3.curveStepAfter,
   'step-before': d3.curveStepBefore,
 }
+
+const css = stylesheet({
+  container: {
+    width: '100%',
+    height: '100%',
+    position: 'relative',
+    flexGrow: 1,
+  }
+})
 
 export const MicroArea = ({ value, color, data, zeroValue, curve }: Props) => {
   const
@@ -83,5 +93,5 @@ export const MicroArea = ({ value, color, data, zeroValue, curve }: Props) => {
   }, [])
   React.useLayoutEffect(renderViz, [value, color, data, zeroValue, curve])
 
-  return <div ref={ref} style={{ width: '100%', height: '100%', display: 'flex', position: 'relative', flexGrow: 1 }}>{content}</div>
+  return <div ref={ref} className={css.container}>{content}</div>
 }

--- a/ui/src/parts/microarea.tsx
+++ b/ui/src/parts/microarea.tsx
@@ -15,7 +15,8 @@
 /* eslint-disable @typescript-eslint/no-non-null-asserted-optional-chain */
 import * as d3 from 'd3'
 import React from 'react'
-import { debounce, F, S } from '../qd'
+import { F, S, debounce } from '../qd'
+import { px } from '../theme'
 
 interface Props {
   data: any[]
@@ -67,8 +68,9 @@ export const MicroArea = ({ value, color, data, zeroValue, curve }: Props) => {
           .y1(d => scaleY(d[value]))
           .curve(fcurve)
 
+      if (ref.current) ref.current.style.maxHeight = px(height)
       setContent(
-        <svg width={width} height={height}>
+        <svg viewBox={`0 0 ${width} ${height}`}>
           <path d={ar(data) as S} fill={color} fillOpacity='0.1' strokeLinejoin='round' strokeLinecap='round'></path>
           <path d={ln(data) as S} fill='none' stroke={color} strokeWidth='1.5' strokeLinejoin='round' strokeLinecap='round'></path>
         </svg>

--- a/ui/src/parts/microbars.tsx
+++ b/ui/src/parts/microbars.tsx
@@ -15,8 +15,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-asserted-optional-chain */
 import * as d3 from 'd3'
 import React from 'react'
-import { F, S, debounce } from '../qd'
-import { px } from '../theme'
+import { debounce, F, S } from '../qd'
 
 interface Props {
   data: any[]
@@ -50,9 +49,7 @@ export const MicroBars = ({ value, category = 'x', color, data, zeroValue }: Pro
           const x = scaleX(d[category]), y = scaleY(d[value])
           return <rect key={i} fill={color} x={x} y={y} width={2} height={height - y} />
         })
-
-      ref.current.style.maxHeight = px(height)
-      setContent(<svg viewBox={`0 0 ${width} ${height}`}>{rects}</svg>)
+      setContent(<svg viewBox={`0 0 ${width} ${height}`} style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 }}>{rects}</svg>)
     },
     onResize = debounce(1000, renderViz)
 
@@ -62,5 +59,5 @@ export const MicroBars = ({ value, category = 'x', color, data, zeroValue }: Pro
   }, [])
   React.useLayoutEffect(renderViz, [value, category, color, data, zeroValue])
 
-  return <div ref={ref} style={{ width: '100%', height: '100%' }}>{content}</div>
+  return <div ref={ref} style={{ width: '100%', height: '100%', display: 'flex', position: 'relative', flexGrow: 1 }}>{content}</div>
 }

--- a/ui/src/parts/microbars.tsx
+++ b/ui/src/parts/microbars.tsx
@@ -40,9 +40,10 @@ export const MicroBars = ({ value, category = 'x', color, data, zeroValue }: Pro
       return [minY, maxY]
     }, [data, zeroValue]),
     renderViz = () => {
+      if (!ref.current) return
+
       const
-        width = ref.current?.clientWidth!,
-        height = ref.current?.clientHeight!,
+        { width, height } = ref.current.getBoundingClientRect(),
         scaleX = d3.scaleBand().domain(data.map(d => d[category])).range([0, width]).paddingInner(0.1),
         scaleY = d3.scaleLinear().domain([minY, maxY]).range([height, 0]),
         rects = data.map((d, i) => {
@@ -50,7 +51,7 @@ export const MicroBars = ({ value, category = 'x', color, data, zeroValue }: Pro
           return <rect key={i} fill={color} x={x} y={y} width={2} height={height - y} />
         })
 
-      if (ref.current) ref.current.style.maxHeight = px(height)
+      ref.current.style.maxHeight = px(height)
       setContent(<svg viewBox={`0 0 ${width} ${height}`}>{rects}</svg>)
     },
     onResize = debounce(1000, renderViz)

--- a/ui/src/parts/microbars.tsx
+++ b/ui/src/parts/microbars.tsx
@@ -15,7 +15,8 @@
 /* eslint-disable @typescript-eslint/no-non-null-asserted-optional-chain */
 import * as d3 from 'd3'
 import React from 'react'
-import { debounce, F, S } from '../qd'
+import { F, S, debounce } from '../qd'
+import { px } from '../theme'
 
 interface Props {
   data: any[]
@@ -48,7 +49,9 @@ export const MicroBars = ({ value, category = 'x', color, data, zeroValue }: Pro
           const x = scaleX(d[category]), y = scaleY(d[value])
           return <rect key={i} fill={color} x={x} y={y} width={2} height={height - y} />
         })
-      setContent(<svg width={width} height={height}>{rects}</svg>)
+
+      if (ref.current) ref.current.style.maxHeight = px(height)
+      setContent(<svg viewBox={`0 0 ${width} ${height}`}>{rects}</svg>)
     },
     onResize = debounce(1000, renderViz)
 

--- a/ui/src/parts/microbars.tsx
+++ b/ui/src/parts/microbars.tsx
@@ -15,6 +15,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-asserted-optional-chain */
 import * as d3 from 'd3'
 import React from 'react'
+import { stylesheet } from 'typestyle'
 import { debounce, F, S } from '../qd'
 
 interface Props {
@@ -24,6 +25,15 @@ interface Props {
   value: S
   color: S
 }
+
+const css = stylesheet({
+  container: {
+    width: '100%',
+    height: '100%',
+    position: 'relative',
+    flexGrow: 1,
+  }
+})
 
 export const MicroBars = ({ value, category = 'x', color, data, zeroValue }: Props) => {
   const
@@ -59,5 +69,5 @@ export const MicroBars = ({ value, category = 'x', color, data, zeroValue }: Pro
   }, [])
   React.useLayoutEffect(renderViz, [value, category, color, data, zeroValue])
 
-  return <div ref={ref} style={{ width: '100%', height: '100%', display: 'flex', position: 'relative', flexGrow: 1 }}>{content}</div>
+  return <div ref={ref} className={css.container}>{content}</div>
 }

--- a/ui/src/parts/progress_arc.tsx
+++ b/ui/src/parts/progress_arc.tsx
@@ -17,6 +17,7 @@ import * as d3 from 'd3'
 import React from 'react'
 import { stylesheet } from 'typestyle'
 import { debounce, F, S, U } from '../qd'
+import { px } from '../theme'
 
 
 interface Props {
@@ -56,8 +57,11 @@ export const ProgressArc = ({ thickness, color, value }: Props) => {
           startAngle: 0,
           endAngle: 2 * Math.PI * value,
         })
+
+      if (ref.current) ref.current.style.maxHeight = px(height)
+
       setContent(
-        <svg width={width} height={height}>
+        <svg viewBox={`0 0 ${width} ${height}`}>
           <g transform={diameter === height ? `translate(${(width - (2 * outerRadius)) / 2}, 0)` : `translate(0, ${(height - (2 * outerRadius)) / 2})`}>
             <path d={slot as S} fill={color} fillOpacity={0.15} transform={`translate(${outerRadius},${outerRadius})`} />
             <path d={bar as S} fill={color} transform={`translate(${outerRadius},${outerRadius})`} />

--- a/ui/src/parts/progress_arc.tsx
+++ b/ui/src/parts/progress_arc.tsx
@@ -17,7 +17,6 @@ import * as d3 from 'd3'
 import React from 'react'
 import { stylesheet } from 'typestyle'
 import { debounce, F, S, U } from '../qd'
-import { px } from '../theme'
 
 
 interface Props {
@@ -30,7 +29,8 @@ const css = stylesheet({
   container: {
     width: '100%',
     height: '100%',
-    textAlign: 'center',
+    position: 'relative',
+    flexGrow: 1
   }
 })
 
@@ -39,9 +39,10 @@ export const ProgressArc = ({ thickness, color, value }: Props) => {
     ref = React.useRef<HTMLDivElement>(null),
     [content, setContent] = React.useState<JSX.Element | null>(null),
     renderViz = () => {
+      if (!ref.current) return
+
       const
-        width = ref.current?.clientWidth!,
-        height = ref.current?.clientHeight!,
+        { width, height } = ref.current.getBoundingClientRect(),
         diameter = Math.min(width, height),
         outerRadius = diameter / 2,
         innerRadius = diameter / 2 - thickness,
@@ -58,10 +59,8 @@ export const ProgressArc = ({ thickness, color, value }: Props) => {
           endAngle: 2 * Math.PI * value,
         })
 
-      if (ref.current) ref.current.style.maxHeight = px(height)
-
       setContent(
-        <svg viewBox={`0 0 ${width} ${height}`}>
+        <svg viewBox={`0 0 ${width} ${height}`} style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 }}>
           <g transform={diameter === height ? `translate(${(width - (2 * outerRadius)) / 2}, 0)` : `translate(0, ${(height - (2 * outerRadius)) / 2})`}>
             <path d={slot as S} fill={color} fillOpacity={0.15} transform={`translate(${outerRadius},${outerRadius})`} />
             <path d={bar as S} fill={color} transform={`translate(${outerRadius},${outerRadius})`} />

--- a/ui/src/plot.tsx
+++ b/ui/src/plot.tsx
@@ -735,11 +735,6 @@ const
       flexGrow: 1,
       display: 'flex',
     },
-    plotContainer: {
-      $nest: {
-        '>div': { textAlign: 'center' }
-      }
-    }
   })
 
 /** Create a visualization for display inside a form. */
@@ -814,11 +809,13 @@ export const
       render = () => {
         const
           { width, height, visible, name } = model,
+          // BUG: inside a flex layout, the plot does not use all available width.
+          // Maybe the width here needs to be set explicitly using getBoundingClientRect()?
           style: React.CSSProperties = (width === 'auto' && height === 'auto')
             ? { flexGrow: 1 }
             : { width: width || 'auto', height: height || '300px' }
         return (
-          <div data-test={name} style={{ ...style, ...displayMixin(visible) }} className={css.plotContainer} ref={container} />
+          <div data-test={name} style={{ ...style, ...displayMixin(visible) }} ref={container} />
         )
       }
     return { init, update, render }

--- a/ui/src/plot.tsx
+++ b/ui/src/plot.tsx
@@ -735,6 +735,11 @@ const
       flexGrow: 1,
       display: 'flex',
     },
+    plotContainer: {
+      $nest: {
+        '>div': { textAlign: 'center' }
+      }
+    }
   })
 
 /** Create a visualization for display inside a form. */
@@ -813,7 +818,7 @@ export const
             ? { flexGrow: 1 }
             : { width: width || 'auto', height: height || '300px' }
         return (
-          <div data-test={name} style={{ ...style, ...displayMixin(visible) }} ref={container} />
+          <div data-test={name} style={{ ...style, ...displayMixin(visible) }} className={css.plotContainer} ref={container} />
         )
       }
     return { init, update, render }

--- a/ui/src/small_series_stat.tsx
+++ b/ui/src/small_series_stat.tsx
@@ -39,9 +39,6 @@ const
     value: {
       ...theme.font.s12,
     },
-    plot: {
-      flexGrow: 1,
-    },
   })
 
 /** Create a small stat card displaying a primary value and a series plot. */
@@ -97,7 +94,7 @@ export const
             <Format data={data} format={s.title || 'Untitled'} className={css.title} />
             <Format data={data} format={s.value} className={css.value} />
           </div>
-          <div className={css.plot}>{plot}</div>
+          {plot}
         </div>
       )
     }

--- a/ui/src/tall_series_stat.tsx
+++ b/ui/src/tall_series_stat.tsx
@@ -42,9 +42,6 @@ const
       ...theme.font.s12,
       color: theme.colors.text7,
     },
-    plot: {
-      flexGrow: 1,
-    }
   })
 
 /** Create a tall stat card displaying a primary value, an auxiliary value and a series plot. */


### PR DESCRIPTION
* Use absolute positioning (to avoid normal document flow) to avoid weird flexbox behavior with inline SVG - probably due to scalability capabilities.
* Fix some flexbox browser quirks - flex child didn't take full height on all major browsers - tested with Chrome, Safari, Firefox, Edge.
* Recompute svgs on `resize` event.
* Fixed grey dashboard as commented in issue.

Closes #473