### PR TITLE
Fix ProgressArc in Safari

### DIFF
--- a/ui/src/parts/progress_arc.tsx
+++ b/ui/src/parts/progress_arc.tsx
@@ -27,8 +27,6 @@ interface Props {
 
 const css = stylesheet({
   container: {
-    width: '100%',
-    height: '100%',
     // Height 100% is not working in Safari. Without this, container has 0 height and d3 cannot compute properly.
     position: 'absolute',
     top: 0, left: 0, right: 0, bottom: 0

--- a/ui/src/parts/progress_arc.tsx
+++ b/ui/src/parts/progress_arc.tsx
@@ -29,7 +29,8 @@ const css = stylesheet({
   container: {
     width: '100%',
     height: '100%',
-    position: 'relative',
+    position: 'absolute',
+    top: 0, left: 0, right: 0, bottom: 0
   }
 })
 

--- a/ui/src/parts/progress_arc.tsx
+++ b/ui/src/parts/progress_arc.tsx
@@ -29,6 +29,7 @@ const css = stylesheet({
   container: {
     width: '100%',
     height: '100%',
+    // Height 100% is not working in Safari. Without this, container has 0 height and d3 cannot compute properly.
     position: 'absolute',
     top: 0, left: 0, right: 0, bottom: 0
   }


### PR DESCRIPTION
`height: 100%` is not working for flex parent with `flex-grow: 1`. Had to use absolute positioning instead.

Closes #520