### PR TITLE
feat: add support to print via browser.

### DIFF
--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -33,3 +33,32 @@ body,
   right: 0;
   bottom: 0;
 }
+
+@media print {
+
+  #root * {
+    overflow: visible;
+  }
+
+  pre {
+    white-space: pre-wrap !important;
+  }
+
+  img, th, tr {
+    page-break-inside: avoid;
+  }
+
+  blockquote, pre {
+    border: 1px solid #adb5bd;
+    page-break-inside: avoid;
+  }
+
+  div[class^="ms-ScrollablePane"], div[class*=" root-"] {
+    overflow: hidden !important;
+  }
+
+  @page {
+    orphans: 4;
+    widows: 2;
+  }
+}


### PR DESCRIPTION
Currently, browser print captures only the visible part of the page. This adds support to capturing whole screen when using the browsers' print option.
Fixes: https://github.com/h2oai/wave/issues/486