### PR TITLE
feat: allow using height in vega spec #543

### DIFF
--- a/ui/src/vega.tsx
+++ b/ui/src/vega.tsx
@@ -66,10 +66,13 @@ export const
       init = () => {
         const el = ref.current
         if (!el) return
+
+        const spec = JSON.parse(state.specification)
+        if (!isNaN(spec.height)) el.style.height = `${spec.height + 10}px`
         // If card does not have specified height, it uses content. Since the wrapper is empty, it takes very little space - set to 300px by default.
-        if (el.clientHeight < 30) el.style.height = '300px'
+        else if (el.clientHeight < 30) el.style.height = '300px'
+
         const
-          spec = JSON.parse(state.specification),
           data = unpack<any[]>(state.data),
           width = el.clientWidth - 10, // HACK: Vega calculates dimensions with extra 10px for some reason.
           height = el.clientHeight - 10 // HACK: Vega calculates dimensions with extra 10px for some reason.
@@ -123,10 +126,10 @@ export const
   View = bond(({ name, state, changed }: Card<State>) => {
     const
       render = () => {
-        const { specification, data } = state
+        const { specification, data, title } = state
         return (
           <div data-test={name} className={css.card}>
-            <div className='s12 w6'>{state.title}</div>
+            <div className='s12 w6'>{title}</div>
             <div className={css.body}>
               <XVegaVisualization key={xid()} model={{ specification, data }} />
             </div>

--- a/ui/src/vega.tsx
+++ b/ui/src/vega.tsx
@@ -72,7 +72,9 @@ export const
           el.style.height = `${spec.height + 10}px`// HACK: Vega calculates dimensions with extra 10px for some reason, increase container for 10px as well.
         }
         // If card does not have specified height, it uses content. Since the wrapper is empty, it takes very little space - set to 300px by default.
-        else if (el.clientHeight < 30) el.style.height = '300px'
+        else if (el.clientHeight < 30) {
+          el.style.height = '300px'
+        }
 
         const
           data = unpack<any[]>(state.data),

--- a/ui/src/vega.tsx
+++ b/ui/src/vega.tsx
@@ -68,7 +68,9 @@ export const
         if (!el) return
 
         const spec = JSON.parse(state.specification)
-        if (!isNaN(spec.height)) el.style.height = `${spec.height + 10}px`
+        if (!isNaN(spec.height)) {
+          el.style.height = `${spec.height + 10}px`// HACK: Vega calculates dimensions with extra 10px for some reason, increase container for 10px as well.
+        }
         // If card does not have specified height, it uses content. Since the wrapper is empty, it takes very little space - set to 300px by default.
         else if (el.clientHeight < 30) el.style.height = '300px'
 


### PR DESCRIPTION
Needs discussion:

As discussed with @goldentom42, there are basically two ways for manipulating card size in Wave:
1. Card level - specified it in layout definition.
2. Card content - card size is based on its content.

#543 can be resolved easily by (1).

Vega allows controlling its dimensions via [spec](https://vega.github.io/vega-lite/docs/size.html). Which is (2) approach. This PR introduces ability for handling `height` defined in spec, but I don't think it makes sense for `width` as well, since `vega_card` has only plot as content and you always want to stretch it to the full of the container (see images below)
**Stretched**
![image](https://user-images.githubusercontent.com/64769322/106609994-7b9eb400-6566-11eb-8303-249dce7352a0.png)
**Static width in vega spec**
![image](https://user-images.githubusercontent.com/64769322/106610023-848f8580-6566-11eb-86e0-e716a49c766b.png)

My opinion is that we should follow general Wave philosophy and treat everything layout related in `layouts` (for flex layout) or `box` (in grid), then let our vega fill whole card by default. This would need a warning in Docs that using Vega width/height directly in spec is discouraged in favor of layouts. This can however be a bit of trouble for seasoned Vega users who are used to controlling dimensions via spec.
wdyt @lo5 ?

Closes #543