### PR TITLE
fix: let React handle page updates #508

### DIFF
--- a/ui/src/qd.ts
+++ b/ui/src/qd.ts
@@ -853,22 +853,19 @@ const
       qd.socket = null
       backoff *= 2
       if (backoff > 16) backoff = 16
-      handle({ t: SockEventType.Message, type: SockMessageType.Warn, message: `Disconneced. Reconnecting in ${backoff} seconds...` })
+      handle({ t: SockEventType.Message, type: SockMessageType.Warn, message: `Disconnected. Reconnecting in ${backoff} seconds...` })
       window.setTimeout(retry, backoff * 1000)
     }
     sock.onmessage = function (e) {
-      if (!e.data) return
-      if (!e.data.length) return
+      if (!e.data?.length) return
       qd.busyB(false)
       for (const line of e.data.split('\n')) {
         try {
           const msg = JSON.parse(line) as OpsD
           if (msg.d) {
             const page = exec(currentPage || newPage(), msg.d)
-            if (currentPage !== page) {
-              currentPage = page
-              if (page) handle({ t: SockEventType.Data, page: page })
-            }
+            currentPage = page
+            if (page) handle({ t: SockEventType.Data, page })
           } else if (msg.p) {
             currentPage = load(msg.p)
             handle({ t: SockEventType.Data, page: currentPage })
@@ -890,4 +887,3 @@ const
   }
 
 export const connect = (path: S, handle: SockHandler) => reconnect(toSocketAddress(path), handle)
-


### PR DESCRIPTION
Needs discussion - cc @lo5 

The problem was that websocket sent "box changes" in `msg.d` (I believe that stands for data), which then just calls `changedB` on corresponding card, causing specific card update.  As the page itself didn't really change, `currentPage` stays the same and doesn't call `onSocket` handler that is in charge of updating layout in general.

This PR proposes a solution that allows React itself decide what to update instead of doing it ourselves manually.

Closes #508