### PR TITLE
fix: remove displaying form items in flex column due to Safari #563

### DIFF
--- a/ui/src/form.tsx
+++ b/ui/src/form.tsx
@@ -154,8 +154,6 @@ const
   css = stylesheet({
     card: {
       padding: 15,
-      display: 'flex',
-      flexDirection: 'column'
     },
     vertical: {
       display: 'flex',


### PR DESCRIPTION
Needs more testing.

Closes #563