### PR TITLE
Safari iframe fix

### DIFF
--- a/py/examples/dashboard.py
+++ b/py/examples/dashboard.py
@@ -22,7 +22,7 @@ def next_color():
 
 
 _curve_index = -1
-curves = 'linear smooth step stepAfter stepBefore'.split()
+curves = 'linear smooth step step-after step-before'.split()
 
 
 def next_curve():

--- a/ui/src/frame.tsx
+++ b/ui/src/frame.tsx
@@ -32,7 +32,12 @@ const
     },
     body: {
       flexGrow: 1,
+      position: 'relative',
     },
+    frame: {
+      position: 'absolute',
+      top: 10, left: 0, right: 0, bottom: 0
+    }
   })
 
 /**
@@ -72,7 +77,7 @@ const
   fixrefs = (s: S): S => s.replace(/(\s+src\s*=\s*["'])\//g, `$1${window.location.protocol}//${window.location.host}/`),
   inline = (s: S): S => URL.createObjectURL(new Blob([fixrefs(s)], { type: 'text/html' })),
   InlineFrame = ({ path, content }: { path?: S, content?: S }) => (
-    <iframe title={xid()} src={path ? path : content ? inline(content) : inline('Nothing to render.')} frameBorder="0" width="100%" height="100%" />
+    <iframe title={xid()} src={path ? path : content ? inline(content) : inline('Nothing to render.')} className={css.frame} frameBorder="0" width="100%" height="100%" />
   )
 
 // HACK: Applying width/height styles directly on iframe don't work in Chrome/FF; so wrap in div instead.

--- a/ui/src/frame.tsx
+++ b/ui/src/frame.tsx
@@ -36,7 +36,7 @@ const
     },
     frame: {
       position: 'absolute',
-      top: 10, left: 0, right: 0, bottom: 0
+      top: 0, left: 0, right: 0, bottom: 0
     }
   })
 

--- a/ui/src/frame.tsx
+++ b/ui/src/frame.tsx
@@ -35,6 +35,8 @@ const
       position: 'relative',
     },
     frame: {
+      // WORKAROUND: Iframe "height:100%" implementation differs from Chrome/FF despite container being
+      // correctly expanded via "flex-grow:1". Need to position it absolutely instead.
       position: 'absolute',
       top: 0, left: 0, right: 0, bottom: 0
     }


### PR DESCRIPTION
The core problem is that Safari's `height: 100%` implementation differs from Chrome/FF. It used default height `150px` instead. The iframe wrapper correctly takes up all the space via `flex-grow: 1`, but iframe is still not capable of filling it corectly.

None of the workarounds found could solve this, so I went for absolute positioning.

Discussion: This fix affects `frame_card` only as it works with dynamic height (the only way to control height is to change card's height). I believe it is enough since form frames have the ability to control height manually with default to `150px`. if not, we can exchange the `150px` height default for `flex-grow:1` and absolute positioning in the same way like `frame_card`.

Closes #519