### PR TITLE
fix: stretch slider for available space #582

### DIFF
--- a/ui/src/form.tsx
+++ b/ui/src/form.tsx
@@ -197,11 +197,12 @@ export const
           // All form items are wrapped by their component name (first and only prop of "m").
           [componentKey] = Object.keys(m),
           { name, visible = true } = m[componentKey],
-          visibleStyles: React.CSSProperties = visible ? {} : { display: 'none' }
+          visibleStyles: React.CSSProperties = visible ? {} : { display: 'none' },
+          width = componentKey === 'slider' || componentKey === 'range_slider' ? '100%' : 'auto'
 
         return (
           // Recreate only if name or position within form items changed, update otherwise.
-          <div key={name || `${componentKey}-${i}`} data-visible={visible} style={visibleStyles}>
+          <div key={name || `${componentKey}-${i}`} data-visible={visible} style={{ ...visibleStyles, width }}>
             <XComponent model={m} />
           </div>
         )

--- a/ui/src/range_slider.tsx
+++ b/ui/src/range_slider.tsx
@@ -150,7 +150,8 @@ export const XRangeSlider = ({ model: m }: { model: RangeSlider }) => {
   React.useEffect(() => { wave.args[m.name] = Object.values(value as Range) }, [])
 
   return (
-    <div data-test={m.name} style={{ width: '100%' }}>
+    // Max value label causes card overflow so add a bit of right padding.
+    <div data-test={m.name} style={{ paddingRight: 17 }}>
       {m.label && <Fluent.Label disabled={m.disabled}>{m.label}</Fluent.Label>}
       <div className={`${css.container} ${m.disabled ? css.disabled : ''}`}>
         <InputRange maxValue={max} minValue={min} step={step} disabled={m.disabled} allowSameValues value={value} onChange={onChange} />

--- a/ui/src/range_slider.tsx
+++ b/ui/src/range_slider.tsx
@@ -150,7 +150,7 @@ export const XRangeSlider = ({ model: m }: { model: RangeSlider }) => {
   React.useEffect(() => { wave.args[m.name] = Object.values(value as Range) }, [])
 
   return (
-    <div data-test={m.name}>
+    <div data-test={m.name} style={{ width: '100%' }}>
       {m.label && <Fluent.Label disabled={m.disabled}>{m.label}</Fluent.Label>}
       <div className={`${css.container} ${m.disabled ? css.disabled : ''}`}>
         <InputRange maxValue={max} minValue={min} step={step} disabled={m.disabled} allowSameValues value={value} onChange={onChange} />

--- a/ui/src/section.tsx
+++ b/ui/src/section.tsx
@@ -27,8 +27,9 @@ const
       display: 'flex',
       paddingTop: 5,
     },
-    lhs: {
+    rhs: {
       flexGrow: 1,
+      marginLeft: 15
     },
     subtitle: {
       $nest: {
@@ -59,14 +60,14 @@ export const
           { title, subtitle, items } = state,
           components = unpack<Component[]>(items), // XXX ugly
           form = items && (
-            <div>
+            <div className={css.rhs}>
               <XComponents items={components} alignment={XComponentAlignment.Right} />
             </div>
           )
 
         return (
           <div data-test={name} className={css.card}>
-            <div className={css.lhs}>
+            <div>
               <div className='wave-s14 wave-w6'>{title}</div>
               <div className={clas(css.subtitle, 'wave-s12')}><Markdown source={subtitle} /></div>
             </div>

--- a/ui/src/slider.tsx
+++ b/ui/src/slider.tsx
@@ -70,7 +70,6 @@ export const
     return (
       <Fluent.Slider
         data-test={m.name}
-        styles={{ root: { width: '100%' } }}
         buttonProps={{ 'data-test': m.name } as React.HTMLAttributes<HTMLButtonElement>}
         label={m.label}
         min={min}

--- a/ui/src/slider.tsx
+++ b/ui/src/slider.tsx
@@ -70,6 +70,7 @@ export const
     return (
       <Fluent.Slider
         data-test={m.name}
+        styles={{ root: { width: '100%' } }}
         buttonProps={{ 'data-test': m.name } as React.HTMLAttributes<HTMLButtonElement>}
         label={m.label}
         min={min}


### PR DESCRIPTION
The sliders were cramped within `ui.inline` because there was no default width specified originally. This PR sets it for 100% which doesn't change anything if slider specified as a form child and takes up available space for inline. This seems reasonable for me since short sliders (not wide enough) are harder to use because of smaller dragging area. Another possiblity is to specify default min width or exposing width attr. 100% width solution feels the best though.

Fixed with 100% width:
![Screen Shot 2021-02-24 at 4 40 38 PM](https://user-images.githubusercontent.com/64769322/109026935-91644c80-76c0-11eb-86e1-c48c4303434f.png)

Possible improvements: Make our range slider UX the same as Fluent one, something like:
![Screen Shot 2021-02-24 at 4 29 16 PM](https://user-images.githubusercontent.com/64769322/109027111-bd7fcd80-76c0-11eb-985b-0354462b9d25.png)


Closes #582