### PR TITLE
fix/flex plot

### DIFF
--- a/py/demo/dashboard_purple.py
+++ b/py/demo/dashboard_purple.py
@@ -272,7 +272,6 @@ async def show_purple_dashboard(q: Q):
                         ('In-store', next(sales_days_2), next(sales_amounts_2)) for i in range(15)],
                     pack=True
                 ),
-                height='210px',
             )
         ],
     )
@@ -309,7 +308,6 @@ async def show_purple_dashboard(q: Q):
                         ('In-store', next(audience_days2), next(audience_hits2)) for i in range(60)],
                     pack=True
                 ),
-                height='210px',
             )
         ],
     )

--- a/ui/src/form.tsx
+++ b/ui/src/form.tsx
@@ -155,17 +155,16 @@ const
   css = stylesheet({
     card: {
       padding: 15,
+      display: 'flex',
+      flexDirection: 'column'
     },
     vertical: {
+      display: 'flex',
+      flexDirection: 'column',
+      flexGrow: 1,
       $nest: {
-        '>*': {
-          margin: margin(10, 0)
-        },
-        '>*:first-child': {
-          marginTop: 0,
-        },
-        '>*:last-child': {
-          marginBottom: 0,
+        '>*:not(:first-child)': {
+          marginTop: 10
         },
       }
     },

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -33,11 +33,3 @@ body,
   right: 0;
   bottom: 0;
 }
-
-p {
-  margin: 0;
-}
-
-p + p {
-  margin-top: 10px;
-}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1,4 +1,4 @@
- /*
+/*
   Copyright 2020 H2O.ai, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,21 +15,29 @@
 */
 body {
   margin: 0;
-  font-family: "Inter", -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell",
+    "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
+  font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New", monospace;
 }
 
-body, #root {
+body,
+#root {
   position: absolute;
   left: 0;
   top: 0;
   right: 0;
   bottom: 0;
+}
+
+p {
+  margin: 0;
+}
+
+p + p {
+  margin-top: 10px;
 }

--- a/ui/src/markdown.tsx
+++ b/ui/src/markdown.tsx
@@ -65,6 +65,9 @@ const
         p: {
           margin: 0
         },
+        'p+p': {
+          marginTop: 10
+        }
       },
     },
   })

--- a/ui/src/markdown.tsx
+++ b/ui/src/markdown.tsx
@@ -62,6 +62,9 @@ const
           maxWidth: '100%',
           maxHeight: '100%',
         },
+        p: {
+          margin: 0
+        },
       },
     },
   })

--- a/ui/src/plot.tsx
+++ b/ui/src/plot.tsx
@@ -734,6 +734,15 @@ const
     body: {
       flexGrow: 1,
       display: 'flex',
+      $nest: {
+        'canvas': {
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: 0
+        }
+      }
     },
   })
 
@@ -765,6 +774,8 @@ export const
       init = () => {
         const el = container.current
         if (!el) return
+        // If card does not have specified height, it uses content. Since the wrapper is empty, it takes very little space - set to 300px by default.
+        if (el.clientHeight < 30) el.style.height = '300px'
         const
           raw_data = unpack<any[]>(model.data),
           raw_plot = unpack<Plot>(model.plot),
@@ -808,15 +819,11 @@ export const
       },
       render = () => {
         const
-          { width, height, visible, name } = model,
-          // BUG: inside a flex layout, the plot does not use all available width.
-          // Maybe the width here needs to be set explicitly using getBoundingClientRect()?
+          { width = 'auto', height = 'auto', visible, name } = model,
           style: React.CSSProperties = (width === 'auto' && height === 'auto')
             ? { flexGrow: 1 }
-            : { width: width || 'auto', height: height || '300px' }
-        return (
-          <div data-test={name} style={{ ...style, ...displayMixin(visible) }} ref={container} />
-        )
+            : { width, height }
+        return <div data-test={name} style={{ ...style, ...displayMixin(visible) }} ref={container} />
       }
     return { init, update, render }
   })
@@ -837,12 +844,12 @@ export const
   View = bond(({ name, state, changed }: Card<State>) => {
     const
       render = () => {
-        const { title, plot, data, events } = state
+        const { title = 'Untitled', plot, data, events } = state
         return (
           <div className={css.card}>
-            <div className={css.title}>{title || 'Untitled'}</div>
+            <div className={css.title}>{title}</div>
             <div className={css.body}>
-              <XVisualization model={{ name, plot, data, width: 'auto', height: 'auto', events }} />
+              <XVisualization model={{ name, plot, data, events }} />
             </div>
           </div>
         )
@@ -851,4 +858,3 @@ export const
   })
 
 cards.register('plot', View)
-


### PR DESCRIPTION
Additional layout fixes

* Managed to fix g2 plots kind of - they take all available free space also within flex layout - to make it work with form cards as well, I had to display form items as flexbox children with col direction for vertical alignment. There is one catch though - the margins don’t collapse within flexbox (https://stackoverflow.com/questions/43882869/margin-collapsing-in-flexbox) which in combination with default margins for p tags for examples caused large gaps between text form elements. I managed to work around it, but it is not ideal.
* Discovered scrolling bug on g2 plots - seems like scroll event bubbles outside the component and interferes with native scroll event handler. (video 1)
* Discovered overflow bugs on g2 plots (img1, img2) - didn’t dig deeper for now
* Added vega resizing
* Centered vega in forms and grid layouts
* Checked tour and dashboards and it seems to be fine
![image (2)](https://user-images.githubusercontent.com/64769322/104325668-2d5b3f80-54e9-11eb-9a4c-ad0f47b7bfd5.png)

![image (1)](https://user-images.githubusercontent.com/64769322/104325659-28968b80-54e9-11eb-9594-5d510be53d1c.png)

https://user-images.githubusercontent.com/64769322/104325706-39470180-54e9-11eb-85f8-dc83ef1f1646.mov
