### PR TITLE
fix: explicitly set conda package name

### DIFF
--- a/py/conda/meta.yaml
+++ b/py/conda/meta.yaml
@@ -1,7 +1,7 @@
 {% set data = load_setup_py_data() %}
 
 package:
-  name: "h2o_wave"
+  name: "h2o-wave"
   version: "{{ VERSION }}"
 
 about:


### PR DESCRIPTION
Explicitly set Conda package name as h2o-wave