### PR TITLE
Fix: form visibility

### DIFF
--- a/py/examples/form_visibility.py
+++ b/py/examples/form_visibility.py
@@ -1,0 +1,41 @@
+# Form / Visible
+# Use "visible" property to control whether form element should be shown / hidden.
+# ---
+from h2o_wave import main, app, Q, ui
+
+
+@app('/demo')
+async def serve(q: Q):
+    if not q.client.initialized:
+        q.page['example'] = ui.form_card(box='1 1 4 10', items=[
+            ui.text_xl(content='First text'),
+            ui.text_l(content='Second text'),
+            ui.text_m(content='Third text'),
+            ui.text_s(content='Fourth text'),
+            ui.inline([
+                ui.button(name='left1', label='Left1'),
+                ui.button(name='left2', label='Left2'),
+                ui.button(name='left3', label='Left3'),
+            ]),
+            ui.buttons(justify='end', items=[
+                ui.button(name='right1', label='Right1'),
+                ui.button(name='right2', label='Right2'),
+                ui.button(name='right3', label='Right3'),
+            ]),
+            ui.buttons(items=[ui.button(name='show', label='Show'), ui.button(name='hide', label='Hide')])
+        ])
+        q.client.initialized = True
+    items = q.page['example'].items
+    items_to_hide = [
+        items[0].text_xl,
+        items[2].text_m,
+        items[4].inline.items[0].button,
+        items[5].buttons.items[2].button,
+    ]
+    if q.args.hide:
+        for i in items_to_hide:
+            i.visible = False
+    if q.args.show:
+        for i in items_to_hide:
+            i.visible = True
+    await q.page.save()

--- a/py/examples/tour.conf
+++ b/py/examples/tour.conf
@@ -20,6 +20,7 @@ layout.py
 layout_size.py
 layout_responsive.py
 form.py
+form_visibility.py
 text.py
 text_sizes.py
 label.py

--- a/py/h2o_wave/types.py
+++ b/py/h2o_wave/types.py
@@ -5245,26 +5245,32 @@ class Stats:
             items: List[Stat],
             justify: Optional[str] = None,
             inset: Optional[bool] = None,
+            visible: Optional[bool] = None,
     ):
         _guard_vector('Stats.items', items, (Stat,), False, False, False)
         _guard_enum('Stats.justify', justify, _StatsJustify, True)
         _guard_scalar('Stats.inset', inset, (bool,), False, True, False)
+        _guard_scalar('Stats.visible', visible, (bool,), False, True, False)
         self.items = items
         """The individual stats to be displayed."""
         self.justify = justify
         """Specifies how to lay out the individual stats. Defaults to 'start'. One of 'start', 'end', 'center', 'between', 'around'. See enum h2o_wave.ui.StatsJustify."""
         self.inset = inset
         """Whether to display the stats with a contrasting background."""
+        self.visible = visible
+        """True if the component should be visible. Defaults to true."""
 
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""
         _guard_vector('Stats.items', self.items, (Stat,), False, False, False)
         _guard_enum('Stats.justify', self.justify, _StatsJustify, True)
         _guard_scalar('Stats.inset', self.inset, (bool,), False, True, False)
+        _guard_scalar('Stats.visible', self.visible, (bool,), False, True, False)
         return _dump(
             items=[__e.dump() for __e in self.items],
             justify=self.justify,
             inset=self.inset,
+            visible=self.visible,
         )
 
     @staticmethod
@@ -5276,13 +5282,17 @@ class Stats:
         _guard_enum('Stats.justify', __d_justify, _StatsJustify, True)
         __d_inset: Any = __d.get('inset')
         _guard_scalar('Stats.inset', __d_inset, (bool,), False, True, False)
+        __d_visible: Any = __d.get('visible')
+        _guard_scalar('Stats.visible', __d_visible, (bool,), False, True, False)
         items: List[Stat] = [Stat.load(__e) for __e in __d_items]
         justify: Optional[str] = __d_justify
         inset: Optional[bool] = __d_inset
+        visible: Optional[bool] = __d_visible
         return Stats(
             items,
             justify,
             inset,
+            visible,
         )
 
 
@@ -5352,11 +5362,13 @@ class Image:
             type: Optional[str] = None,
             image: Optional[str] = None,
             path: Optional[str] = None,
+            visible: Optional[bool] = None,
     ):
         _guard_scalar('Image.title', title, (str,), False, False, False)
         _guard_scalar('Image.type', type, (str,), False, True, False)
         _guard_scalar('Image.image', image, (str,), False, True, False)
         _guard_scalar('Image.path', path, (str,), False, True, False)
+        _guard_scalar('Image.visible', visible, (bool,), False, True, False)
         self.title = title
         """The image title, typically displayed as a tooltip."""
         self.type = type
@@ -5365,6 +5377,8 @@ class Image:
         """Image data, base64-encoded."""
         self.path = path
         """The path or URL or data URL of the image, e.g. `/foo.png` or `http://example.com/foo.png` or `data:image/png;base64,???`."""
+        self.visible = visible
+        """True if the component should be visible. Defaults to true."""
 
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""
@@ -5372,11 +5386,13 @@ class Image:
         _guard_scalar('Image.type', self.type, (str,), False, True, False)
         _guard_scalar('Image.image', self.image, (str,), False, True, False)
         _guard_scalar('Image.path', self.path, (str,), False, True, False)
+        _guard_scalar('Image.visible', self.visible, (bool,), False, True, False)
         return _dump(
             title=self.title,
             type=self.type,
             image=self.image,
             path=self.path,
+            visible=self.visible,
         )
 
     @staticmethod
@@ -5390,15 +5406,19 @@ class Image:
         _guard_scalar('Image.image', __d_image, (str,), False, True, False)
         __d_path: Any = __d.get('path')
         _guard_scalar('Image.path', __d_path, (str,), False, True, False)
+        __d_visible: Any = __d.get('visible')
+        _guard_scalar('Image.visible', __d_visible, (bool,), False, True, False)
         title: str = __d_title
         type: Optional[str] = __d_type
         image: Optional[str] = __d_image
         path: Optional[str] = __d_path
+        visible: Optional[bool] = __d_visible
         return Image(
             title,
             type,
             image,
             path,
+            visible,
         )
 
 

--- a/py/h2o_wave/ui.py
+++ b/py/h2o_wave/ui.py
@@ -1978,6 +1978,7 @@ def stats(
         items: List[Stat],
         justify: Optional[str] = None,
         inset: Optional[bool] = None,
+        visible: Optional[bool] = None,
 ) -> Component:
     """Create a set of stats laid out horizontally.
 
@@ -1985,6 +1986,7 @@ def stats(
         items: The individual stats to be displayed.
         justify: Specifies how to lay out the individual stats. Defaults to 'start'. One of 'start', 'end', 'center', 'between', 'around'. See enum h2o_wave.ui.StatsJustify.
         inset: Whether to display the stats with a contrasting background.
+        visible: True if the component should be visible. Defaults to true.
     Returns:
         A `h2o_wave.types.Stats` instance.
     """
@@ -1992,6 +1994,7 @@ def stats(
         items,
         justify,
         inset,
+        visible,
     ))
 
 
@@ -2021,6 +2024,7 @@ def image(
         type: Optional[str] = None,
         image: Optional[str] = None,
         path: Optional[str] = None,
+        visible: Optional[bool] = None,
 ) -> Component:
     """Create an image.
 
@@ -2029,6 +2033,7 @@ def image(
         type: The image MIME subtype. One of `apng`, `bmp`, `gif`, `x-icon`, `jpeg`, `png`, `webp`. Required only if `image` is set.
         image: Image data, base64-encoded.
         path: The path or URL or data URL of the image, e.g. `/foo.png` or `http://example.com/foo.png` or `data:image/png;base64,???`.
+        visible: True if the component should be visible. Defaults to true.
     Returns:
         A `h2o_wave.types.Image` instance.
     """
@@ -2037,6 +2042,7 @@ def image(
         type,
         image,
         path,
+        visible,
     ))
 
 

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -2302,19 +2302,23 @@ ui_stat <- function(
 #' @param justify Specifies how to lay out the individual stats. Defaults to 'start'.
 #'   One of 'start', 'end', 'center', 'between', 'around'. See enum h2o_wave.ui.StatsJustify.
 #' @param inset Whether to display the stats with a contrasting background.
+#' @param visible True if the component should be visible. Defaults to true.
 #' @return A Stats instance.
 #' @export
 ui_stats <- function(
   items,
   justify = NULL,
-  inset = NULL) {
+  inset = NULL,
+  visible = NULL) {
   .guard_vector("items", "WaveStat", items)
   # TODO Validate justify
   .guard_scalar("inset", "logical", inset)
+  .guard_scalar("visible", "logical", visible)
   .o <- list(stats=list(
     items=items,
     justify=justify,
-    inset=inset))
+    inset=inset,
+    visible=visible))
   class(.o) <- append(class(.o), c(.wave_obj, "WaveComponent"))
   return(.o)
 }
