### PR TITLE
docs: use explicit instead of truthy throughout the examples #168

### DIFF
--- a/py/examples/plot_matplotlib.py
+++ b/py/examples/plot_matplotlib.py
@@ -29,10 +29,10 @@ async def serve(q: Q):
         )
         q.page['plot'] = ui.markdown_card(box='3 1 2 3', title='Your plot!', content='')
 
-    if q.args.points:
+    if q.args.points is not None:
         q.client.points = q.args.points
 
-    if q.args.alpha:
+    if q.args.alpha is not None:
         q.client.alpha = q.args.alpha
 
     n = q.client.points

--- a/py/examples/plot_plotly.py
+++ b/py/examples/plot_plotly.py
@@ -28,7 +28,7 @@ async def serve(q: Q):
         )
         q.page['plot'] = ui.frame_card(box='1 3 4 5', title='', content='')
 
-    if q.args.points:
+    if q.args.points is not None:
         q.client.points = q.args.points
 
     if q.args.plotly_controls is not None:


### PR DESCRIPTION
Closes #168