### PR TITLE
chore: update caniuse-lite to remove warning during ui build

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -5213,9 +5213,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001117",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001117.tgz",
-      "integrity": "sha512-4tY0Fatzdx59kYjQs+bNxUwZB03ZEBgVmJ1UkFPz/Q8OLiUUbjct2EdpnXj0fvFTPej2EkbPIG0w8BWsjAyk1Q=="
+      "version": "1.0.30001183",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001183.tgz",
+      "integrity": "sha512-7JkwTEE1hlRKETbCFd8HDZeLiQIUcl8rC6JgNjvHCNaxOeNmQ9V4LvQXRUsKIV2CC73qKxljwVhToaA3kLRqTw=="
     },
     "capture-exit": {
       "version": "2.0.0",


### PR DESCRIPTION
Resolves warning during ui build.

Run `npm i` after pulling this change.