@@ -2348,22 +2352,26 @@ ui_inline <- function(
 #' @param type The image MIME subtype. One of `apng`, `bmp`, `gif`, `x-icon`, `jpeg`, `png`, `webp`. Required only if `image` is set.
 #' @param image Image data, base64-encoded.
 #' @param path The path or URL or data URL of the image, e.g. `/foo.png` or `http://example.com/foo.png` or `data:image/png;base64,???`.
+#' @param visible True if the component should be visible. Defaults to true.
 #' @return A Image instance.
 #' @export
 ui_image <- function(
   title,
   type = NULL,
   image = NULL,
-  path = NULL) {
+  path = NULL,
+  visible = NULL) {
   .guard_scalar("title", "character", title)
   .guard_scalar("type", "character", type)
   .guard_scalar("image", "character", image)
   .guard_scalar("path", "character", path)
+  .guard_scalar("visible", "logical", visible)
   .o <- list(image=list(
     title=title,
     type=type,
     image=image,
-    path=path))
+    path=path,
+    visible=visible))
   class(.o) <- append(class(.o), c(.wave_obj, "WaveComponent"))
   return(.o)
 }

--- a/ui/src/button.test.tsx
+++ b/ui/src/button.test.tsx
@@ -14,7 +14,7 @@
 
 import { fireEvent, render } from '@testing-library/react'
 import React from 'react'
-import { Buttons, XButtons, XStandAloneButton } from './button'
+import { Buttons, XButtons } from './button'
 import { wave } from './ui'
 
 const name = 'test-btn'
@@ -41,18 +41,6 @@ describe('Button.tsx', () => {
   it('Renders data-test attr for Button', () => {
     const { queryByTestId } = render(<XButtons model={btnProps} />)
     expect(queryByTestId(name)).toBeInTheDocument()
-  })
-
-  it('Does not display buttons when visible set to false', () => {
-    const { queryByTestId } = render(<XButtons model={{ ...btnProps, visible: false }} />)
-    expect(queryByTestId(name)).toBeInTheDocument()
-    expect(queryByTestId(name)).not.toBeVisible()
-  })
-
-  it('Does not display standalone button when visible set to false', () => {
-    const { queryByTestId } = render(<XStandAloneButton model={{ ...btnProps.items[0].button!, visible: false }} />)
-    expect(queryByTestId(name)).toBeInTheDocument()
-    expect(queryByTestId(name)).not.toBeVisible()
   })
 
   it('Calls sync() after click', () => {

--- a/ui/src/button.tsx
+++ b/ui/src/button.tsx
@@ -17,7 +17,6 @@ import { B, Dict, Id, S } from 'h2o-wave'
 import React from 'react'
 import { stylesheet } from 'typestyle'
 import { Component } from './form'
-import { displayMixin } from './theme'
 import { XToolTip } from './tooltip'
 import { bond, wave } from './ui'
 
@@ -102,10 +101,12 @@ const
         wave.push()
       },
       render = () => {
+        // HACK: Our visibility logic in XComponents doesn't count with nested components, e.g. Butttons > Button.
+        const styles: Fluent.IButtonStyles = { root: (m as any).visible ?? true ? {} : { display: 'none' } }
         if (m.link) {
-          return <Fluent.Link data-test={m.name} disabled={m.disabled} onClick={onClick}>{m.label}</Fluent.Link>
+          return <Fluent.Link data-test={m.name} disabled={m.disabled} onClick={onClick} styles={styles}>{m.label}</Fluent.Link>
         }
-        const btnProps: Fluent.IButtonProps = { text: m.label, disabled: m.disabled, onClick, iconProps: { iconName: m.icon } }
+        const btnProps: Fluent.IButtonProps = { text: m.label, disabled: m.disabled, onClick, styles, iconProps: { iconName: m.icon } }
         return m.caption?.length
           ? m.primary
             ? <Fluent.CompoundButton {...btnProps} data-test={m.name} primary secondaryText={m.caption} />
@@ -125,13 +126,13 @@ export const
         </XToolTip>
       ))
     return (
-      <div data-test={m.name} className={css.buttons} style={displayMixin(m.visible)}>
+      <div data-test={m.name} className={css.buttons}>
         <Fluent.Stack horizontal horizontalAlign={justifications[m.justify || '']} tokens={{ childrenGap: 10 }}>{children}</Fluent.Stack>
       </div>
     )
   },
   XStandAloneButton = ({ model: m }: { model: Button }) => (
-    <div className={css.buttons} style={displayMixin(m.visible)}>
+    <div className={css.buttons}>
       <XButton key={m.name} model={m}>{m.label}</XButton>
     </div>
   )

--- a/ui/src/button.tsx
+++ b/ui/src/button.tsx
@@ -89,31 +89,31 @@ const
   }
 
 const
