### PR TITLE
Fixes Issue #599:   h2o_wave module missing the __version__ attribute

### DIFF
--- a/py/h2o_wave/__init__.py
+++ b/py/h2o_wave/__init__.py
@@ -42,3 +42,5 @@ __pdoc__ = {
     'db': False,
     'ide': False,
 }
+
+__version__ = '1.12.1'


### PR DESCRIPTION
## Description
As a fix I have added the ```__version__``` dunder with the current version number (```1.12.1```) in the ```__init__.py``` file. Now calling h2o_wave.__version__ should not result in an Attribute error.

Fixes Issue #599 