### PR TITLE
fix: Set git PAS to publish docs workflow

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -8,15 +8,14 @@ on:
         default: 'docs: Publish documentation website'
         required: false
 
-env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
 jobs:
   publish:
     name: Publish Docs
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GIT_TOKEN }}
 
       - name: Setup
         run: make setup


### PR DESCRIPTION
Fix for permission denied to commit to protected branch issue in Github actions pipeline. 