-  XButton = bond(({ model: m }: { model: Button }) => {
-    wave.args[m.name] = false
+  XButton = bond(({ model: { name, visible = true, link, label, disabled, icon, caption, value, primary } }: { model: Button }) => {
+    wave.args[name] = false
     const
       onClick = () => {
-        if (m.name.startsWith('#')) {
-          window.location.hash = m.name.substr(1)
+        if (name.startsWith('#')) {
+          window.location.hash = name.substr(1)
           return
         }
-        wave.args[m.name] = m.value === undefined || m.value
+        wave.args[name] = value === undefined || value
         wave.push()
       },
       render = () => {
         // HACK: Our visibility logic in XComponents doesn't count with nested components, e.g. Butttons > Button.
-        const styles: Fluent.IButtonStyles = { root: (m as any).visible ?? true ? {} : { display: 'none' } }
-        if (m.link) {
-          return <Fluent.Link data-test={m.name} disabled={m.disabled} onClick={onClick} styles={styles}>{m.label}</Fluent.Link>
+        const styles: Fluent.IButtonStyles = { root: visible ? {} : { display: 'none' } }
+        if (link) {
+          return <Fluent.Link data-test={name} disabled={disabled} onClick={onClick} styles={styles}>{label}</Fluent.Link>
         }
-        const btnProps: Fluent.IButtonProps = { text: m.label, disabled: m.disabled, onClick, styles, iconProps: { iconName: m.icon } }
-        return m.caption?.length
-          ? m.primary
-            ? <Fluent.CompoundButton {...btnProps} data-test={m.name} primary secondaryText={m.caption} />
-            : <Fluent.CompoundButton {...btnProps} data-test={m.name} secondaryText={m.caption} />
-          : m.primary
-            ? <Fluent.PrimaryButton {...btnProps} data-test={m.name} />
-            : <Fluent.DefaultButton {...btnProps} data-test={m.name} />
+        const btnProps: Fluent.IButtonProps = { text: label, disabled, onClick, styles, iconProps: { iconName: icon } }
+        return caption?.length
+          ? primary
+            ? <Fluent.CompoundButton {...btnProps} data-test={name} primary secondaryText={caption} />
+            : <Fluent.CompoundButton {...btnProps} data-test={name} secondaryText={caption} />
+          : primary
+            ? <Fluent.PrimaryButton {...btnProps} data-test={name} />
+            : <Fluent.DefaultButton {...btnProps} data-test={name} />
       }
     return { render }
   })

--- a/ui/src/checkbox.tsx
+++ b/ui/src/checkbox.tsx
@@ -15,7 +15,6 @@
 import * as Fluent from '@fluentui/react'
 import { B, Id, S } from 'h2o-wave'
 import React from 'react'
-import { displayMixin } from './theme'
 import { bond, wave } from './ui'
 
 /**
@@ -64,7 +63,6 @@ export const
       render = () => (
         <Fluent.Checkbox
           data-test={m.name}
-          style={displayMixin(m.visible)}
           inputProps={{ 'data-test': m.name } as any} // HACK: data-test does not work on root as of this version
           label={m.label}
           defaultIndeterminate={m.indeterminate}

--- a/ui/src/checklist.test.tsx
+++ b/ui/src/checklist.test.tsx
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { initializeIcons } from '@fluentui/react'
 import { fireEvent, render } from '@testing-library/react'
 import React from 'react'
 import { Checklist, XChecklist } from './checklist'
@@ -21,7 +20,6 @@ import { wave } from './ui'
 const name = 'checklist'
 const checklistProps: Checklist = { name, choices: [{ name: 'Choice1' }, { name: 'Choice2' }, { name: 'Choice3' },] }
 describe('Checklist.tsx', () => {
-  beforeAll(() => initializeIcons())
   beforeEach(() => {
     jest.clearAllMocks()
     wave.args[name] = null
@@ -30,12 +28,6 @@ describe('Checklist.tsx', () => {
   it('Renders data-test attr', () => {
     const { queryByTestId } = render(<XChecklist model={checklistProps} />)
     expect(queryByTestId(name)).toBeInTheDocument()
-  })
-
-  it('Does not display checklist when visible is false', () => {
-    const { queryByTestId } = render(<XChecklist model={{ ...checklistProps, visible: false }} />)
-    expect(queryByTestId(name)).toBeInTheDocument()
-    expect(queryByTestId(name)).not.toBeVisible()
   })
 
   it('Sets args - single selection', () => {

--- a/ui/src/checklist.tsx
+++ b/ui/src/checklist.tsx
@@ -17,7 +17,7 @@ import { B, box, Box, Id, on, S } from 'h2o-wave'
 import React from 'react'
 import { stylesheet } from 'typestyle'
 import { Choice } from './choice_group'
-import { displayMixin, margin } from './theme'
+import { margin } from './theme'
 import { bond, wave } from './ui'
 
 /**
@@ -104,7 +104,7 @@ export const
             <XChecklistItem name={`checkbox-${i + 1}`} key={i} label={choice.label || choice.name} disabled={!!choice.disabled} selectedB={selectedB} />
           ))
         return (
-          <div data-test={m.name} style={displayMixin(m.visible)}>
+          <div data-test={m.name}>
             <Fluent.Label>{m.label}</Fluent.Label>
             <div className={css.toolbar}>
               <Fluent.Text variant='small'>

--- a/ui/src/choice_group.test.tsx
+++ b/ui/src/choice_group.test.tsx
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { initializeIcons } from '@fluentui/react'
 import { fireEvent, render } from '@testing-library/react'
 import React from 'react'
 import { ChoiceGroup, XChoiceGroup } from './choice_group'
@@ -21,18 +20,11 @@ import { wave } from './ui'
 const name = 'choiceGroup'
 const choiceGroupProps: ChoiceGroup = { name, choices: [{ name: 'Choice1' }, { name: 'Choice2' }, { name: 'Choice3' },] }
 describe('ChoiceGroup.tsx', () => {
-  beforeAll(() => initializeIcons())
   beforeEach(() => { wave.args[name] = null })
 
   it('Renders data-test attr', () => {
     const { queryByTestId } = render(<XChoiceGroup model={choiceGroupProps} />)
     expect(queryByTestId(name)).toBeInTheDocument()
-  })
-
-  it('Does not display choice group when visible is false', () => {
-    const { queryByTestId } = render(<XChoiceGroup model={{ ...choiceGroupProps, visible: false }} />)
-    expect(queryByTestId(name)).toBeInTheDocument()
-    expect(queryByTestId(name)).not.toBeVisible()
   })
 
   it('Sets args - single selection', () => {

--- a/ui/src/choice_group.tsx
+++ b/ui/src/choice_group.tsx
@@ -15,7 +15,6 @@
 import * as Fluent from '@fluentui/react'
 import { B, Id, S } from 'h2o-wave'
 import React from 'react'
-import { displayMixin } from './theme'
 import { bond, wave } from './ui'
 
 /**
@@ -73,7 +72,6 @@ export const
       render = () => (
         <Fluent.ChoiceGroup
           data-test={m.name}
-          style={displayMixin(m.visible)}
           label={m.label}
           required={m.required}
           defaultSelectedKey={m.value}

--- a/ui/src/color_picker.test.tsx
+++ b/ui/src/color_picker.test.tsx
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { initializeIcons } from '@fluentui/react'
 import { fireEvent, render } from '@testing-library/react'
 import React from 'react'
 import { ColorPicker, XColorPicker } from './color_picker'
@@ -21,18 +20,11 @@ import { wave } from './ui'
 const name = 'colorPicker'
 const colorPickerProps: ColorPicker = { name }
 describe('ColorPicker.tsx', () => {
-  beforeAll(() => initializeIcons())
   beforeEach(() => { wave.args[name] = null })
 
   it('Renders data-test attr', () => {
     const { queryByTestId } = render(<XColorPicker model={colorPickerProps} />)
     expect(queryByTestId(name)).toBeInTheDocument()
-  })
-
-  it('Does not display color picker when visible is false', () => {
-    const { queryByTestId } = render(<XColorPicker model={{ ...colorPickerProps, visible: false }} />)
-    expect(queryByTestId(name)).toBeInTheDocument()
-    expect(queryByTestId(name)).not.toBeVisible()
   })
 
   it('Sets args - init - value not specified', () => {

--- a/ui/src/color_picker.tsx
+++ b/ui/src/color_picker.tsx
@@ -15,7 +15,6 @@
 import * as Fluent from '@fluentui/react'
 import { B, Id, S } from 'h2o-wave'
 import React from 'react'
-import { displayMixin } from './theme'
 import { bond, wave } from './ui'
 
 /**
@@ -59,7 +58,7 @@ export const
         if (m.trigger) wave.push()
       },
       render = () => (
-        <div data-test={m.name} style={displayMixin(m.visible)}>
+        <div data-test={m.name}>
           <Fluent.Label>{m.label}</Fluent.Label>
           {
             m.choices?.length

--- a/ui/src/combobox.test.tsx
+++ b/ui/src/combobox.test.tsx
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { initializeIcons } from '@fluentui/react'
 import { fireEvent, render } from '@testing-library/react'
 import React from 'react'
 import { Combobox, XCombobox } from './combobox'
@@ -21,18 +20,11 @@ import { wave } from './ui'
 const name = 'combobox'
 const comboboxProps: Combobox = { name }
 describe('Combobox.tsx', () => {
-  beforeAll(() => initializeIcons())
   beforeEach(() => { wave.args[name] = null })
 
   it('Renders data-test attr', () => {
     const { queryByTestId } = render(<XCombobox model={comboboxProps} />)
     expect(queryByTestId(name)).toBeInTheDocument()
-  })
-
-  it('Does not display combobox when visible is false', () => {
-    const { queryByTestId } = render(<XCombobox model={{ ...comboboxProps, visible: false }} />)
-    expect(queryByTestId(name)).toBeInTheDocument()
-    expect(queryByTestId(name)).not.toBeVisible()
   })
 
   it('Sets args - init - value not specified', () => {

--- a/ui/src/combobox.tsx
+++ b/ui/src/combobox.tsx
@@ -15,7 +15,6 @@
 import * as Fluent from '@fluentui/react'
 import { B, box, Id, S } from 'h2o-wave'
 import React from 'react'
-import { displayMixin } from './theme'
 import { bond, wave } from './ui'
 
 /**
@@ -67,7 +66,6 @@ export const
       render = () => (
         <Fluent.ComboBox
           data-test={m.name}
-          style={displayMixin(m.visible)}
           label={m.label}
           placeholder={m.placeholder}
           options={options}

--- a/ui/src/date_picker.test.tsx
+++ b/ui/src/date_picker.test.tsx
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { initializeIcons } from '@fluentui/react'
 import { fireEvent, render } from '@testing-library/react'
 import React from 'react'
 import { DatePicker, XDatePicker } from './date_picker'
@@ -21,18 +20,11 @@ import { wave } from './ui'
 const name = 'datepicker'
 const datepickerProps: DatePicker = { name }
 describe('Datepicker.tsx', () => {
-  beforeAll(() => initializeIcons())
   beforeEach(() => { wave.args[name] = null })
 
   it('Renders data-test attr', () => {
     const { queryByTestId } = render(<XDatePicker model={datepickerProps} />)
     expect(queryByTestId(name)).toBeInTheDocument()
-  })
-
-  it('Does not display date picker when visible is false', () => {
-    const { queryByTestId } = render(<XDatePicker model={{ ...datepickerProps, visible: false }} />)
-    expect(queryByTestId(name)).toBeInTheDocument()
-    expect(queryByTestId(name)).not.toBeVisible()
   })
 
   it('Sets args - init - value not specified', () => {

--- a/ui/src/date_picker.tsx
+++ b/ui/src/date_picker.tsx
@@ -15,7 +15,6 @@
 import * as Fluent from '@fluentui/react'
 import { B, Id, S, U } from 'h2o-wave'
 import React from 'react'
-import { displayMixin } from './theme'
 import { bond, wave } from './ui'
 
 /**
@@ -69,7 +68,6 @@ export const
       render = () => (
         <Fluent.DatePicker
           data-test={m.name}
-          style={displayMixin(m.visible)}
           label={m.label}
           value={parseDate(value)}
           placeholder={m.placeholder}

--- a/ui/src/dialog.test.tsx
+++ b/ui/src/dialog.test.tsx
@@ -16,7 +16,6 @@ import { fireEvent, render, wait } from '@testing-library/react'
 import React from 'react'
 import Dialog, { dialogB } from './dialog'
 
-
 const
   name = 'dialog',
   dialogProps = {

--- a/ui/src/dropdown.test.tsx
+++ b/ui/src/dropdown.test.tsx
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { initializeIcons } from '@fluentui/react'
 import { fireEvent, render } from '@testing-library/react'
 import React from 'react'
 import { Dropdown, XDropdown } from './dropdown'
@@ -31,17 +30,9 @@ const defaultProps: Dropdown = {
 }
 describe('Dropdown.tsx', () => {
 
-  beforeAll(() => initializeIcons())
-
   it('Renders data-test attr', () => {
     const { queryByTestId } = render(<XDropdown model={defaultProps} />)
     expect(queryByTestId(name)).toBeInTheDocument()
-  })
-
-  it('Does not display dropdown when visible is false', () => {
-    const { queryByTestId } = render(<XDropdown model={{ ...defaultProps, visible: false }} />)
-    expect(queryByTestId(name)).toBeInTheDocument()
-    expect(queryByTestId(name)).not.toBeVisible()
   })
 
   it('Calls qd.sync() when trigger is on', () => {

--- a/ui/src/dropdown.tsx
+++ b/ui/src/dropdown.tsx
@@ -16,7 +16,6 @@ import * as Fluent from '@fluentui/react'
 import { B, box, Id, S } from 'h2o-wave'
 import React from 'react'
 import { Choice } from './choice_group'
-import { displayMixin } from './theme'
 import { bond, wave } from './ui'
 
 /**
@@ -108,7 +107,7 @@ export const
         onChange()
       },
       render = () =>
-        <div style={displayMixin(m.visible)}>
+        <>
           <Fluent.Dropdown
             data-test={m.name}
             label={m.label}
@@ -129,7 +128,7 @@ export const
               </Fluent.Text>
             </div>
           }
-        </div>
+        </>
 
     return { render, selectedOptionsB }
   })

--- a/ui/src/expander.test.tsx
+++ b/ui/src/expander.test.tsx
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { initializeIcons } from '@fluentui/react'
 import { fireEvent, render } from '@testing-library/react'
 import React from 'react'
 import { Expander, XExpander } from './expander'
@@ -21,18 +20,11 @@ import { wave } from './ui'
 const name = 'expander'
 const expanderProps: Expander = { name }
 describe('Expander.tsx', () => {
-  beforeAll(() => initializeIcons())
   beforeEach(() => { wave.args[name] = null })
 
   it('Renders data-test attr', () => {
     const { queryByTestId } = render(<XExpander model={expanderProps} />)
     expect(queryByTestId(name)).toBeInTheDocument()
-  })
-
-  it('Does not display expander when visible is false', () => {
-    const { queryByTestId } = render(<XExpander model={{ ...expanderProps, visible: false }} />)
-    expect(queryByTestId(name)).toBeInTheDocument()
-    expect(queryByTestId(name)).not.toBeVisible()
   })
 
   it('Sets args - init - null', () => {

--- a/ui/src/expander.tsx
+++ b/ui/src/expander.tsx
@@ -17,7 +17,6 @@ import { B, box, Id, S } from 'h2o-wave'
 import React from 'react'
 import { stylesheet } from 'typestyle'
 import { Component, XComponents } from './form'
-import { displayMixin } from './theme'
 import { bond, wave } from './ui'
 
 /**
@@ -76,7 +75,7 @@ export const
           className = isOpenB() ? css.expanderOpen : css.expanderClosed
 
         return (
-          <div data-test={m.name} className={className} style={displayMixin(m.visible)}>
+          <div data-test={m.name} className={className}>
             <Fluent.Separator alignContent="start" styles={{ content: { paddingLeft: 0 } }}>
               <Fluent.ActionButton
                 title={actionTitle}

--- a/ui/src/file_upload.test.tsx
+++ b/ui/src/file_upload.test.tsx
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { initializeIcons } from '@fluentui/react'
 import { createEvent, fireEvent, render, wait } from '@testing-library/react'
 import * as T from 'h2o-wave'
 import React from 'react'
@@ -24,7 +23,6 @@ const fileUploadProps: FileUpload = { name }
 interface FileObj { name: T.S; size?: T.F }
 
 describe('FileUpload.tsx', () => {
-  beforeAll(() => initializeIcons())
   beforeEach(() => {
     jest.clearAllMocks()
     wave.args[name] = null
@@ -49,12 +47,6 @@ describe('FileUpload.tsx', () => {
   it('Renders data-test attr', () => {
     const { queryByTestId } = render(<XFileUpload model={fileUploadProps} />)
     expect(queryByTestId(name)).toBeInTheDocument()
-  })
-
-  it('Does not display file upload when visible is false', () => {
-    const { queryByTestId } = render(<XFileUpload model={{ ...fileUploadProps, visible: false }} />)
-    expect(queryByTestId(name)).toBeInTheDocument()
-    expect(queryByTestId(name)).not.toBeVisible()
   })
 
   it('Shows dragging screen on dragging', () => {

--- a/ui/src/file_upload.tsx
+++ b/ui/src/file_upload.tsx
@@ -16,7 +16,7 @@ import * as Fluent from '@fluentui/react'
 import { B, box, F, Id, S, U, xid } from 'h2o-wave'
 import React from 'react'
 import { stylesheet } from 'typestyle'
-import { centerMixin, clas, dashed, displayMixin, padding } from './theme'
+import { centerMixin, clas, dashed, padding } from './theme'
 import { bond, wave } from './ui'
 
 /**
@@ -282,7 +282,7 @@ export const
       render = () => {
         const uploadClasses = isDraggingB() && !errorB() && !successMsgB() ? clas(css.upload, css.uploadDragging) : css.upload
         return (
-          <div style={displayMixin(model.visible)}>
+          <>
             <form
               className={uploadClasses}
               style={{ height: model.height || 300 }}
@@ -299,7 +299,7 @@ export const
               disabled={!!percentCompleteB() || !filesB().length}
               text={model.label || 'Upload'}
               onClick={upload} />
-          </div>
+          </>
         )
       }
 

--- a/ui/src/form.test.tsx
+++ b/ui/src/form.test.tsx
@@ -15,6 +15,7 @@
 import { render } from '@testing-library/react'
 import * as T from 'h2o-wave'
 import React from 'react'
+import { Button, Buttons } from './button'
 import { View } from './form'
 
 const
@@ -30,5 +31,29 @@ describe('Form.tsx', () => {
   it('Renders data-test attr', () => {
     const { queryByTestId } = render(<View {...formProps} />)
     expect(queryByTestId(name)).toBeInTheDocument()
+  })
+
+  it('Hides a button component', () => {
+    const
+      button: Button = { name: 'btn', visible: false },
+      _formProps = { ...formProps, state: { items: [{ button }] } },
+      { queryByTestId } = render(<View {..._formProps} />)
+    expect(queryByTestId('btn')).not.toBeVisible()
+  })
+
+  it('Hides a button component within buttons', () => {
+    const
+      buttons: Buttons = { items: [{ button: { name: 'btn', visible: false } }] },
+      _formProps = { ...formProps, state: { items: [{ buttons }] } },
+      { queryByTestId } = render(<View {..._formProps} />)
+    expect(queryByTestId('btn')).not.toBeVisible()
+  })
+
+  it('Hides a button component within inline', () => {
+    const
+      inline = { items: [{ button: { name: 'btn', visible: false } }] },
+      _formProps = { ...formProps, state: { items: [{ inline }] } },
+      { queryByTestId } = render(<View {..._formProps} />)
+    expect(queryByTestId('btn')).not.toBeVisible()
   })
 })

--- a/ui/src/form.tsx
+++ b/ui/src/form.tsx
@@ -47,7 +47,7 @@ import { Tabs, XTabs } from './tabs'
 import { Template, XTemplate } from './template'
 import { Text, TextL, TextM, TextS, TextXl, TextXs, XText } from './text'
 import { Textbox, XTextbox } from './textbox'
-import { clas, cssVar, margin, padding } from './theme'
+import { clas, cssVar, padding } from './theme'
 import { Toggle, XToggle } from './toggle'
 import { XToolTip } from './tooltip'
 import { bond } from './ui'
@@ -164,7 +164,7 @@ const
       flexDirection: 'column',
       flexGrow: 1,
       $nest: {
-        '>*:not(:first-child)': {
+        '> [data-visible="true"] ~ div': {
           marginTop: 10
         },
       }
@@ -172,25 +172,18 @@ const
     horizontal: {
       display: 'flex',
       alignItems: 'center',
+      $nest: {
+        '> [data-visible="true"] ~ div': {
+          marginLeft: 25
+        }
+      }
     },
     inset: {
       background: cssVar('$page'),
       padding: padding(10, 15)
     },
-    horizontalLeft: {
-      $nest: {
-        '> *': {
-          margin: margin(0, 25, 0, 0),
-        }
-      }
-    },
     horizontalRight: {
       justifyContent: 'flex-end',
-      $nest: {
-        '> *': {
-          margin: margin(0, 0, 0, 25),
-        }
-      }
     },
   })
 
@@ -199,9 +192,20 @@ export enum XComponentAlignment { Top, Left, Right }
 export const
   XComponents = ({ items, alignment, inset }: { items: Component[], alignment?: XComponentAlignment, inset?: B }) => {
     const
-      components = items.map(m => <XComponent key={xid()} model={m} />),
+      components = items.map((m: any) => {
+        const
+          // All form items are wrapped by their component name (first and only prop of "m").
+          visible = m[Object.keys(m)[0]].visible ?? true,
+          visibleStyles: React.CSSProperties = visible ? {} : { display: 'none' }
+
+        return (
+          <div key={xid()} data-visible={visible} style={visibleStyles}>
+            <XComponent model={m} />
+          </div>
+        )
+      }),
       className = alignment === XComponentAlignment.Left
-        ? clas(css.horizontal, css.horizontalLeft, inset ? css.inset : '')
+        ? clas(css.horizontal, inset ? css.inset : '')
         : alignment === XComponentAlignment.Right
           ? clas(css.horizontal, css.horizontalRight, inset ? css.inset : '')
           : css.vertical
@@ -218,12 +222,12 @@ export const
 
 const
   XComponent = ({ model: m }: { model: Component }) => {
-    if (m.text) return <XToolTip content={m.text.tooltip} expand={false}><XText name={m.text.name} content={m.text.content} size={m.text.size} visibility={m.text.visible} /></XToolTip>
-    if (m.text_xl) return <XToolTip content={m.text_xl.tooltip} expand={false}><XText name={m.text_xl.name} content={m.text_xl.content} size='xl' commands={m.text_xl.commands} visibility={m.text_xl.visible} /></XToolTip>
-    if (m.text_l) return <XToolTip content={m.text_l.tooltip} expand={false}><XText name={m.text_l.name} content={m.text_l.content} size='l' commands={m.text_l.commands} visibility={m.text_l.visible} /></XToolTip>
-    if (m.text_m) return <XToolTip content={m.text_m.tooltip} expand={false}><XText name={m.text_m.name} content={m.text_m.content} visibility={m.text_m.visible} /></XToolTip>
-    if (m.text_s) return <XToolTip content={m.text_s.tooltip} expand={false}><XText name={m.text_s.name} content={m.text_s.content} size='s' visibility={m.text_s.visible} /></XToolTip>
-    if (m.text_xs) return <XToolTip content={m.text_xs.tooltip} expand={false}><XText name={m.text_xs.name} content={m.text_xs.content} size='xs' visibility={m.text_xs.visible} /></XToolTip>
+    if (m.text) return <XToolTip content={m.text.tooltip} expand={false}><XText name={m.text.name} content={m.text.content} size={m.text.size} /></XToolTip>
+    if (m.text_xl) return <XToolTip content={m.text_xl.tooltip} expand={false}><XText name={m.text_xl.name} content={m.text_xl.content} size='xl' commands={m.text_xl.commands} /></XToolTip>
+    if (m.text_l) return <XToolTip content={m.text_l.tooltip} expand={false}><XText name={m.text_l.name} content={m.text_l.content} size='l' commands={m.text_l.commands} /></XToolTip>
+    if (m.text_m) return <XToolTip content={m.text_m.tooltip} expand={false}><XText name={m.text_m.name} content={m.text_m.content} /></XToolTip>
+    if (m.text_s) return <XToolTip content={m.text_s.tooltip} expand={false}><XText name={m.text_s.name} content={m.text_s.content} size='s' /></XToolTip>
+    if (m.text_xs) return <XToolTip content={m.text_xs.tooltip} expand={false}><XText name={m.text_xs.name} content={m.text_xs.content} size='xs' /></XToolTip>
     if (m.label) return <XToolTip content={m.label.tooltip} expand={false}><XLabel model={m.label} /></XToolTip>
     if (m.link) return <XToolTip content={m.link.tooltip} expand={false}><XLink model={m.link} /></XToolTip>
     if (m.separator) return <XSeparator model={m.separator} />
@@ -280,4 +284,3 @@ export const
   })
 
 cards.register('form', View)
-

--- a/ui/src/frame.test.tsx
+++ b/ui/src/frame.test.tsx
@@ -37,12 +37,6 @@ describe('Frame.tsx', () => {
   describe('Form Frame', () => {
     const formFrameProps: Frame = { name }
 
-    it('Does not display form frame when visible is false', () => {
-      const { queryByTestId } = render(<XFrame model={{ ...formFrameProps, visible: false }} />)
-      expect(queryByTestId(name)).toBeInTheDocument()
-      expect(queryByTestId(name)).not.toBeVisible()
-    })
-
     it('Does not render data-test attr for XFrame', () => {
       const { container } = render(<XFrame model={{}} />)
       expect(container.querySelectorAll('[data-test]')).toHaveLength(0)

--- a/ui/src/frame.tsx
+++ b/ui/src/frame.tsx
@@ -16,7 +16,6 @@ import { B, Model, S, xid } from 'h2o-wave'
 import React from 'react'
 import { stylesheet } from 'typestyle'
 import { cards, grid } from './layout'
-import { displayMixin } from './theme'
 import { bond } from './ui'
 
 const
@@ -94,11 +93,12 @@ const
   )
 
 // HACK: Applying width/height styles directly on iframe don't work in Chrome/FF; so wrap in div instead.
-export const XFrame = ({ model: { name, path, content, width = '100%', height = '150px', visible } }: { model: Frame }) => (
-  <div data-test={name} style={{ width, height, ...displayMixin(visible) }}>
+export const XFrame = ({ model: { name, path, content, width = '100%', height = '150px' } }: { model: Frame }) => (
+  <div data-test={name} style={{ width, height }}>
     <InlineFrame path={path} content={content} />
   </div>
 )
+
 
 export const
   View = bond(({ name, state, changed }: Model<State>) => {

--- a/ui/src/image.tsx
+++ b/ui/src/image.tsx
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Model, Rec, S } from 'h2o-wave'
+import { B, Model, Rec, S } from 'h2o-wave'
 import React from 'react'
 import { stylesheet } from 'typestyle'
 import { cards, Format, grid } from './layout'
@@ -57,6 +57,8 @@ export interface Image {
   image?: S
   /** The path or URL or data URL of the image, e.g. `/foo.png` or `http://example.com/foo.png` or `data:image/png;base64,???`. */
   path?: S
+  /** True if the component should be visible. Defaults to true. */
+  visible?: B
 }
 
 export const

--- a/ui/src/label.test.tsx
+++ b/ui/src/label.test.tsx
@@ -33,9 +33,4 @@ describe('Label.tsx', () => {
     expect(queryByTestId(name)).toBeInTheDocument()
   })
 
-  it('Does not display label when visible is false', () => {
-    const { queryByTestId } = render(<XLabel model={{ ...labelProps, visible: false }} />)
-    expect(queryByTestId(name)).not.toBeVisible()
-  })
-
 })

--- a/ui/src/label.tsx
+++ b/ui/src/label.tsx
@@ -15,7 +15,6 @@
 import * as Fluent from '@fluentui/react'
 import { B, S } from 'h2o-wave'
 import React from 'react'
-import { displayMixin } from './theme'
 
 /**
  * Create a label.
@@ -43,13 +42,6 @@ export interface Label {
 
 export const
   XLabel = ({ model }: { model: Label }) => {
-    const { label, required = false, disabled = false, visible, name } = model
-    return (
-      <Fluent.Label
-        data-test={name}
-        style={displayMixin(visible)}
-        required={required}
-        disabled={disabled}
-      >{label}</Fluent.Label>
-    )
+    const { label, required = false, disabled = false, name } = model
+    return <Fluent.Label data-test={name} required={required} disabled={disabled} >{label}</Fluent.Label>
   }

--- a/ui/src/link.test.tsx
+++ b/ui/src/link.test.tsx
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { initializeIcons } from '@fluentui/react'
 import { fireEvent, render } from '@testing-library/react'
 import React from 'react'
 import { Link, XLink } from './link'
@@ -22,7 +21,6 @@ const
   linkProps: Link = { name, path: name }
 
 describe('Link.tsx', () => {
-  beforeAll(() => initializeIcons())
   beforeEach(() => { jest.clearAllMocks() })
 
   it('Does not render data-test attr', () => {
@@ -33,12 +31,6 @@ describe('Link.tsx', () => {
   it('Renders data-test attr', () => {
     const { queryByTestId } = render(<XLink model={linkProps} />)
     expect(queryByTestId(name)).toBeInTheDocument()
-  })
-
-  it('Does not display link when visible is false', () => {
-    const { queryByTestId } = render(<XLink model={{ ...linkProps, visible: false }} />)
-    expect(queryByTestId(name)).toBeInTheDocument()
-    expect(queryByTestId(name)).not.toBeVisible()
   })
 
   it('Sets default label when not specified', () => {

--- a/ui/src/link.tsx
+++ b/ui/src/link.tsx
@@ -15,7 +15,6 @@
 import * as Fluent from '@fluentui/react'
 import { B, S } from 'h2o-wave'
 import React from 'react'
-import { displayMixin } from './theme'
 import { bond } from './ui'
 
 /**
@@ -53,20 +52,16 @@ export const
       target = m.target === '' ? '_blank' : m.target,
       onClick = () => target ? window.open(m.path, target) : window.open(m.path),
       render = () => (
-        <div style={displayMixin(m.visible)}>
-          {
-            m.button
-              ? <Fluent.DefaultButton data-test={m.name} text={label} disabled={m.disabled} onClick={onClick} />
-              : <Fluent.Link
-                data-test={m.name}
-                href={m.path}
-                download={m.download}
-                disabled={m.disabled}
-                target={target}>
-                {label}
-              </Fluent.Link>
-          }
-        </div>
+        m.button
+          ? <Fluent.DefaultButton data-test={m.name} text={label} disabled={m.disabled} onClick={onClick} />
+          : <Fluent.Link
+            data-test={m.name}
+            href={m.path}
+            download={m.download}
+            disabled={m.disabled}
+            target={target}>
+            {label}
+          </Fluent.Link>
       )
     return { render }
   })

--- a/ui/src/markup.test.tsx
+++ b/ui/src/markup.test.tsx
@@ -47,9 +47,5 @@ describe('Markup.tsx', () => {
       expect(queryByTestId(name)).not.toBeInTheDocument()
     })
 
-    it('Does not display Markup when visible is false', () => {
-      const { queryByTestId } = render(<XMarkup model={{ ...formMarkupProps, visible: false }} />)
-      expect(queryByTestId(name)).not.toBeVisible()
-    })
   })
 })

--- a/ui/src/markup.tsx
+++ b/ui/src/markup.tsx
@@ -16,7 +16,6 @@ import { B, Model, S } from 'h2o-wave'
 import React from 'react'
 import { stylesheet } from 'typestyle'
 import { cards, grid } from './layout'
-import { displayMixin } from './theme'
 import { bond } from './ui'
 
 const
@@ -61,8 +60,8 @@ interface State {
 }
 
 export const
-  XMarkup = ({ model: { content, visible, name } }: { model: Markup }) => (
-    <div data-test={name} dangerouslySetInnerHTML={{ __html: content }} style={displayMixin(visible)} />
+  XMarkup = ({ model: { content, name } }: { model: Markup }) => (
+    <div data-test={name} dangerouslySetInnerHTML={{ __html: content }} />
   ),
   MarkupCard = ({ name, title, content }: { name: S, title: S, content: S }) => (
     <div data-test={name} className={css.card}>

--- a/ui/src/message_bar.test.tsx
+++ b/ui/src/message_bar.test.tsx
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { initializeIcons } from '@fluentui/react'
 import { render } from '@testing-library/react'
 import React from 'react'
 import { MessageBar, XMessageBar } from './message_bar'
@@ -22,7 +21,6 @@ const
   messagebarProps: MessageBar = { name, text: name }
 
 describe('MessageBar.tsx', () => {
-  beforeAll(() => initializeIcons())
 
   it('Does not render data-test attr', () => {
     const { container } = render(<XMessageBar model={{}} />)
@@ -34,9 +32,4 @@ describe('MessageBar.tsx', () => {
     expect(queryByTestId(name)).toBeInTheDocument()
   })
 
-  it('Does not display message bar when visible is false', () => {
-    const { queryByTestId } = render(<XMessageBar model={{ ...messagebarProps, visible: false }} />)
-    expect(queryByTestId(name)).toBeInTheDocument()
-    expect(queryByTestId(name)).not.toBeVisible()
-  })
 })

--- a/ui/src/message_bar.tsx
+++ b/ui/src/message_bar.tsx
@@ -15,7 +15,6 @@
 import * as Fluent from '@fluentui/react'
 import { B, S } from 'h2o-wave'
 import React from 'react'
-import { displayMixin } from './theme'
 
 /**
  * Create a message bar.
@@ -50,11 +49,6 @@ const
 export const
   XMessageBar = ({ model: m }: { model: MessageBar }) => (
     m.text?.length
-      ? (
-        <Fluent.MessageBar
-          data-test={m.name}
-          style={displayMixin(m.visible)}
-          messageBarType={toMessageBarType(m.type)} >{m.text}</Fluent.MessageBar>
-      )
+      ? <Fluent.MessageBar data-test={m.name} messageBarType={toMessageBarType(m.type)} >{m.text}</Fluent.MessageBar>
       : <div />
   )

--- a/ui/src/picker.test.tsx
+++ b/ui/src/picker.test.tsx
@@ -40,12 +40,6 @@ describe('Picker.tsx', () => {
     expect(queryByTestId(name)).toBeInTheDocument()
   })
 
-  it('Does not display picker when visible is false', () => {
-    const { queryByTestId } = render(<XPicker model={{ ...pickerProps, visible: false }} />)
-    expect(queryByTestId(name)).toBeInTheDocument()
-    expect(queryByTestId(name)).not.toBeVisible()
-  })
-
   it('Sets correct args - init', () => {
     render(<XPicker model={pickerProps} />)
     expect(wave.args[name]).toBeNull()

--- a/ui/src/picker.tsx
+++ b/ui/src/picker.tsx
@@ -16,7 +16,6 @@ import * as Fluent from '@fluentui/react'
 import { B, box, Id, S, U } from 'h2o-wave'
 import React from 'react'
 import { Choice } from './choice_group'
-import { displayMixin } from './theme'
 import { bond, wave } from './ui'
 
 /**
@@ -68,7 +67,7 @@ export const XPicker = bond(({ model: m }: { model: Picker }) => {
     onEmptyResolveSuggestions = () => tags,
     init = () => wave.args[m.name] = m.values || null,
     render = () => (
-      <div style={displayMixin(m.visible)}>
+      <>
         {m.label && <Fluent.Text>{m.label}</Fluent.Text>}
         <Fluent.TagPicker
           inputProps={{ 'data-test': m.name } as any} // HACK: data-test does not work on root as of this version
@@ -81,7 +80,7 @@ export const XPicker = bond(({ model: m }: { model: Picker }) => {
           disabled={m.disabled}
           onEmptyResolveSuggestions={onEmptyResolveSuggestions}
         />
-      </div>
+      </>
     )
 
   return { init, render, selectedTagsB }

--- a/ui/src/plot.test.tsx
+++ b/ui/src/plot.test.tsx
@@ -15,7 +15,7 @@
 import { render } from '@testing-library/react'
 import * as T from 'h2o-wave'
 import React from 'react'
-import { View, Visualization, XVisualization } from './plot'
+import { View } from './plot'
 
 const name = 'plot'
 
@@ -31,24 +31,6 @@ describe('Plot.tsx', () => {
     it('Renders data-test attr', () => {
       const { queryByTestId } = render(<View {...cardPlotProps} />)
       expect(queryByTestId(name)).toBeInTheDocument()
-    })
-  })
-
-  describe('Form Plot', () => {
-    const formPlotProps: Visualization = {
-      name,
-      data: [] as any,
-      plot: { marks: [] }
-    }
-
-    it('Renders data-test attr', () => {
-      const { queryByTestId } = render(<XVisualization model={{ ...formPlotProps, visible: false }} />)
-      expect(queryByTestId(name)).toBeInTheDocument()
-    })
-
-    it('Does not display form plot when visible is false', () => {
-      const { queryByTestId } = render(<XVisualization model={{ ...formPlotProps, visible: false }} />)
-      expect(queryByTestId(name)).not.toBeVisible()
     })
   })
 })

--- a/ui/src/plot.tsx
+++ b/ui/src/plot.tsx
@@ -19,7 +19,7 @@ import React from 'react'
 import { stylesheet } from 'typestyle'
 import { Fmt, parseFormat } from './intl'
 import { cards, grid } from './layout'
-import { cssVarValue, displayMixin } from './theme'
+import { cssVarValue } from './theme'
 import { bond, wave } from './ui'
 
 let
@@ -827,11 +827,11 @@ export const
       },
       render = () => {
         const
-          { width = 'auto', height = 'auto', visible, name } = model,
+          { width = 'auto', height = 'auto', name } = model,
           style: React.CSSProperties = (width === 'auto' && height === 'auto')
             ? { flexGrow: 1 }
             : { width, height }
-        return <div data-test={name} style={{ ...style, ...displayMixin(visible) }} className={css.plot} ref={container} />
+        return <div data-test={name} style={style} className={css.plot} ref={container} />
       }
     return { init, update, render }
   })

--- a/ui/src/progress.test.tsx
+++ b/ui/src/progress.test.tsx
@@ -33,8 +33,4 @@ describe('Progress.tsx', () => {
     expect(queryByTestId(name)).toBeInTheDocument()
   })
 
-  it('Does not display progress when visible is false', () => {
-    const { queryByTestId } = render(<XProgress model={{ ...progressProps, visible: false }} />)
-    expect(queryByTestId(name)).not.toBeVisible()
-  })
 })

--- a/ui/src/progress.tsx
+++ b/ui/src/progress.tsx
@@ -15,7 +15,6 @@
 import * as Fluent from '@fluentui/react'
 import { B, F, S } from 'h2o-wave'
 import React from 'react'
-import { displayMixin } from './theme'
 
 /**
  * Create a progress bar.
@@ -56,14 +55,10 @@ export interface Progress {
 export const
   XProgress = ({ model }: { model: Progress }) => {
     const
-      { label, caption = 'Please wait...', value, visible, name } = model
+      { label, caption = 'Please wait...', value, name } = model
     return (
-      <div data-test={name} style={displayMixin(visible)}>
-        <Fluent.ProgressIndicator
-          label={label}
-          description={caption}
-          percentComplete={value}
-        />
+      <div data-test={name}>
+        <Fluent.ProgressIndicator label={label} description={caption} percentComplete={value} />
       </div>
     )
   }

--- a/ui/src/range_slider.test.tsx
+++ b/ui/src/range_slider.test.tsx
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { initializeIcons } from '@fluentui/react'
 import { fireEvent, render } from '@testing-library/react'
 import React from 'react'
 import { RangeSlider, XRangeSlider } from './range_slider'
@@ -24,18 +23,11 @@ const defaultRect = { left: 0, top: 0, right: 0, bottom: 0, width: 100, height: 
 const mouseEvent = { clientX: 50, clientY: 0 }
 
 describe('rangeSlider.tsx', () => {
-  beforeAll(() => initializeIcons())
   beforeEach(() => { wave.args[name] = null })
 
   it('Renders data-test attr', () => {
     const { queryByTestId } = render(<XRangeSlider model={rangeSliderProps} />)
     expect(queryByTestId(name)).toBeInTheDocument()
-  })
-
-  it('Does not display range slider when visible is false', () => {
-    const { queryByTestId } = render(<XRangeSlider model={{ ...rangeSliderProps, visible: false }} />)
-    expect(queryByTestId(name)).toBeInTheDocument()
-    expect(queryByTestId(name)).not.toBeVisible()
   })
 
   it('Sets args - init', () => {

--- a/ui/src/range_slider.tsx
+++ b/ui/src/range_slider.tsx
@@ -18,7 +18,7 @@ import React from 'react'
 import InputRange, { Range } from 'react-input-range'
 import 'react-input-range/lib/css/index.css'
 import { stylesheet } from 'typestyle'
-import { displayMixin, padding } from './theme'
+import { padding } from './theme'
 import { bond, wave } from './ui'
 
 const
@@ -150,7 +150,7 @@ export const XRangeSlider = bond(({ model: m }: { model: RangeSlider }) => {
       if (m.trigger) wave.push()
     },
     render = () => (
-      <div data-test={m.name} style={displayMixin(m.visible)}>
+      <div data-test={m.name}>
         {m.label && <Fluent.Label disabled={m.disabled}>{m.label}</Fluent.Label>}
         <div className={`${css.container} ${m.disabled ? css.disabled : ''}`}>
           <InputRange maxValue={max} minValue={min} step={step} disabled={m.disabled} allowSameValues value={valueB()} onChange={onChange} />

--- a/ui/src/separator.test.tsx
+++ b/ui/src/separator.test.tsx
@@ -32,9 +32,4 @@ describe('Separator.tsx', () => {
     expect(queryByTestId(name)).toBeInTheDocument()
   })
 
-  it('Does not display separator when visible is false', () => {
-    const { queryByTestId } = render(<XSeparator model={{ ...separatorProps, visible: false }} />)
-    expect(queryByTestId(name)).toBeInTheDocument()
-    expect(queryByTestId(name)).not.toBeVisible()
-  })
 })

--- a/ui/src/separator.tsx
+++ b/ui/src/separator.tsx
@@ -16,7 +16,6 @@ import * as Fluent from '@fluentui/react'
 import { B, S } from 'h2o-wave'
 import React from 'react'
 import { stylesheet } from 'typestyle'
-import { displayMixin } from './theme'
 
 const
   css = stylesheet({
@@ -41,7 +40,7 @@ export interface Separator {
 
 export const
   XSeparator = ({ model: m }: { model: Separator }) => (
-    <div data-test={m.name} className={css.separator} style={displayMixin(m.visible)}>
+    <div data-test={m.name} className={css.separator}>
       <Fluent.Separator>{m.label}</Fluent.Separator>
     </div>
   )

--- a/ui/src/slider.test.tsx
+++ b/ui/src/slider.test.tsx
@@ -32,12 +32,6 @@ describe('Slider.tsx', () => {
     expect(queryByTestId(name)).toBeInTheDocument()
   })
 
-  it('Does not display slider when visible is false', () => {
-    const { queryByTestId } = render(<XSlider model={{ ...sliderProps, visible: false }} />)
-    expect(queryByTestId(name)).toBeInTheDocument()
-    expect(queryByTestId(name)).not.toBeVisible()
-  })
-
   it('Sets args - init', () => {
     render(<XSlider model={sliderProps} />)
     expect(wave.args[name]).toBe(0)

--- a/ui/src/slider.tsx
+++ b/ui/src/slider.tsx
@@ -15,7 +15,6 @@
 import * as Fluent from '@fluentui/react'
 import { B, F, Id, S } from 'h2o-wave'
 import React from 'react'
-import { displayMixin } from './theme'
 import { bond, wave } from './ui'
 
 /**
@@ -69,7 +68,6 @@ export const
       render = () => (
         <Fluent.Slider
           data-test={m.name}
-          styles={{ root: displayMixin(m.visible) as Fluent.IStyle }}
           buttonProps={{ 'data-test': m.name } as any} // HACK: data-test does not work on root as of this version
           label={m.label}
           min={min}

--- a/ui/src/spinbox.test.tsx
+++ b/ui/src/spinbox.test.tsx
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { initializeIcons } from '@fluentui/react'
 import { fireEvent, render } from '@testing-library/react'
 import React from 'react'
 import { Spinbox, XSpinbox } from './spinbox'
@@ -23,18 +22,11 @@ const spinboxProps: Spinbox = { name }
 
 const mouseEvent = { clientX: 0, clientY: 0 }
 describe('Spinbox.tsx', () => {
-  beforeAll(() => initializeIcons())
   beforeEach(() => { wave.args[name] = null })
 
   it('Renders data-test attr', () => {
     const { queryByTestId } = render(<XSpinbox model={spinboxProps} />)
     expect(queryByTestId(name)).toBeInTheDocument()
-  })
-
-  it('Does not display spinbox when visible is false', () => {
-    const { queryByTestId } = render(<XSpinbox model={{ ...spinboxProps, visible: false }} />)
-    expect(queryByTestId(name)).toBeInTheDocument()
-    expect(queryByTestId(name)).not.toBeVisible()
   })
 
   it('Sets args - init', () => {

--- a/ui/src/spinbox.tsx
+++ b/ui/src/spinbox.tsx
@@ -15,7 +15,6 @@
 import * as Fluent from '@fluentui/react'
 import { B, F, Id, S } from 'h2o-wave'
 import React from 'react'
-import { displayMixin } from './theme'
 import { bond, wave } from './ui'
 
 /**
@@ -77,7 +76,6 @@ export const
       },
       render = () => (
         <Fluent.SpinButton
-          styles={{ root: displayMixin(m.visible) as Fluent.IStyle }}
           inputProps={{ 'data-test': m.name } as any} // HACK: data-test does not work on root as of this version
           label={m.label}
           min={min}

--- a/ui/src/stats.tsx
+++ b/ui/src/stats.tsx
@@ -26,6 +26,8 @@ export interface Stats {
   justify?: 'start' | 'end' | 'center' | 'between' | 'around'
   /** Whether to display the stats with a contrasting background. */
   inset?: B
+  /** True if the component should be visible. Defaults to true. */
+  visible?: B
 }
 
 /** Create a stat (a label-value pair) for displaying a metric. */

