### PR TITLE
feat: Add ML API as a pip option

### DIFF
--- a/py/setup.py
+++ b/py/setup.py
@@ -57,6 +57,6 @@ setuptools.setup(
         console_scripts=["wave = h2o_wave.cli:main"]
     ),
     extras_require=dict(
-        ml=['h2o_wave_ml@https://github.com/h2oai/wave-ml/releases/download/v0.1.0/h2o_wave_ml-0.1.0-py3-none-any.whl']
+        ml=['h2o_wave_ml']
     ),
 )

--- a/py/setup.py
+++ b/py/setup.py
@@ -56,4 +56,7 @@ setuptools.setup(
     entry_points=dict(
         console_scripts=["wave = h2o_wave.cli:main"]
     ),
+    extras_require=dict(
+        ml=['h2o_wave_ml@https://github.com/h2oai/wave-ml/releases/download/v0.1.0/h2o_wave_ml-0.1.0-py3-none-any.whl']
+    ),
 )


### PR DESCRIPTION
If PR merged, the first version of ML API will be available in Wave. ML API is completely separated and will be installable by:
```sh
pip install h2o-wave[ml]
```
