### PR TITLE
fix: allow auth cookies for manifest.json #h2oai/h2o-ai-cloud#798

### DIFF
--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -12,7 +12,7 @@
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-  <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+  <link rel="manifest" href="%PUBLIC_URL%/manifest.json" crossorigin="use-credentials" />
   <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.


### PR DESCRIPTION
This PR allows auth cookies for `manifest.json`. The question is, whether deleting the manifest completely isn't better option since it serves as metadata for PWAs, which we currently don't support.

Closes h2oai/h2o-ai-cloud#798