--- a/ui/src/stepper.test.tsx
+++ b/ui/src/stepper.test.tsx
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { initializeIcons } from '@fluentui/react'
 import { render } from '@testing-library/react'
 import React from 'react'
 import { Stepper, XStepper } from './stepper'
@@ -21,7 +20,6 @@ let stepperProps: Stepper
 const name = 'stepper'
 
 describe('Stepper.tsx', () => {
-  beforeAll(() => initializeIcons())
   beforeEach(() => {
     stepperProps = {
       name,
@@ -36,11 +34,6 @@ describe('Stepper.tsx', () => {
   it('Renders data-test attr', () => {
     const { queryByTestId } = render(<XStepper model={stepperProps} />)
     expect(queryByTestId(name)).toBeInTheDocument()
-  })
-
-  it('Does not display stepper when visible is false', () => {
-    const { queryByTestId } = render(<XStepper model={{ ...stepperProps, visible: false }} />)
-    expect(queryByTestId(name)).not.toBeVisible()
   })
 
   it('Renders step numbers by default', () => {

--- a/ui/src/stepper.tsx
+++ b/ui/src/stepper.tsx
@@ -16,7 +16,7 @@ import * as Fluent from '@fluentui/react'
 import { B, Id, S, U } from 'h2o-wave'
 import React from 'react'
 import { stylesheet } from 'typestyle'
-import { displayMixin, rem } from './theme'
+import { rem } from './theme'
 import { bond } from './ui'
 
 /**
@@ -94,7 +94,6 @@ export const
       ),
       render = () => (
         <Fluent.Stack
-          style={displayMixin(m.visible)}
           data-test={m.name}
           horizontal
           horizontalAlign='space-between'

--- a/ui/src/table.test.tsx
+++ b/ui/src/table.test.tsx
@@ -48,12 +48,6 @@ describe('Table.tsx', () => {
     expect(queryByTestId(name)).toBeInTheDocument()
   })
 
-  it('Does not display table when visible is false', () => {
-    const { queryByTestId } = render(<XTable model={{ ...tableProps, visible: false }} />)
-    expect(queryByTestId(name)).toBeInTheDocument()
-    expect(queryByTestId(name)).not.toBeVisible()
-  })
-
   it('Renders time column correctly', () => {
     tableProps = {
       ...tableProps,

--- a/ui/src/table.tsx
+++ b/ui/src/table.tsx
@@ -18,7 +18,7 @@ import React from 'react'
 import { stylesheet } from 'typestyle'
 import { IconTableCellType, XIconTableCellType } from "./icon_table_cell_type"
 import { ProgressTableCellType, XProgressTableCellType } from "./progress_table_cell_type"
-import { cssVar, displayMixin, rem } from './theme'
+import { cssVar, rem } from './theme'
 import { bond, wave } from './ui'
 
 /** Defines cell content to be rendered instead of a simple text. */
@@ -494,7 +494,7 @@ export const
         </>
       ),
       render = () => (
-        <div data-test={m.name} style={{ position: 'relative', height: computeHeight(), ...displayMixin(m.visible) }}>
+        <div data-test={m.name} style={{ position: 'relative', height: computeHeight() }}>
           <Fluent.Stack horizontal horizontalAlign='space-between' >
             {m.groupable && <Fluent.Dropdown data-test='groupby' label='Group by' selectedKey={groupByKeyB()} onChange={onGroupByChange} options={groupByOptions} styles={{ root: { width: 300 } }} />}
             {!!searchableKeys.length && <Fluent.TextField data-test='search' label='Search' onChange={onSearchChange} value={searchStrB()} styles={{ root: { width: '50%' } }} />}

--- a/ui/src/tabs.test.tsx
+++ b/ui/src/tabs.test.tsx
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { initializeIcons } from '@fluentui/react'
 import { fireEvent, render } from '@testing-library/react'
 import React from 'react'
 import { Tabs, XTabs } from './tabs'
@@ -22,18 +21,11 @@ const name = 'tabs'
 const tabsProps: Tabs = { name, items: [{ name }] }
 
 describe('Tabs.tsx', () => {
-  beforeAll(() => initializeIcons())
   beforeEach(() => { wave.args[name] = null })
 
   it('Renders data-test attr', () => {
     const { queryByTestId } = render(<XTabs model={tabsProps} />)
     expect(queryByTestId(name)).toBeInTheDocument()
-  })
-
-  it('Does not display tabs when visible is false', () => {
-    const { queryByTestId } = render(<XTabs model={{ ...tabsProps, visible: false }} />)
-    expect(queryByTestId(name)).toBeInTheDocument()
-    expect(queryByTestId(name)).not.toBeVisible()
   })
 
   it('Sets args and calls sync on click', () => {

--- a/ui/src/tabs.tsx
+++ b/ui/src/tabs.tsx
@@ -16,7 +16,6 @@ import * as Fluent from '@fluentui/react'
 import { B, Id, S } from 'h2o-wave'
 import React from 'react'
 import { stylesheet } from 'typestyle'
-import { displayMixin } from './theme'
 import { bond, wave } from './ui'
 
 /**
@@ -89,7 +88,6 @@ export const
           <div className={css.pivot}>
             <Fluent.Pivot
               data-test={m.name}
-              style={displayMixin(m.visible)}
               selectedKey={m.value ?? null}
               linkFormat={m.link ? Fluent.PivotLinkFormat.links : Fluent.PivotLinkFormat.tabs}
               onLinkClick={onLinkClick}>{tabs}</Fluent.Pivot>

--- a/ui/src/template.tsx
+++ b/ui/src/template.tsx
@@ -47,7 +47,7 @@ export const
       template = Handlebars.compile(m.content || ''),
       render = () => {
         const data = unpack<Rec>(m.data)
-        return <div data-test={m.name}><XMarkup model={{ content: template(data || {}), visible: m.visible }} /></div>
+        return <div data-test={m.name}><XMarkup model={{ content: template(data || {}) }} /></div>
       }
     return { render }
   }),

--- a/ui/src/text.test.tsx
+++ b/ui/src/text.test.tsx
@@ -31,9 +31,4 @@ describe('Text.tsx', () => {
     expect(queryByTestId(name)).toBeInTheDocument()
   })
 
-  it('Does not display text when visible is false', () => {
-    const { queryByTestId } = render(<XText {...textProps} visibility={false} />)
-    expect(queryByTestId(name)).toBeInTheDocument()
-    expect(queryByTestId(name)).not.toBeVisible()
-  })
 })

--- a/ui/src/text.tsx
+++ b/ui/src/text.tsx
@@ -18,7 +18,7 @@ import React from 'react'
 import { stylesheet } from 'typestyle'
 import { CardMenu } from './card_menu'
 import { Markdown } from './markdown'
-import { displayMixin, margin } from './theme'
+import { margin } from './theme'
 import { Command } from './toolbar'
 
 /** Create text content. */
@@ -121,10 +121,10 @@ const
   toTextVariant = (s: S) => textVariants[s] || 'mediumPlus'
 
 export const
-  XText = ({ content, name, size, commands, visibility = true }: { content: S, name?: S, size?: S, commands?: Command[], visibility?: B }) => {
+  XText = ({ content, name, size, commands }: { content: S, name?: S, size?: S, commands?: Command[] }) => {
     const menuName = name ? `${name}-menu` : name
     return (
-      <div className={css.text} style={displayMixin(visibility)}>
+      <div className={css.text}>
         <Fluent.Text data-test={name} variant={toTextVariant(size || 'm')} block>
           <Markdown source={content} />
         </Fluent.Text>

--- a/ui/src/textbox.test.tsx
+++ b/ui/src/textbox.test.tsx
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { initializeIcons } from '@fluentui/react'
 import { fireEvent, render } from '@testing-library/react'
 import React from 'react'
 import { Textbox, XTextbox } from './textbox'
@@ -22,7 +21,6 @@ const name = 'textbox'
 const textboxProps: Textbox = { name }
 
 describe('Textbox.tsx', () => {
-  beforeAll(() => initializeIcons())
   beforeEach(() => {
     jest.clearAllMocks()
     jest.useFakeTimers()
@@ -32,12 +30,6 @@ describe('Textbox.tsx', () => {
   it('Renders data-test attr', () => {
     const { queryByTestId } = render(<XTextbox model={textboxProps} />)
     expect(queryByTestId(name)).toBeInTheDocument()
-  })
-
-  it('Does not display textbox when visible is false', () => {
-    const { queryByTestId } = render(<XTextbox model={{ ...textboxProps, visible: false }} />)
-    expect(queryByTestId(name)).toBeInTheDocument()
-    expect(queryByTestId(name)).not.toBeVisible()
   })
 
   it('Renders data-test attr - masked', () => {

--- a/ui/src/textbox.tsx
+++ b/ui/src/textbox.tsx
@@ -15,7 +15,6 @@
 import * as Fluent from '@fluentui/react'
 import { B, Id, S } from 'h2o-wave'
 import React from 'react'
-import { displayMixin } from './theme'
 import { bond, debounce, wave } from './ui'
 
 /**
@@ -79,7 +78,6 @@ export const
         ? (
           <Fluent.MaskedTextField
             data-test={m.name}
-            style={displayMixin(m.visible)}
             label={m.label}
             defaultValue={m.value}
             mask={m.mask}
@@ -93,7 +91,6 @@ export const
         : (
           <Fluent.TextField
             data-test={m.name}
-            style={displayMixin(m.visible)}
             styles={m.multiline && m.height ? { fieldGroup: { height: m.height } } : undefined}
             label={m.label}
             placeholder={m.placeholder}

--- a/ui/src/theme.test.tsx
+++ b/ui/src/theme.test.tsx
@@ -1,4 +1,4 @@
-import { border, centerMixin, clas, cssVar, dashed, displayMixin, margin, padding, pc, px, rem } from "./theme"
+import { border, centerMixin, clas, cssVar, dashed, margin, padding, pc, px, rem } from "./theme"
 
 describe('Theme util functions', () => {
 
@@ -42,11 +42,6 @@ describe('Theme util functions', () => {
 
   it('returns expected flex centering obj', () => {
     expect(centerMixin()).toMatchObject({ display: 'flex', alignItems: 'center', justifyContent: 'center' })
-  })
-
-  it('returns expected display obj', () => {
-    expect(displayMixin()).toMatchObject({})
-    expect(displayMixin(false)).toMatchObject({ display: 'none' })
   })
 
   describe('CSS var func', () => {

--- a/ui/src/theme.ts
+++ b/ui/src/theme.ts
@@ -36,7 +36,6 @@ export const
   padding = (...t: I[]) => t.map(px).join(' '),
   margin = padding,
   centerMixin = () => ({ display: 'flex', alignItems: 'center', justifyContent: 'center' }),
-  displayMixin = (visible = true): React.CSSProperties => visible ? {} : { display: 'none' },
   // if color starts with $, treat  it like a css var, otherwise treat it like a regular color.
   // TODO this is ugly - why does the argument need a '$' prefix?
   cssVar = (color = '$gray') => color.startsWith('$') ? `var(--${color.substr(1)}, var(--gray))` : color,

--- a/ui/src/toggle.test.tsx
+++ b/ui/src/toggle.test.tsx
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { initializeIcons } from '@fluentui/react'
 import { fireEvent, render } from '@testing-library/react'
 import React from 'react'
 import { Toggle, XToggle } from './toggle'
@@ -22,7 +21,6 @@ const name = 'toggle'
 const toggleProps: Toggle = { name }
 
 describe('Toggle.tsx', () => {
-  beforeAll(() => initializeIcons())
   beforeEach(() => {
     jest.clearAllMocks()
     wave.args[name] = null
@@ -31,12 +29,6 @@ describe('Toggle.tsx', () => {
   it('Renders data-test attr', () => {
     const { queryByTestId } = render(<XToggle model={toggleProps} />)
     expect(queryByTestId(name)).toBeInTheDocument()
-  })
-
-  it('Does not display toggle when visible is false', () => {
-    const { queryByTestId } = render(<XToggle model={{ ...toggleProps, visible: false }} />)
-    expect(queryByTestId(name)).toBeInTheDocument()
-    expect(queryByTestId(name)).not.toBeVisible()
   })
 
   it('Calls sync when trigger is on', () => {

--- a/ui/src/toggle.tsx
+++ b/ui/src/toggle.tsx
@@ -15,7 +15,6 @@
 import * as Fluent from '@fluentui/react'
 import { B, Id, S } from 'h2o-wave'
 import React from 'react'
-import { displayMixin } from './theme'
 import { bond, wave } from './ui'
 
 /**
@@ -56,7 +55,6 @@ export const
       render = () => (
         <Fluent.Toggle
           data-test={m.name}
-          style={displayMixin(m.visible)}
           label={m.label}
           defaultChecked={m.value}
           onChange={onChange}

--- a/ui/src/vega.test.tsx
+++ b/ui/src/vega.test.tsx
@@ -53,12 +53,6 @@ describe('Vega.tsx', () => {
   describe('Form Vega', () => {
     const formVegaProps: VegaVisualization = { name, specification }
 
-    it('Does not display expander when visible is false', () => {
-      const { queryByTestId } = render(<XVegaVisualization model={{ ...formVegaProps, visible: false }} />)
-      expect(queryByTestId(name)).toBeInTheDocument()
-      expect(queryByTestId(name)).not.toBeVisible()
-    })
-
     it('Does not render data-test attr', () => {
       const { container } = render(<XVegaVisualization model={{ specification }} />)
       expect(container.querySelectorAll('[data-test]')).toHaveLength(0)

--- a/ui/src/vega.tsx
+++ b/ui/src/vega.tsx
@@ -17,7 +17,6 @@ import React from 'react'
 import { stylesheet } from 'typestyle'
 import vegaEmbed from 'vega-embed'
 import { cards, grid } from './layout'
-import { displayMixin } from './theme'
 import { bond, debounce } from './ui'
 
 const
@@ -106,11 +105,11 @@ export const
       dispose = () => window.removeEventListener('resize', onResize),
       render = () => {
         const
-          { name, width = 'auto', height = 'auto', visible } = state,
+          { name, width = 'auto', height = 'auto' } = state,
           style: React.CSSProperties = (width === 'auto' && height === 'auto')
             ? { flexGrow: 1 }
             : { width, height }
-        return <div data-test={name} className={css.plot} style={{ ...style, position: 'relative', ...displayMixin(visible) }} ref={ref} />
+        return <div data-test={name} className={css.plot} style={{ ...style, position: 'relative' }} ref={ref} />
       }
     window.addEventListener('resize', onResize)
 


### PR DESCRIPTION
Moved the visibility handling logic to parent form component instead of dealing with it at component level.

There was also a minor spacing issue - we applied `marginTop: 0` to `:not(:first-child)` selector. The problem is, this selector looks at the DOM (hidden elements are still present in the DOM), not whether the element is visible or not. I managed to fix it via CSS.

Closes #484
Closes #817 