### PR TITLE
docs: Update security page of access token info

### DIFF
--- a/website/docs/security.md
+++ b/website/docs/security.md
@@ -44,5 +44,11 @@ from h2o_wave import Q, main, app
 @app('/example')
 async def serve(q: Q):
     print(q.auth.username)
-    print(q.auth.subject)
+    print(q.auth.access_token)
 ```
+
+:::caution
+Note that access token is not refreshed automatically and it's not suited for long running jobs. The lifespan of a token
+depends on a provider settings but usually it's short. Access token is refreshed each time user performs an action i.e.
+the query handler `serve()` is called.
+:::


### PR DESCRIPTION
If PR merged, the security page of Wave docs will be updated of `access token` lifespan info.