### PR TITLE
fix: add post init dimensions check to plots due to Safari event loop behavior #516

### DIFF
--- a/ui/src/parts/microarea.tsx
+++ b/ui/src/parts/microarea.tsx
@@ -60,8 +60,13 @@ export const MicroArea = ({ value, color, data, zeroValue, curve }: Props) => {
     renderViz = () => {
       if (!ref.current) return
 
+      const { width, height } = ref.current.getBoundingClientRect()
+      if (!height) {
+        // Safari has weird event loop meaning this React code can run before Layout phase is finished (flex items not positioned yet).
+        setTimeout(renderViz, 300)
+        return
+      }
       const
-        { width, height } = ref.current.getBoundingClientRect(),
         scaleX = d3.scaleLinear().domain([0, data.length - 1]).range([0, width]),
         scaleY = d3.scaleLinear().domain([minY, maxY]).range([height, 2]),
         fcurve = curves[curve] || d3.curveLinear,

--- a/ui/src/parts/microbars.tsx
+++ b/ui/src/parts/microbars.tsx
@@ -52,8 +52,14 @@ export const MicroBars = ({ value, category = 'x', color, data, zeroValue }: Pro
     renderViz = () => {
       if (!ref.current) return
 
+      const { width, height } = ref.current.getBoundingClientRect()
+      if (!height) {
+        // Safari has weird event loop meaning this React code can run before Layout phase is finished (flex items not positioned yet).
+        setTimeout(renderViz, 300)
+        return
+      }
+
       const
-        { width, height } = ref.current.getBoundingClientRect(),
         scaleX = d3.scaleBand().domain(data.map(d => d[category])).range([0, width]).paddingInner(0.1),
         scaleY = d3.scaleLinear().domain([minY, maxY]).range([height, 0]),
         rects = data.map((d, i) => {

--- a/ui/src/parts/progress_arc.tsx
+++ b/ui/src/parts/progress_arc.tsx
@@ -40,8 +40,14 @@ export const ProgressArc = ({ thickness, color, value }: Props) => {
     renderViz = () => {
       if (!ref.current) return
 
+      const { width, height } = ref.current.getBoundingClientRect()
+      if (!height) {
+        // Safari has weird event loop meaning this React code can run before Layout phase is finished (flex items not positioned yet).
+        setTimeout(renderViz, 300)
+        return
+      }
+
       const
-        { width, height } = ref.current.getBoundingClientRect(),
         diameter = Math.min(width, height),
         outerRadius = diameter / 2,
         innerRadius = diameter / 2 - thickness,

--- a/ui/src/plot.tsx
+++ b/ui/src/plot.tsx
@@ -730,6 +730,8 @@ const
     body: {
       flexGrow: 1,
       display: 'flex',
+    },
+    plot: {
       $nest: {
         'canvas': {
           position: 'absolute',
@@ -739,7 +741,7 @@ const
           bottom: 0
         }
       }
-    },
+    }
   })
 
 /** Create a visualization for display inside a form. */
@@ -764,9 +766,19 @@ export const
   XVisualization = bond(({ model }: { model: Visualization }) => {
     let
       currentChart: Chart | null = null,
-      currentPlot: Plot | null = null
+      currentPlot: Plot | null = null,
+      initWidth = 0,
+      initHeight = 0
     const
       container = React.createRef<HTMLDivElement>(),
+      checkDimensionsPostInit = () => {
+        const el = container.current
+        if (!el) return
+        if (el.clientHeight !== initHeight || el.clientWidth !== initWidth) {
+          currentChart?.destroy()
+          init()
+        }
+      },
       init = () => {
         // Map CSS var colors to their hex values.
         cat10 = cat10.map(cssVarValue)
@@ -805,6 +817,11 @@ export const
             }
           }
           chart.render()
+          initHeight = el.clientHeight
+          initWidth = el.clientWidth
+          // React fires mount lifecycle hook before Safari finishes Layout phase so we need recheck if original card dimensions are the
+          // same as after Layout phase. If not, rerender the plot again.
+          setTimeout(checkDimensionsPostInit, 300)
         }
       },
       update = () => {
@@ -821,7 +838,7 @@ export const
           style: React.CSSProperties = (width === 'auto' && height === 'auto')
             ? { flexGrow: 1 }
             : { width, height }
-        return <div data-test={name} style={{ ...style, ...displayMixin(visible) }} ref={container} />
+        return <div data-test={name} style={{ ...style, ...displayMixin(visible) }} className={css.plot} ref={container} />
       }
     return { init, update, render }
   })

--- a/ui/src/plot.tsx
+++ b/ui/src/plot.tsx
@@ -766,15 +766,13 @@ export const
   XVisualization = bond(({ model }: { model: Visualization }) => {
     let
       currentChart: Chart | null = null,
-      currentPlot: Plot | null = null,
-      initWidth = 0,
-      initHeight = 0
+      currentPlot: Plot | null = null
     const
       container = React.createRef<HTMLDivElement>(),
-      checkDimensionsPostInit = () => {
+      checkDimensionsPostInit = (w: F, h: F) => { // Safari fix
         const el = container.current
         if (!el) return
-        if (el.clientHeight !== initHeight || el.clientWidth !== initWidth) {
+        if (el.clientHeight !== h || el.clientWidth !== w) {
           currentChart?.destroy()
           init()
         }
@@ -817,11 +815,9 @@ export const
             }
           }
           chart.render()
-          initHeight = el.clientHeight
-          initWidth = el.clientWidth
           // React fires mount lifecycle hook before Safari finishes Layout phase so we need recheck if original card dimensions are the
           // same as after Layout phase. If not, rerender the plot again.
-          setTimeout(checkDimensionsPostInit, 300)
+          setTimeout(() => checkDimensionsPostInit(el.clientWidth, el.clientHeight), 300)
         }
       },
       update = () => {


### PR DESCRIPTION
The problem was that React runs its `componentDidMount` lifecycle hook when browser Layout phase is not finished yet, giving us incorrect dimensions required for plot calculations:

![image](https://user-images.githubusercontent.com/64769322/107347738-6bd32280-6ac6-11eb-83be-c7efae9a5dfa.png)
This is the state of UI when our React hooks run. Safari will eventually catch up, but by the time, we already have incorrect dimensions in place. Flexbox Layout is not done yet, each component is displayed in its own row (width 1200px) and calculates the rest with this dimension, resulting in odd-looking plots as described in the issue.

This bug was especially hard to debug since it is not reproducible with Safari devtools open for some reason.

One solution that worked for unknown reason was to add a fake timeout on initial loading phase (spinner). It seemed like Safari could finish all the work needed on its own and then would be ready to paint our layout correctly. This would however impact the performance of the rest of browsers as well, which is best avoided.

The solution I went for is doing a post-render check for dimensions (original vs after timeout). If these are the same, we can be confident our layout is correct, if not, tear down the plot and render it again. This affects rendering performance only for broken browsers.

Thanks @geomodular for pair-debugging sessions!

Closes #516