### PR TITLE
User defined themes

### DIFF
--- a/py/examples/meta_theme.py
+++ b/py/examples/meta_theme.py
@@ -7,7 +7,7 @@ from h2o_wave import Q, ui, main, app
 @app('/demo')
 async def serve(q: Q):
     if not q.client.initialized:
-        q.page['meta'] = ui.meta_card(box='')
+        q.page['meta'] = ui.meta_card(box='', theme='neon')
         q.page['controls'] = ui.form_card(box='1 1 2 8', items=[
             ui.text_xl('Form'),
             ui.textbox(name='textbox', label='Textbox'),

--- a/py/examples/theme_generator.py
+++ b/py/examples/theme_generator.py
@@ -1,0 +1,153 @@
+# Theme generator
+# Use theme generator to quickly generate custom color schemes for your app.
+# #theme_generator
+# ---
+from h2o_wave import main, app, Q, ui
+
+from pygments import highlight
+from pygments.formatters.html import HtmlFormatter
+from pygments.lexers import get_lexer_by_name
+from pygments.style import Style
+from pygments.token import Name, String, Operator, Punctuation
+
+py_lexer = get_lexer_by_name('python')
+
+
+def get_theme_code(text: str, card: str, page: str, primary: str):
+    contents = f'''
+ui.theme(
+    name='<theme-name>',
+    colors=ui.colors(
+        text='{text}',
+        card='{card}',
+        page='{page}',
+        primary='{primary}'
+    )
+)'''
+
+    # Reference: http://svn.python.org/projects/external/Pygments-0.10/docs/build/styles.html
+    class CustomStyle(Style):
+        styles = {
+            Name: text,
+            Operator: text,
+            Punctuation: text,
+            String: primary
+        }
+
+    html_formatter = HtmlFormatter(full=True, style=CustomStyle, nobackground=True)
+    return highlight(contents, py_lexer, html_formatter)
+
+
+@app('/demo')
+async def serve(q: Q):
+    if not q.client.initialized:
+        q.client.primary = '#000'
+        q.client.page = '#e2e2e2'
+        q.client.card = '#fff'
+        q.client.text = '#000'
+        q.page['meta'] = ui.meta_card(box='', theme='custom', layouts=[
+            ui.layout(
+                breakpoint='xs',
+                zones=[
+                    ui.zone('header'),
+                    ui.zone('content', direction=ui.ZoneDirection.ROW, zones=[
+                        ui.zone('colors', size='300px'),
+                        ui.zone('preview')
+                    ]),
+                    ui.zone('footer')
+                ]
+            )
+        ])
+        q.page['header'] = ui.header_card(box='header', title='Theme generator', subtitle='Color your app easily',
+                                          icon='Color', icon_color='$card')
+        q.page['form'] = ui.form_card(box='colors', items=[
+            ui.color_picker(name='primary', label='Primary', trigger=True, alpha=False, inline=True,
+                            value=q.client.primary),
+            ui.color_picker(name='text', label='Text', trigger=True, alpha=False, inline=True, value=q.client.text),
+            ui.color_picker(name='card', label='Card', trigger=True, alpha=False, inline=True, value=q.client.card),
+            ui.color_picker(name='page', label='Page', trigger=True, alpha=False, inline=True, value=q.client.page),
+            ui.text_xl('Code to Copy'),
+            ui.frame(content=get_theme_code(q.client.text, q.client.card, q.client.page, q.client.primary),
+                     height='180px')
+        ])
+        q.page['sample'] = ui.form_card(box='preview', items=[
+            ui.text_xl(content='Sample App to show off colors'),
+            ui.progress(label='A progress bar'),
+            ui.inline([
+                ui.checkbox(name='checkbox1', label='A checkbox', value=True),
+                ui.checkbox(name='checkbox1', label='Another checkbox'),
+                ui.checkbox(name='checkbox1', label='Yet another checkbox'),
+                ui.toggle(name='toggle', label='Toggle', value=True),
+            ]),
+            ui.inline([
+                ui.date_picker(name='date_picker', label='Date picker'),
+                ui.picker(name='picker', label='Picker', choices=[
+                    ui.choice('choice1', label='Choice 1'),
+                    ui.choice('choice2', label='Choice 2'),
+                    ui.choice('choice3', label='Choice 3'),
+                ]),
+                ui.combobox(name='combobox', label='Combobox', choices=['Choice 1', 'Choice 2', 'Choice 3']),
+            ]),
+            ui.slider(name='slider', label='Slider', value=70),
+            ui.link(label='Link'),
+            ui.stepper(name='stepper', items=[
+                ui.step(label='Step 1', icon='MailLowImportance'),
+                ui.step(label='Step 2', icon='TaskManagerMirrored'),
+                ui.step(label='Step 3', icon='Cafe'),
+            ]),
+            ui.table(
+                name='table',
+                columns=[
+                    ui.table_column(name='name', label='Name'),
+                    ui.table_column(name='surname', label='Surname', filterable=True),
+                    ui.table_column(name='age', label='Age', sortable=True),
+                    ui.table_column(name='progress', label='Progress',
+                                    cell_type=ui.progress_table_cell_type(color='$themePrimary')),
+                ],
+                rows=[
+                    ui.table_row(name='row1', cells=['John', 'Doe', '25', '0.90']),
+                    ui.table_row(name='row2', cells=['Ann', 'Doe', '35', '0.75']),
+                    ui.table_row(name='row3', cells=['Casey', 'Smith', '40', '0.33']),
+                ],
+                height='330px',
+            ),
+            ui.buttons([
+                ui.button(name='primary_button', label='Primary', primary=True),
+                ui.button(name='standard_button', label='Standard'),
+                ui.button(name='standard_disabled_button', label='Standard', disabled=True),
+            ]),
+        ])
+        q.page['footer'] = ui.footer_card(box='footer', caption='(c) 2021 H2O.ai. All rights reserved.')
+        q.client.themes = [ui.theme(name='custom', colors=ui.colors(
+            text=q.client.text,
+            card=q.client.card,
+            page=q.client.page,
+            primary=q.client.primary
+        ))]
+        q.client.initialized = True
+
+    if q.args.primary:
+        q.client.themes[0].colors.primary = q.args.primary
+        q.client.primary = q.args.primary
+        # TODO: Remove after resolving https://github.com/h2oai/wave/issues/150.
+        q.page['form'].items[0].color_picker.value = q.args.primary
+    if q.args.text:
+        q.client.themes[0].colors.text = q.args.text
+        q.client.text = q.args.text
+        # TODO: Remove after resolving https://github.com/h2oai/wave/issues/150.
+        q.page['form'].items[1].color_picker.value = q.args.text
+    if q.args.card:
+        q.client.themes[0].colors.card = q.args.card
+        q.client.card = q.args.card
+        # TODO: Remove after resolving https://github.com/h2oai/wave/issues/150.
+        q.page['form'].items[2].color_picker.value = q.args.card
+    if q.args.page:
+        q.client.themes[0].colors.page = q.args.page
+        q.client.page = q.args.page
+        # TODO: Remove after resolving https://github.com/h2oai/wave/issues/150.
+        q.page['form'].items[3].color_picker.value = q.args.page
+
+    q.page['meta'].themes = q.client.themes
+    q.page['form'].items[5].frame.content = get_theme_code(q.client.text, q.client.card, q.client.page,
+                                                           q.client.primary)
+    await q.page.save()

--- a/py/examples/theme_generator.py
+++ b/py/examples/theme_generator.py
@@ -2,7 +2,9 @@
 # Use theme generator to quickly generate custom color schemes for your app.
 # #theme_generator
 # ---
-from h2o_wave import main, app, Q, ui
+from typing import Tuple
+from h2o_wave import main, app, Q, ui, data
+from .synth import FakeCategoricalSeries
 
 from pygments import highlight
 from pygments.formatters.html import HtmlFormatter
@@ -10,48 +12,88 @@ from pygments.lexers import get_lexer_by_name
 from pygments.style import Style
 from pygments.token import Name, String, Operator, Punctuation
 
+import math
+
 py_lexer = get_lexer_by_name('python')
 
 
-def get_theme_code(text: str, card: str, page: str, primary: str):
+def to_grayscale(color: float) -> float:
+    color /= 255
+    return color / 12.92 if color <= 0.03928 else math.pow((color + 0.055) / 1.055, 2.4)
+
+
+def get_luminance(r: float, g: float, b: float) -> float:
+    return to_grayscale(r) * 0.2126 + to_grayscale(g) * 0.7152 + to_grayscale(b) * 0.0722
+
+
+# Source: https://www.delftstack.com/howto/python/python-hex-to-rgb/.
+def hex_to_rgb(hex_color: str) -> Tuple[int, ...]:
+    if len(hex_color) == 3:
+        hex_color = f'{hex_color[0]}{hex_color[0]}{hex_color[1]}{hex_color[1]}{hex_color[2]}{hex_color[2]}'
+    return tuple(int(hex_color[i:i + 2], 16) for i in (0, 2, 4))
+
+
+# Source: https://stackoverflow.com/questions/9733288/how-to-programmatically-calculate-the-contrast-ratio-between-two-colors. # noqa
+def get_contrast(color1: str, color2: str, q: Q, min_contrast=4.5):
+    rgb1 = hex_to_rgb(q.client[color1].lstrip('#'))
+    rgb2 = hex_to_rgb(q.client[color2].lstrip('#'))
+    lum1 = get_luminance(rgb1[0], rgb1[1], rgb1[2])
+    lum2 = get_luminance(rgb2[0], rgb2[1], rgb2[2])
+    brightest = max(lum1, lum2)
+    darkest = min(lum1, lum2)
+    contrast = (brightest + 0.05) / (darkest + 0.05)
+    if contrast < min_contrast:
+        return ui.message_bar(type='error', text=f'Improve contrast between **{color1}** and **{color2}**.')
+    else:
+        return ui.message_bar(type='success', text=f'Contrast between **{color1}** and **{color2}** is great!')
+
+
+def get_theme_code(q: Q):
     contents = f'''
 ui.theme(
     name='<theme-name>',
     colors=ui.colors(
-        text='{text}',
-        card='{card}',
-        page='{page}',
-        primary='{primary}'
+        primary='{q.client.primary}',
+        text='{q.client.text}',
+        card='{q.client.card}',
+        page='{q.client.page}',
     )
-)'''
+)
+'''
 
     # Reference: http://svn.python.org/projects/external/Pygments-0.10/docs/build/styles.html
     class CustomStyle(Style):
         styles = {
-            Name: text,
-            Operator: text,
-            Punctuation: text,
-            String: primary
+            Name: q.client.text,
+            Operator: q.client.text,
+            Punctuation: q.client.text,
+            String: q.client.primary
         }
 
     html_formatter = HtmlFormatter(full=True, style=CustomStyle, nobackground=True)
-    return highlight(contents, py_lexer, html_formatter)
+    html = highlight(contents, py_lexer, html_formatter)
+    html = html.replace('<h2></h2>', '')
+    html = html.replace('<body>', '<body style="margin: 0 inherit">')
+    html = html.replace('<pre>', '<pre style="margin: 0">')
+    return html
 
 
 @app('/demo')
 async def serve(q: Q):
     if not q.client.initialized:
-        q.client.primary = '#000'
+        image = 'https://images.pexels.com/photos/220453/pexels-photo-220453.jpeg?auto=compress&h=750&w=1260'
+        f = FakeCategoricalSeries()
+        q.client.primary = '#000000'
         q.client.page = '#e2e2e2'
-        q.client.card = '#fff'
-        q.client.text = '#000'
+        q.client.card = '#ffffff'
+        q.client.text = '#000000'
         q.page['meta'] = ui.meta_card(box='', theme='custom', layouts=[
             ui.layout(
                 breakpoint='xs',
                 zones=[
                     ui.zone('header'),
                     ui.zone('content', direction=ui.ZoneDirection.ROW, zones=[
-                        ui.zone('colors', size='300px'),
+                        ui.zone('colors', size='340px'),
                         ui.zone('preview')
                     ]),
                     ui.zone('footer')
@@ -61,22 +103,25 @@ async def serve(q: Q):
         q.page['header'] = ui.header_card(box='header', title='Theme generator', subtitle='Color your app easily',
                                           icon='Color', icon_color='$card')
         q.page['form'] = ui.form_card(box='colors', items=[
-            ui.color_picker(name='primary', label='Primary', trigger=True, alpha=False, inline=True,
-                            value=q.client.primary),
+            ui.color_picker(name='primary', label='Primary', trigger=True, alpha=False, inline=True, value=q.client.primary),
             ui.color_picker(name='text', label='Text', trigger=True, alpha=False, inline=True, value=q.client.text),
             ui.color_picker(name='card', label='Card', trigger=True, alpha=False, inline=True, value=q.client.card),
             ui.color_picker(name='page', label='Page', trigger=True, alpha=False, inline=True, value=q.client.page),
-            ui.text_xl('Code to Copy'),
-            ui.frame(content=get_theme_code(q.client.text, q.client.card, q.client.page, q.client.primary),
-                     height='180px')
+            ui.text_xl('Check contrast'),
+            get_contrast('text', 'card', q),
+            get_contrast('card', 'primary', q),
+            get_contrast('text', 'page', q),
+            get_contrast('page', 'primary', q),
+            ui.text_xl('Copy code'),
+            ui.frame(content=get_theme_code(q), height='180px'),
         ])
         q.page['sample'] = ui.form_card(box='preview', items=[
-            ui.text_xl(content='Sample App to show off colors'),
+            ui.text_xl(content='Sample App to show colors'),
             ui.progress(label='A progress bar'),
             ui.inline([
                 ui.checkbox(name='checkbox1', label='A checkbox', value=True),
-                ui.checkbox(name='checkbox1', label='Another checkbox'),
-                ui.checkbox(name='checkbox1', label='Yet another checkbox'),
+                ui.checkbox(name='checkbox2', label='Another checkbox'),
+                ui.checkbox(name='checkbox3', label='Yet another checkbox'),
                 ui.toggle(name='toggle', label='Toggle', value=True),
             ]),
             ui.inline([
@@ -87,34 +132,51 @@ async def serve(q: Q):
                     ui.choice('choice3', label='Choice 3'),
                 ]),
                 ui.combobox(name='combobox', label='Combobox', choices=['Choice 1', 'Choice 2', 'Choice 3']),
+                ui.persona(title='John Doe', subtitle='Data Scientist', size='s', image=image),
             ]),
             ui.slider(name='slider', label='Slider', value=70),
             ui.link(label='Link'),
-            ui.stepper(name='stepper', items=[
-                ui.step(label='Step 1', icon='MailLowImportance'),
-                ui.step(label='Step 2', icon='TaskManagerMirrored'),
-                ui.step(label='Step 3', icon='Cafe'),
+            ui.inline(justify='between', items=[
+                ui.stepper(name='stepper', width='500px', items=[
+                    ui.step(label='Step 1', icon='MailLowImportance'),
+                    ui.step(label='Step 2', icon='TaskManagerMirrored'),
+                    ui.step(label='Step 3', icon='Cafe'),
+                ]),
+                ui.tabs(name='menu', value='email', items=[
+                    ui.tab(name='email', label='Mail', icon='Mail'),
+                    ui.tab(name='events', label='Events', icon='Calendar'),
+                    ui.tab(name='spam', label='Spam'),
+                ]),
             ]),
-            ui.table(
-                name='table',
-                columns=[
-                    ui.table_column(name='name', label='Name'),
-                    ui.table_column(name='surname', label='Surname', filterable=True),
-                    ui.table_column(name='age', label='Age', sortable=True),
-                    ui.table_column(name='progress', label='Progress',
-                                    cell_type=ui.progress_table_cell_type(color='$themePrimary')),
-                ],
-                rows=[
-                    ui.table_row(name='row1', cells=['John', 'Doe', '25', '0.90']),
-                    ui.table_row(name='row2', cells=['Ann', 'Doe', '35', '0.75']),
-                    ui.table_row(name='row3', cells=['Casey', 'Smith', '40', '0.33']),
-                ],
-                height='330px',
-            ),
+            ui.inline(items=[
+                ui.table(
+                    name='table',
+                    width='50%',
+                    columns=[
+                        ui.table_column(name='name', label='Name', min_width='80px'),
+                        ui.table_column(name='surname', label='Surname', filterable=True),
+                        ui.table_column(name='age', label='Age', sortable=True),
+                        ui.table_column(name='progress', label='Progress',
+                                        cell_type=ui.progress_table_cell_type(color='$themePrimary')),
+                    ],
+                    rows=[
+                        ui.table_row(name='row1', cells=['John', 'Doe', '25', '0.90']),
+                        ui.table_row(name='row2', cells=['Ann', 'Doe', '35', '0.75']),
+                        ui.table_row(name='row3', cells=['Casey', 'Smith', '40', '0.33']),
+                    ],
+                    height='330px',
+                ),
+                ui.visualization(
+                    width='50%',
+                    plot=ui.plot([ui.mark(type='interval', x='=product', y='=price', y_min=0)]),
+                    data=data(fields='product price', rows=[(c, x) for c, x, _ in [f.next() for _ in range(20)]], pack=True),
+                ),
+            ]),
             ui.buttons([
                 ui.button(name='primary_button', label='Primary', primary=True),
                 ui.button(name='standard_button', label='Standard'),
                 ui.button(name='standard_disabled_button', label='Standard', disabled=True),
+                ui.button(name='icon_button', icon='Heart', caption='Tooltip text'),
             ]),
         ])
         q.page['footer'] = ui.footer_card(box='footer', caption='(c) 2021 H2O.ai. All rights reserved.')
@@ -129,25 +191,20 @@ async def serve(q: Q):
     if q.args.primary:
         q.client.themes[0].colors.primary = q.args.primary
         q.client.primary = q.args.primary
-        # TODO: Remove after resolving https://github.com/h2oai/wave/issues/150.
-        q.page['form'].items[0].color_picker.value = q.args.primary
     if q.args.text:
         q.client.themes[0].colors.text = q.args.text
         q.client.text = q.args.text
-        # TODO: Remove after resolving https://github.com/h2oai/wave/issues/150.
-        q.page['form'].items[1].color_picker.value = q.args.text
     if q.args.card:
         q.client.themes[0].colors.card = q.args.card
         q.client.card = q.args.card
-        # TODO: Remove after resolving https://github.com/h2oai/wave/issues/150.
-        q.page['form'].items[2].color_picker.value = q.args.card
     if q.args.page:
         q.client.themes[0].colors.page = q.args.page
         q.client.page = q.args.page
-        # TODO: Remove after resolving https://github.com/h2oai/wave/issues/150.
-        q.page['form'].items[3].color_picker.value = q.args.page
 
     q.page['meta'].themes = q.client.themes
-    q.page['form'].items[5].frame.content = get_theme_code(q.client.text, q.client.card, q.client.page,
-                                                           q.client.primary)
+    q.page['form'].items[5] = get_contrast('text', 'card', q)
+    q.page['form'].items[6] = get_contrast('card', 'primary', q)
+    q.page['form'].items[7] = get_contrast('text', 'page', q)
+    q.page['form'].items[8] = get_contrast('page', 'primary', q)
+    q.page['form'].items[10].frame.content = get_theme_code(q)
     await q.page.save()

--- a/py/examples/theme_generator.py
+++ b/py/examples/theme_generator.py
@@ -52,12 +52,10 @@ def get_theme_code(q: Q):
     contents = f'''
 ui.theme(
     name='<theme-name>',
-    colors=ui.colors(
-        primary='{q.client.primary}',
-        text='{q.client.text}',
-        card='{q.client.card}',
-        page='{q.client.page}',
-    )
+    primary='{q.client.primary}',
+    text='{q.client.text}',
+    card='{q.client.card}',
+    page='{q.client.page}',
 )
 '''
 
@@ -180,25 +178,21 @@ async def serve(q: Q):
             ]),
         ])
         q.page['footer'] = ui.footer_card(box='footer', caption='(c) 2021 H2O.ai. All rights reserved.')
-        q.client.themes = [ui.theme(name='custom', colors=ui.colors(
-            text=q.client.text,
-            card=q.client.card,
-            page=q.client.page,
-            primary=q.client.primary
-        ))]
+        q.client.themes = [ui.theme(name='custom', text=q.client.text, card=q.client.card,
+                                    page=q.client.page, primary=q.client.primary)]
         q.client.initialized = True
 
     if q.args.primary:
-        q.client.themes[0].colors.primary = q.args.primary
+        q.client.themes[0].primary = q.args.primary
         q.client.primary = q.args.primary
     if q.args.text:
-        q.client.themes[0].colors.text = q.args.text
+        q.client.themes[0].text = q.args.text
         q.client.text = q.args.text
     if q.args.card:
-        q.client.themes[0].colors.card = q.args.card
+        q.client.themes[0].card = q.args.card
         q.client.card = q.args.card
     if q.args.page:
-        q.client.themes[0].colors.page = q.args.page
+        q.client.themes[0].page = q.args.page
         q.client.page = q.args.page
 
     q.page['meta'].themes = q.client.themes

--- a/py/examples/tour.conf
+++ b/py/examples/tour.conf
@@ -182,6 +182,7 @@ meta_notification.py
 meta_refresh.py
 meta_redirect.py
 meta_theme.py
+theme_generator.py
 meta_tracking.py
 counter_global.py
 counter_broadcast.py

--- a/py/h2o_wave/types.py
+++ b/py/h2o_wave/types.py
@@ -2839,7 +2839,10 @@ class DatePicker:
 
 
 class ColorPicker:
-    """No documentation available.
+    """Create a color picker.
+
+    A date picker allows a user to pick a color value.
+    If the 'choices' parameter is set, a swatch picker is displayed instead of the standard color picker.
     """
     def __init__(
             self,
@@ -2848,6 +2851,8 @@ class ColorPicker:
             value: Optional[str] = None,
             choices: Optional[List[str]] = None,
             width: Optional[str] = None,
+            alpha: Optional[bool] = None,
+            inline: Optional[bool] = None,
             visible: Optional[bool] = None,
             trigger: Optional[bool] = None,
             tooltip: Optional[str] = None,
@@ -2857,6 +2862,8 @@ class ColorPicker:
         _guard_scalar('ColorPicker.value', value, (str,), False, True, False)
         _guard_vector('ColorPicker.choices', choices, (str,), False, True, False)
         _guard_scalar('ColorPicker.width', width, (str,), False, True, False)
+        _guard_scalar('ColorPicker.alpha', alpha, (bool,), False, True, False)
+        _guard_scalar('ColorPicker.inline', inline, (bool,), False, True, False)
         _guard_scalar('ColorPicker.visible', visible, (bool,), False, True, False)
         _guard_scalar('ColorPicker.trigger', trigger, (bool,), False, True, False)
         _guard_scalar('ColorPicker.tooltip', tooltip, (str,), False, True, False)
@@ -2869,9 +2876,13 @@ class ColorPicker:
         self.choices = choices
         """A list of colors (CSS-compatible strings) to limit color choices to."""
         self.width = width
-        """No documentation available."""
+        """The width of the color picker, e.g. '100px'. Defaults to '300px'."""
+        self.alpha = alpha
+        """True if user should be allowed to pick color transparency. Defaults to "true"."""
+        self.inline = inline
+        """True if color picker should be displayed inline (takes less space). Doesn't work with choices specified. Defaults to "false"."""
         self.visible = visible
-        """No documentation available."""
+        """True if the component should be visible. Defaults to true."""
         self.trigger = trigger
         """True if the form should be submitted when the color picker value changes."""
         self.tooltip = tooltip
@@ -2884,6 +2895,8 @@ class ColorPicker:
         _guard_scalar('ColorPicker.value', self.value, (str,), False, True, False)
         _guard_vector('ColorPicker.choices', self.choices, (str,), False, True, False)
         _guard_scalar('ColorPicker.width', self.width, (str,), False, True, False)
+        _guard_scalar('ColorPicker.alpha', self.alpha, (bool,), False, True, False)
+        _guard_scalar('ColorPicker.inline', self.inline, (bool,), False, True, False)
         _guard_scalar('ColorPicker.visible', self.visible, (bool,), False, True, False)
         _guard_scalar('ColorPicker.trigger', self.trigger, (bool,), False, True, False)
         _guard_scalar('ColorPicker.tooltip', self.tooltip, (str,), False, True, False)
@@ -2893,6 +2906,8 @@ class ColorPicker:
             value=self.value,
             choices=self.choices,
             width=self.width,
+            alpha=self.alpha,
+            inline=self.inline,
             visible=self.visible,
             trigger=self.trigger,
             tooltip=self.tooltip,
@@ -2911,6 +2926,10 @@ class ColorPicker:
         _guard_vector('ColorPicker.choices', __d_choices, (str,), False, True, False)
         __d_width: Any = __d.get('width')
         _guard_scalar('ColorPicker.width', __d_width, (str,), False, True, False)
+        __d_alpha: Any = __d.get('alpha')
+        _guard_scalar('ColorPicker.alpha', __d_alpha, (bool,), False, True, False)
+        __d_inline: Any = __d.get('inline')
+        _guard_scalar('ColorPicker.inline', __d_inline, (bool,), False, True, False)
         __d_visible: Any = __d.get('visible')
         _guard_scalar('ColorPicker.visible', __d_visible, (bool,), False, True, False)
         __d_trigger: Any = __d.get('trigger')
@@ -2922,6 +2941,8 @@ class ColorPicker:
         value: Optional[str] = __d_value
         choices: Optional[List[str]] = __d_choices
         width: Optional[str] = __d_width
+        alpha: Optional[bool] = __d_alpha
+        inline: Optional[bool] = __d_inline
         visible: Optional[bool] = __d_visible
         trigger: Optional[bool] = __d_trigger
         tooltip: Optional[str] = __d_tooltip
@@ -2931,6 +2952,8 @@ class ColorPicker:
             value,
             choices,
             width,
+            alpha,
+            inline,
             visible,
             trigger,
             tooltip,

--- a/py/h2o_wave/types.py
+++ b/py/h2o_wave/types.py
@@ -2878,11 +2878,11 @@ class ColorPicker:
         self.width = width
         """The width of the color picker, e.g. '100px'. Defaults to '300px'."""
         self.alpha = alpha
-        """True if user should be allowed to pick color transparency. Defaults to "true"."""
+        """True if user should be allowed to pick color transparency. Defaults to 'true'."""
         self.inline = inline
-        """True if color picker should be displayed inline (takes less space). Doesn't work with choices specified. Defaults to "false"."""
+        """True if color picker should be displayed inline (takes less space). Doesn't work with choices specified. Defaults to 'false'."""
         self.visible = visible
-        """True if the component should be visible. Defaults to true."""
+        """True if the component should be visible. Defaults to 'true'."""
         self.trigger = trigger
         """True if the form should be submitted when the color picker value changes."""
         self.tooltip = tooltip

--- a/py/h2o_wave/types.py
+++ b/py/h2o_wave/types.py
@@ -2839,10 +2839,7 @@ class DatePicker:
 
 
 class ColorPicker:
-    """Create a color picker.
-
-    A date picker allows a user to pick a color value.
-    If the 'choices' parameter is set, a swatch picker is displayed instead of the standard color picker.
+    """No documentation available.
     """
     def __init__(
             self,
@@ -2872,9 +2869,9 @@ class ColorPicker:
         self.choices = choices
         """A list of colors (CSS-compatible strings) to limit color choices to."""
         self.width = width
-        """The width of the color picker, e.g. '100px'. Defaults to '300px'."""
+        """No documentation available."""
         self.visible = visible
-        """True if the component should be visible. Defaults to true."""
+        """No documentation available."""
         self.trigger = trigger
         """True if the form should be submitted when the color picker value changes."""
         self.tooltip = tooltip
@@ -7820,6 +7817,104 @@ class SidePanel:
         )
 
 
+class Colors:
+    """Represents colors to be used in your app.
+    """
+    def __init__(
+            self,
+            text: str,
+            card: str,
+            page: str,
+            primary: str,
+    ):
+        _guard_scalar('Colors.text', text, (str,), False, False, False)
+        _guard_scalar('Colors.card', card, (str,), False, False, False)
+        _guard_scalar('Colors.page', page, (str,), False, False, False)
+        _guard_scalar('Colors.primary', primary, (str,), False, False, False)
+        self.text = text
+        """Base color of the textual components."""
+        self.card = card
+        """Card background color."""
+        self.page = page
+        """Page background color."""
+        self.primary = primary
+        """Primary color used to accent components."""
+
+    def dump(self) -> Dict:
+        """Returns the contents of this object as a dict."""
+        _guard_scalar('Colors.text', self.text, (str,), False, False, False)
+        _guard_scalar('Colors.card', self.card, (str,), False, False, False)
+        _guard_scalar('Colors.page', self.page, (str,), False, False, False)
+        _guard_scalar('Colors.primary', self.primary, (str,), False, False, False)
+        return _dump(
+            text=self.text,
+            card=self.card,
+            page=self.page,
+            primary=self.primary,
+        )
+
+    @staticmethod
+    def load(__d: Dict) -> 'Colors':
+        """Creates an instance of this class using the contents of a dict."""
+        __d_text: Any = __d.get('text')
+        _guard_scalar('Colors.text', __d_text, (str,), False, False, False)
+        __d_card: Any = __d.get('card')
+        _guard_scalar('Colors.card', __d_card, (str,), False, False, False)
+        __d_page: Any = __d.get('page')
+        _guard_scalar('Colors.page', __d_page, (str,), False, False, False)
+        __d_primary: Any = __d.get('primary')
+        _guard_scalar('Colors.primary', __d_primary, (str,), False, False, False)
+        text: str = __d_text
+        card: str = __d_card
+        page: str = __d_page
+        primary: str = __d_primary
+        return Colors(
+            text,
+            card,
+            page,
+            primary,
+        )
+
+
+class Theme:
+    """Theme (color scheme) to apply colors to the app.
+    """
+    def __init__(
+            self,
+            name: str,
+            colors: Colors,
+    ):
+        _guard_scalar('Theme.name', name, (str,), True, False, False)
+        _guard_scalar('Theme.colors', colors, (Colors,), False, False, False)
+        self.name = name
+        """An identifying name for this theme."""
+        self.colors = colors
+        """Specific colors to be used in the app."""
+
+    def dump(self) -> Dict:
+        """Returns the contents of this object as a dict."""
+        _guard_scalar('Theme.name', self.name, (str,), True, False, False)
+        _guard_scalar('Theme.colors', self.colors, (Colors,), False, False, False)
+        return _dump(
+            name=self.name,
+            colors=self.colors.dump(),
+        )
+
+    @staticmethod
+    def load(__d: Dict) -> 'Theme':
+        """Creates an instance of this class using the contents of a dict."""
+        __d_name: Any = __d.get('name')
+        _guard_scalar('Theme.name', __d_name, (str,), True, False, False)
+        __d_colors: Any = __d.get('colors')
+        _guard_scalar('Theme.colors', __d_colors, (dict,), False, False, False)
+        name: str = __d_name
+        colors: Colors = Colors.load(__d_colors)
+        return Theme(
+            name,
+            colors,
+        )
+
+
 _TrackerType = ['ga', 'gtag']
 
 
@@ -8091,6 +8186,7 @@ class MetaCard:
             dialog: Optional[Dialog] = None,
             side_panel: Optional[SidePanel] = None,
             theme: Optional[str] = None,
+            themes: Optional[List[Theme]] = None,
             tracker: Optional[Tracker] = None,
             scripts: Optional[List[Script]] = None,
             script: Optional[InlineScript] = None,
@@ -8108,6 +8204,7 @@ class MetaCard:
         _guard_scalar('MetaCard.dialog', dialog, (Dialog,), False, True, False)
         _guard_scalar('MetaCard.side_panel', side_panel, (SidePanel,), False, True, False)
         _guard_scalar('MetaCard.theme', theme, (str,), False, True, False)
+        _guard_vector('MetaCard.themes', themes, (Theme,), False, True, False)
         _guard_scalar('MetaCard.tracker', tracker, (Tracker,), False, True, False)
         _guard_vector('MetaCard.scripts', scripts, (Script,), False, True, False)
         _guard_scalar('MetaCard.script', script, (InlineScript,), False, True, False)
@@ -8134,6 +8231,8 @@ class MetaCard:
         """Display a side panel on the page."""
         self.theme = theme
         """Specify the name of the theme (color scheme) to use on this page. One of 'light', 'neon' or 'h2o-dark'."""
+        self.themes = themes
+        """* Themes (color schemes) that define color used in the app."""
         self.tracker = tracker
         """Configure a tracker for the page (for web analytics)."""
         self.scripts = scripts
@@ -8159,6 +8258,7 @@ class MetaCard:
         _guard_scalar('MetaCard.dialog', self.dialog, (Dialog,), False, True, False)
         _guard_scalar('MetaCard.side_panel', self.side_panel, (SidePanel,), False, True, False)
         _guard_scalar('MetaCard.theme', self.theme, (str,), False, True, False)
+        _guard_vector('MetaCard.themes', self.themes, (Theme,), False, True, False)
         _guard_scalar('MetaCard.tracker', self.tracker, (Tracker,), False, True, False)
         _guard_vector('MetaCard.scripts', self.scripts, (Script,), False, True, False)
         _guard_scalar('MetaCard.script', self.script, (InlineScript,), False, True, False)
@@ -8177,6 +8277,7 @@ class MetaCard:
             dialog=None if self.dialog is None else self.dialog.dump(),
             side_panel=None if self.side_panel is None else self.side_panel.dump(),
             theme=self.theme,
+            themes=None if self.themes is None else [__e.dump() for __e in self.themes],
             tracker=None if self.tracker is None else self.tracker.dump(),
             scripts=None if self.scripts is None else [__e.dump() for __e in self.scripts],
             script=None if self.script is None else self.script.dump(),
@@ -8208,6 +8309,8 @@ class MetaCard:
         _guard_scalar('MetaCard.side_panel', __d_side_panel, (dict,), False, True, False)
         __d_theme: Any = __d.get('theme')
         _guard_scalar('MetaCard.theme', __d_theme, (str,), False, True, False)
+        __d_themes: Any = __d.get('themes')
+        _guard_vector('MetaCard.themes', __d_themes, (dict,), False, True, False)
         __d_tracker: Any = __d.get('tracker')
         _guard_scalar('MetaCard.tracker', __d_tracker, (dict,), False, True, False)
         __d_scripts: Any = __d.get('scripts')
@@ -8230,6 +8333,7 @@ class MetaCard:
         dialog: Optional[Dialog] = None if __d_dialog is None else Dialog.load(__d_dialog)
         side_panel: Optional[SidePanel] = None if __d_side_panel is None else SidePanel.load(__d_side_panel)
         theme: Optional[str] = __d_theme
+        themes: Optional[List[Theme]] = None if __d_themes is None else [Theme.load(__e) for __e in __d_themes]
         tracker: Optional[Tracker] = None if __d_tracker is None else Tracker.load(__d_tracker)
         scripts: Optional[List[Script]] = None if __d_scripts is None else [Script.load(__e) for __e in __d_scripts]
         script: Optional[InlineScript] = None if __d_script is None else InlineScript.load(__d_script)
@@ -8247,6 +8351,7 @@ class MetaCard:
             dialog,
             side_panel,
             theme,
+            themes,
             tracker,
             scripts,
             script,

--- a/py/h2o_wave/types.py
+++ b/py/h2o_wave/types.py
@@ -7840,20 +7840,24 @@ class SidePanel:
         )
 
 
-class Colors:
-    """Represents colors to be used in your app.
+class Theme:
+    """Theme (color scheme) to apply colors to the app.
     """
     def __init__(
             self,
+            name: str,
             text: str,
             card: str,
             page: str,
             primary: str,
     ):
-        _guard_scalar('Colors.text', text, (str,), False, False, False)
-        _guard_scalar('Colors.card', card, (str,), False, False, False)
-        _guard_scalar('Colors.page', page, (str,), False, False, False)
-        _guard_scalar('Colors.primary', primary, (str,), False, False, False)
+        _guard_scalar('Theme.name', name, (str,), True, False, False)
+        _guard_scalar('Theme.text', text, (str,), False, False, False)
+        _guard_scalar('Theme.card', card, (str,), False, False, False)
+        _guard_scalar('Theme.page', page, (str,), False, False, False)
+        _guard_scalar('Theme.primary', primary, (str,), False, False, False)
+        self.name = name
+        """An identifying name for this theme."""
         self.text = text
         """Base color of the textual components."""
         self.card = card
@@ -7865,11 +7869,13 @@ class Colors:
 
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""
-        _guard_scalar('Colors.text', self.text, (str,), False, False, False)
-        _guard_scalar('Colors.card', self.card, (str,), False, False, False)
-        _guard_scalar('Colors.page', self.page, (str,), False, False, False)
-        _guard_scalar('Colors.primary', self.primary, (str,), False, False, False)
+        _guard_scalar('Theme.name', self.name, (str,), True, False, False)
+        _guard_scalar('Theme.text', self.text, (str,), False, False, False)
+        _guard_scalar('Theme.card', self.card, (str,), False, False, False)
+        _guard_scalar('Theme.page', self.page, (str,), False, False, False)
+        _guard_scalar('Theme.primary', self.primary, (str,), False, False, False)
         return _dump(
+            name=self.name,
             text=self.text,
             card=self.card,
             page=self.page,
@@ -7877,64 +7883,29 @@ class Colors:
         )
 
     @staticmethod
-    def load(__d: Dict) -> 'Colors':
-        """Creates an instance of this class using the contents of a dict."""
-        __d_text: Any = __d.get('text')
-        _guard_scalar('Colors.text', __d_text, (str,), False, False, False)
-        __d_card: Any = __d.get('card')
-        _guard_scalar('Colors.card', __d_card, (str,), False, False, False)
-        __d_page: Any = __d.get('page')
-        _guard_scalar('Colors.page', __d_page, (str,), False, False, False)
-        __d_primary: Any = __d.get('primary')
-        _guard_scalar('Colors.primary', __d_primary, (str,), False, False, False)
-        text: str = __d_text
-        card: str = __d_card
-        page: str = __d_page
-        primary: str = __d_primary
-        return Colors(
-            text,
-            card,
-            page,
-            primary,
-        )
-
-
-class Theme:
-    """Theme (color scheme) to apply colors to the app.
-    """
-    def __init__(
-            self,
-            name: str,
-            colors: Colors,
-    ):
-        _guard_scalar('Theme.name', name, (str,), True, False, False)
-        _guard_scalar('Theme.colors', colors, (Colors,), False, False, False)
-        self.name = name
-        """An identifying name for this theme."""
-        self.colors = colors
-        """Specific colors to be used in the app."""
-
-    def dump(self) -> Dict:
-        """Returns the contents of this object as a dict."""
-        _guard_scalar('Theme.name', self.name, (str,), True, False, False)
-        _guard_scalar('Theme.colors', self.colors, (Colors,), False, False, False)
-        return _dump(
-            name=self.name,
-            colors=self.colors.dump(),
-        )
-
-    @staticmethod
     def load(__d: Dict) -> 'Theme':
         """Creates an instance of this class using the contents of a dict."""
         __d_name: Any = __d.get('name')
         _guard_scalar('Theme.name', __d_name, (str,), True, False, False)
-        __d_colors: Any = __d.get('colors')
-        _guard_scalar('Theme.colors', __d_colors, (dict,), False, False, False)
+        __d_text: Any = __d.get('text')
+        _guard_scalar('Theme.text', __d_text, (str,), False, False, False)
+        __d_card: Any = __d.get('card')
+        _guard_scalar('Theme.card', __d_card, (str,), False, False, False)
+        __d_page: Any = __d.get('page')
+        _guard_scalar('Theme.page', __d_page, (str,), False, False, False)
+        __d_primary: Any = __d.get('primary')
+        _guard_scalar('Theme.primary', __d_primary, (str,), False, False, False)
         name: str = __d_name
-        colors: Colors = Colors.load(__d_colors)
+        text: str = __d_text
+        card: str = __d_card
+        page: str = __d_page
+        primary: str = __d_primary
         return Theme(
             name,
-            colors,
+            text,
+            card,
+            page,
+            primary,
         )
 
 

--- a/py/h2o_wave/ui.py
+++ b/py/h2o_wave/ui.py
@@ -1129,9 +1129,9 @@ def color_picker(
         value: The selected color (CSS-compatible string).
         choices: A list of colors (CSS-compatible strings) to limit color choices to.
         width: The width of the color picker, e.g. '100px'. Defaults to '300px'.
-        alpha: True if user should be allowed to pick color transparency. Defaults to "true".
-        inline: True if color picker should be displayed inline (takes less space). Doesn't work with choices specified. Defaults to "false".
-        visible: True if the component should be visible. Defaults to true.
+        alpha: True if user should be allowed to pick color transparency. Defaults to 'true'.
+        inline: True if color picker should be displayed inline (takes less space). Doesn't work with choices specified. Defaults to 'false'.
+        visible: True if the component should be visible. Defaults to 'true'.
         trigger: True if the form should be submitted when the color picker value changes.
         tooltip: An optional tooltip message displayed when a user clicks the help icon to the right of the component.
     Returns:

--- a/py/h2o_wave/ui.py
+++ b/py/h2o_wave/ui.py
@@ -1112,19 +1112,26 @@ def color_picker(
         value: Optional[str] = None,
         choices: Optional[List[str]] = None,
         width: Optional[str] = None,
+        alpha: Optional[bool] = None,
+        inline: Optional[bool] = None,
         visible: Optional[bool] = None,
         trigger: Optional[bool] = None,
         tooltip: Optional[str] = None,
 ) -> Component:
-    """No documentation available.
+    """Create a color picker.
+
+    A date picker allows a user to pick a color value.
+    If the 'choices' parameter is set, a swatch picker is displayed instead of the standard color picker.
 
     Args:
         name: An identifying name for this component.
         label: Text to be displayed alongside the component.
         value: The selected color (CSS-compatible string).
         choices: A list of colors (CSS-compatible strings) to limit color choices to.
-        width: No documentation available.
-        visible: No documentation available.
+        width: The width of the color picker, e.g. '100px'. Defaults to '300px'.
+        alpha: True if user should be allowed to pick color transparency. Defaults to "true".
+        inline: True if color picker should be displayed inline (takes less space). Doesn't work with choices specified. Defaults to "false".
+        visible: True if the component should be visible. Defaults to true.
         trigger: True if the form should be submitted when the color picker value changes.
         tooltip: An optional tooltip message displayed when a user clicks the help icon to the right of the component.
     Returns:
@@ -1136,6 +1143,8 @@ def color_picker(
         value,
         choices,
         width,
+        alpha,
+        inline,
         visible,
         trigger,
         tooltip,

--- a/py/h2o_wave/ui.py
+++ b/py/h2o_wave/ui.py
@@ -1116,18 +1116,15 @@ def color_picker(
         trigger: Optional[bool] = None,
         tooltip: Optional[str] = None,
 ) -> Component:
-    """Create a color picker.
-
-    A date picker allows a user to pick a color value.
-    If the 'choices' parameter is set, a swatch picker is displayed instead of the standard color picker.
+    """No documentation available.
 
     Args:
         name: An identifying name for this component.
         label: Text to be displayed alongside the component.
         value: The selected color (CSS-compatible string).
         choices: A list of colors (CSS-compatible strings) to limit color choices to.
-        width: The width of the color picker, e.g. '100px'. Defaults to '300px'.
-        visible: True if the component should be visible. Defaults to true.
+        width: No documentation available.
+        visible: No documentation available.
         trigger: True if the form should be submitted when the color picker value changes.
         tooltip: An optional tooltip message displayed when a user clicks the help icon to the right of the component.
     Returns:
@@ -2759,6 +2756,48 @@ def side_panel(
     )
 
 
+def colors(
+        text: str,
+        card: str,
+        page: str,
+        primary: str,
+) -> Colors:
+    """Represents colors to be used in your app.
+
+    Args:
+        text: Base color of the textual components.
+        card: Card background color.
+        page: Page background color.
+        primary: Primary color used to accent components.
+    Returns:
+        A `h2o_wave.types.Colors` instance.
+    """
+    return Colors(
+        text,
+        card,
+        page,
+        primary,
+    )
+
+
+def theme(
+        name: str,
+        colors: Colors,
+) -> Theme:
+    """Theme (color scheme) to apply colors to the app.
+
+    Args:
+        name: An identifying name for this theme.
+        colors: Specific colors to be used in the app.
+    Returns:
+        A `h2o_wave.types.Theme` instance.
+    """
+    return Theme(
+        name,
+        colors,
+    )
+
+
 def tracker(
         type: str,
         id: str,
@@ -2875,6 +2914,7 @@ def meta_card(
         dialog: Optional[Dialog] = None,
         side_panel: Optional[SidePanel] = None,
         theme: Optional[str] = None,
+        themes: Optional[List[Theme]] = None,
         tracker: Optional[Tracker] = None,
         scripts: Optional[List[Script]] = None,
         script: Optional[InlineScript] = None,
@@ -2898,6 +2938,7 @@ def meta_card(
         dialog: Display a dialog on the page.
         side_panel: Display a side panel on the page.
         theme: Specify the name of the theme (color scheme) to use on this page. One of 'light', 'neon' or 'h2o-dark'.
+        themes: * Themes (color schemes) that define color used in the app.
         tracker: Configure a tracker for the page (for web analytics).
         scripts: External Javascript files to load into the page.
         script: Javascript code to execute on this page.
@@ -2918,6 +2959,7 @@ def meta_card(
         dialog,
         side_panel,
         theme,
+        themes,
         tracker,
         scripts,
         script,

--- a/py/h2o_wave/ui.py
+++ b/py/h2o_wave/ui.py
@@ -2765,45 +2765,30 @@ def side_panel(
     )
 
 
-def colors(
+def theme(
+        name: str,
         text: str,
         card: str,
         page: str,
         primary: str,
-) -> Colors:
-    """Represents colors to be used in your app.
-
-    Args:
-        text: Base color of the textual components.
-        card: Card background color.
-        page: Page background color.
-        primary: Primary color used to accent components.
-    Returns:
-        A `h2o_wave.types.Colors` instance.
-    """
-    return Colors(
-        text,
-        card,
-        page,
-        primary,
-    )
-
-
-def theme(
-        name: str,
-        colors: Colors,
 ) -> Theme:
     """Theme (color scheme) to apply colors to the app.
 
     Args:
         name: An identifying name for this theme.
-        colors: Specific colors to be used in the app.
+        text: Base color of the textual components.
+        card: Card background color.
+        page: Page background color.
+        primary: Primary color used to accent components.
     Returns:
         A `h2o_wave.types.Theme` instance.
     """
     return Theme(
         name,
-        colors,
+        text,
+        card,
+        page,
+        primary,
     )
 
 

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -1294,17 +1294,14 @@ ui_date_picker <- function(
   return(.o)
 }
 
-#' Create a color picker.
-#' 
-#' A date picker allows a user to pick a color value.
-#' If the 'choices' parameter is set, a swatch picker is displayed instead of the standard color picker.
+#' No documentation available.
 #'
 #' @param name An identifying name for this component.
 #' @param label Text to be displayed alongside the component.
 #' @param value The selected color (CSS-compatible string).
 #' @param choices A list of colors (CSS-compatible strings) to limit color choices to.
-#' @param width The width of the color picker, e.g. '100px'. Defaults to '300px'.
-#' @param visible True if the component should be visible. Defaults to true.
+#' @param width No documentation available.
+#' @param visible No documentation available.
 #' @param trigger True if the form should be submitted when the color picker value changes.
 #' @param tooltip An optional tooltip message displayed when a user clicks the help icon to the right of the component.
 #' @return A ColorPicker instance.
@@ -3227,6 +3224,50 @@ ui_side_panel <- function(
   return(.o)
 }
 
+#' Represents colors to be used in your app.
+#'
+#' @param text Base color of the textual components.
+#' @param card Card background color.
+#' @param page Page background color.
+#' @param primary Primary color used to accent components.
+#' @return A Colors instance.
+#' @export
+ui_colors <- function(
+  text,
+  card,
+  page,
+  primary) {
+  .guard_scalar("text", "character", text)
+  .guard_scalar("card", "character", card)
+  .guard_scalar("page", "character", page)
+  .guard_scalar("primary", "character", primary)
+  .o <- list(
+    text=text,
+    card=card,
+    page=page,
+    primary=primary)
+  class(.o) <- append(class(.o), c(.wave_obj, "WaveColors"))
+  return(.o)
+}
+
+#' Theme (color scheme) to apply colors to the app.
+#'
+#' @param name An identifying name for this theme.
+#' @param colors Specific colors to be used in the app.
+#' @return A Theme instance.
+#' @export
+ui_theme <- function(
+  name,
+  colors) {
+  .guard_scalar("name", "character", name)
+  .guard_scalar("colors", "WaveColors", colors)
+  .o <- list(
+    name=name,
+    colors=colors)
+  class(.o) <- append(class(.o), c(.wave_obj, "WaveTheme"))
+  return(.o)
+}
+
 #' Configure user interaction tracking (analytics) for a page.
 #'
 #' @param type The tracking provider. Supported providers are `ga` (Google Analytics) and `gtag` (Google Global Site Tags or gtag.js)
@@ -3354,6 +3395,7 @@ ui_stylesheet <- function(
 #' @param dialog Display a dialog on the page.
 #' @param side_panel Display a side panel on the page.
 #' @param theme Specify the name of the theme (color scheme) to use on this page. One of 'light', 'neon' or 'h2o-dark'.
+#' @param themes * Themes (color schemes) that define color used in the app.
 #' @param tracker Configure a tracker for the page (for web analytics).
 #' @param scripts External Javascript files to load into the page.
 #' @param script Javascript code to execute on this page.
@@ -3373,6 +3415,7 @@ ui_meta_card <- function(
   dialog = NULL,
   side_panel = NULL,
   theme = NULL,
+  themes = NULL,
   tracker = NULL,
   scripts = NULL,
   script = NULL,
@@ -3389,6 +3432,7 @@ ui_meta_card <- function(
   .guard_scalar("dialog", "WaveDialog", dialog)
   .guard_scalar("side_panel", "WaveSidePanel", side_panel)
   .guard_scalar("theme", "character", theme)
+  .guard_vector("themes", "WaveTheme", themes)
   .guard_scalar("tracker", "WaveTracker", tracker)
   .guard_vector("scripts", "WaveScript", scripts)
   .guard_scalar("script", "WaveInlineScript", script)
@@ -3406,6 +3450,7 @@ ui_meta_card <- function(
     dialog=dialog,
     side_panel=side_panel,
     theme=theme,
+    themes=themes,
     tracker=tracker,
     scripts=scripts,
     script=script,

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -1304,9 +1304,9 @@ ui_date_picker <- function(
 #' @param value The selected color (CSS-compatible string).
 #' @param choices A list of colors (CSS-compatible strings) to limit color choices to.
 #' @param width The width of the color picker, e.g. '100px'. Defaults to '300px'.
-#' @param alpha True if user should be allowed to pick color transparency. Defaults to "true".
-#' @param inline True if color picker should be displayed inline (takes less space). Doesn't work with choices specified. Defaults to "false".
-#' @param visible True if the component should be visible. Defaults to true.
+#' @param alpha True if user should be allowed to pick color transparency. Defaults to 'true'.
+#' @param inline True if color picker should be displayed inline (takes less space). Doesn't work with choices specified. Defaults to 'false'.
+#' @param visible True if the component should be visible. Defaults to 'true'.
 #' @param trigger True if the form should be submitted when the color picker value changes.
 #' @param tooltip An optional tooltip message displayed when a user clicks the help icon to the right of the component.
 #' @return A ColorPicker instance.

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -3235,46 +3235,32 @@ ui_side_panel <- function(
   return(.o)
 }
 
-#' Represents colors to be used in your app.
+#' Theme (color scheme) to apply colors to the app.
 #'
+#' @param name An identifying name for this theme.
 #' @param text Base color of the textual components.
 #' @param card Card background color.
 #' @param page Page background color.
 #' @param primary Primary color used to accent components.
-#' @return A Colors instance.
+#' @return A Theme instance.
 #' @export
-ui_colors <- function(
+ui_theme <- function(
+  name,
   text,
   card,
   page,
   primary) {
+  .guard_scalar("name", "character", name)
   .guard_scalar("text", "character", text)
   .guard_scalar("card", "character", card)
   .guard_scalar("page", "character", page)
   .guard_scalar("primary", "character", primary)
   .o <- list(
+    name=name,
     text=text,
     card=card,
     page=page,
     primary=primary)
-  class(.o) <- append(class(.o), c(.wave_obj, "WaveColors"))
-  return(.o)
-}
-
-#' Theme (color scheme) to apply colors to the app.
-#'
-#' @param name An identifying name for this theme.
-#' @param colors Specific colors to be used in the app.
-#' @return A Theme instance.
-#' @export
-ui_theme <- function(
-  name,
-  colors) {
-  .guard_scalar("name", "character", name)
-  .guard_scalar("colors", "WaveColors", colors)
-  .o <- list(
-    name=name,
-    colors=colors)
   class(.o) <- append(class(.o), c(.wave_obj, "WaveTheme"))
   return(.o)
 }

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -1294,14 +1294,19 @@ ui_date_picker <- function(
   return(.o)
 }
 
-#' No documentation available.
+#' Create a color picker.
+#' 
+#' A date picker allows a user to pick a color value.
+#' If the 'choices' parameter is set, a swatch picker is displayed instead of the standard color picker.
 #'
 #' @param name An identifying name for this component.
 #' @param label Text to be displayed alongside the component.
 #' @param value The selected color (CSS-compatible string).
 #' @param choices A list of colors (CSS-compatible strings) to limit color choices to.
-#' @param width No documentation available.
-#' @param visible No documentation available.
+#' @param width The width of the color picker, e.g. '100px'. Defaults to '300px'.
+#' @param alpha True if user should be allowed to pick color transparency. Defaults to "true".
+#' @param inline True if color picker should be displayed inline (takes less space). Doesn't work with choices specified. Defaults to "false".
+#' @param visible True if the component should be visible. Defaults to true.
 #' @param trigger True if the form should be submitted when the color picker value changes.
 #' @param tooltip An optional tooltip message displayed when a user clicks the help icon to the right of the component.
 #' @return A ColorPicker instance.
@@ -1312,6 +1317,8 @@ ui_color_picker <- function(
   value = NULL,
   choices = NULL,
   width = NULL,
+  alpha = NULL,
+  inline = NULL,
   visible = NULL,
   trigger = NULL,
   tooltip = NULL) {
@@ -1320,6 +1327,8 @@ ui_color_picker <- function(
   .guard_scalar("value", "character", value)
   .guard_vector("choices", "character", choices)
   .guard_scalar("width", "character", width)
+  .guard_scalar("alpha", "logical", alpha)
+  .guard_scalar("inline", "logical", inline)
   .guard_scalar("visible", "logical", visible)
   .guard_scalar("trigger", "logical", trigger)
   .guard_scalar("tooltip", "character", tooltip)
@@ -1329,6 +1338,8 @@ ui_color_picker <- function(
     value=value,
     choices=choices,
     width=width,
+    alpha=alpha,
+    inline=inline,
     visible=visible,
     trigger=trigger,
     tooltip=tooltip))

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -17,11 +17,11 @@ import { box, WaveErrorCode, WaveEventType } from 'h2o-wave'
 import React from 'react'
 import { stylesheet } from 'typestyle'
 import Dialog from './dialog'
-import SidePanel from './side_panel'
 import { LayoutPicker } from './editor'
 import { Logo } from './logo'
 import { PageLayout } from './page'
-import { clas, cssVar, pc, themeB } from './theme'
+import SidePanel from './side_panel'
+import { clas, cssVar, pc } from './theme'
 import { bond, busyB, config, contentB, listen, wave } from './ui'
 
 const
@@ -150,7 +150,7 @@ const
         window.removeEventListener('md-link-click', onMdLinkClick)
       }
 
-    return { init, render, dispose, contentB, themeB }
+    return { init, render, dispose, contentB }
   })
 
 export default App

--- a/ui/src/color_picker.tsx
+++ b/ui/src/color_picker.tsx
@@ -36,11 +36,11 @@ export interface ColorPicker {
   choices?: S[]
   /** The width of the color picker, e.g. '100px'. Defaults to '300px'. */
   width?: S
-  /** True if user should be allowed to pick color transparency. Defaults to "true". */
+  /** True if user should be allowed to pick color transparency. Defaults to 'true'. */
   alpha?: B
-  /** True if color picker should be displayed inline (takes less space). Doesn't work with choices specified. Defaults to "false". */
+  /** True if color picker should be displayed inline (takes less space). Doesn't work with choices specified. Defaults to 'false'. */
   inline?: B
-  /** True if the component should be visible. Defaults to true. */
+  /** True if the component should be visible. Defaults to 'true'. */
   visible?: B
   /** True if the form should be submitted when the color picker value changes. */
   trigger?: B

--- a/ui/src/color_picker.tsx
+++ b/ui/src/color_picker.tsx
@@ -54,7 +54,8 @@ const
     inlinePickerContainer: {
       display: 'flex',
       alignItems: 'center',
-      justifyContent: 'space-between'
+      justifyContent: 'space-between',
+      maxWidth: 250
     },
     preview: {
       width: 20,

--- a/ui/src/color_picker.tsx
+++ b/ui/src/color_picker.tsx
@@ -16,7 +16,6 @@ import * as Fluent from '@fluentui/react'
 import { B, Id, S } from 'h2o-wave'
 import React from 'react'
 import { stylesheet } from 'typestyle'
-import { bond, box } from './qd'
 import { border, cssVar, formItemWidth, margin } from './theme'
 import { wave } from './ui'
 
@@ -69,43 +68,42 @@ const
     }
   }),
   toColorCells = (cs: S[]) => cs.map((c): Fluent.IColorCellProps => ({ id: c, label: c, color: c })),
-  InlineColorPicker = bond(({ model, onChange }: { model: ColorPicker, onChange: (...args: any) => void }) => {
+  InlineColorPicker = ({ model, onChange }: { model: ColorPicker, onChange: (...args: any) => void }) => {
     const
-      isCalloutVisibleB = box(false),
+      [isCalloutVisible, setIsCalloutVisible] = React.useState(false),
       val = model.value || '#000',
-      colorValueB = box(Fluent.getColorFromString(val)),
-      textValueB = box(val),
-      toggleCallout = () => isCalloutVisibleB(!isCalloutVisibleB()),
+      [color, setColor] = React.useState(Fluent.getColorFromString(val)),
+      [colorText, setColorText] = React.useState(val),
+      toggleCallout = () => setIsCalloutVisible(!isCalloutVisible),
       onTextChange = (_e: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, val = '') => {
-        textValueB(val)
+        setColorText(val)
         if (!val?.match(/^#([0-9a-f]{3}){1,2}$/i)) return // Hex format validation.
 
         const fluentColor = Fluent.getColorFromString(val)!
-        colorValueB(fluentColor)
+        setColor(fluentColor)
         onChange(null, fluentColor)
       },
       onColorChange = (_e: React.SyntheticEvent<HTMLElement>, color: Fluent.IColor) => {
-        colorValueB(color)
-        textValueB(color.str)
+        setColor(color)
+        setColorText(color.str)
         onChange(null, color)
-      },
-      render = () => (
-        <div className={css.inlinePickerContainer}>
-          <Fluent.Label>{model.label}</Fluent.Label>
-          <div className={css.rhs}>
-            <div className={css.preview} style={{ background: colorValueB().str }} onClick={toggleCallout} />
-            {isCalloutVisibleB() && (
-              <Fluent.Callout directionalHint={Fluent.DirectionalHint.rightBottomEdge} target={`.${css.preview}`} onDismiss={toggleCallout} gapSpace={10}>
-                <Fluent.ColorPicker alphaType={model.alpha ? 'alpha' : 'none'} color={colorValueB()} onChange={onColorChange} />
-              </Fluent.Callout>
-            )}
-            <Fluent.TextField value={textValueB()} onChange={onTextChange} />
-          </div>
-        </div>
-      )
+      }
 
-    return { render, isCalloutVisibleB, colorValueB, textValueB }
-  })
+    return (
+      <div className={css.inlinePickerContainer}>
+        <Fluent.Label>{model.label}</Fluent.Label>
+        <div className={css.rhs}>
+          <div className={css.preview} style={{ background: color?.str }} onClick={toggleCallout} />
+          {isCalloutVisible && (
+            <Fluent.Callout directionalHint={Fluent.DirectionalHint.rightBottomEdge} target={`.${css.preview}`} onDismiss={toggleCallout} gapSpace={10}>
+              <Fluent.ColorPicker alphaType={model.alpha ? 'alpha' : 'none'} color={color!} onChange={onColorChange} />
+            </Fluent.Callout>
+          )}
+          <Fluent.TextField value={colorText} onChange={onTextChange} />
+        </div>
+      </div>
+    )
+  }
 
 export const
   XColorPicker = ({ model }: { model: ColorPicker }) => {
@@ -129,7 +127,6 @@ export const
 
     return (
       <div data-test={name}>
-        <Fluent.Label>{label}</Fluent.Label>
         {
           inline
             ? <InlineColorPicker model={model} onChange={onChange} />

--- a/ui/src/meta.tsx
+++ b/ui/src/meta.tsx
@@ -103,10 +103,12 @@ export interface Zone {
   zones?: Zone[]
 }
 
-/**
- * Represents colors to be used in your app.
- */
-interface Colors {
+/** 
+ * Theme (color scheme) to apply colors to the app.
+*/
+export interface Theme {
+  /** An identifying name for this theme. */
+  name: Id
   /** Base color of the textual components. */
   text: S
   /** Card background color. */
@@ -115,16 +117,6 @@ interface Colors {
   page: S
   /** Primary color used to accent components. */
   primary: S
-
-}
-/** 
- * Theme (color scheme) to apply colors to the app.
-*/
-export interface Theme {
-  /** An identifying name for this theme. */
-  name: Id
-  /** Specific colors to be used in the app. */
-  colors: Colors
 }
 
 /**

--- a/ui/src/meta.tsx
+++ b/ui/src/meta.tsx
@@ -19,7 +19,7 @@ import { cards } from './layout'
 import { showNotification } from './notification'
 import { executeScript, InlineScript, installScripts, Script } from './script'
 import { SidePanel, sidePanelB } from './side_panel'
-import { themeB } from './theme'
+import { themeB, themesB } from './theme'
 import { setupTracker, Tracker } from './tracking'
 import { bond } from './ui'
 
@@ -104,6 +104,30 @@ export interface Zone {
 }
 
 /**
+ * Represents colors to be used in your app.
+ */
+interface Colors {
+  /** Base color of the textual components. */
+  text: S
+  /** Card background color. */
+  card: S
+  /** Page background color. */
+  page: S
+  /** Primary color used to accent components. */
+  primary: S
+
+}
+/** 
+ * Theme (color scheme) to apply colors to the app.
+*/
+export interface Theme {
+  /** An identifying name for this theme. */
+  name: Id
+  /** Specific colors to be used in the app. */
+  colors: Colors
+}
+
+/**
  * Represents page-global state.
  *
  * This card is invisible.
@@ -131,6 +155,8 @@ interface State {
   side_panel?: SidePanel
   /** Specify the name of the theme (color scheme) to use on this page. One of 'light', 'neon' or 'h2o-dark'. */
   theme?: S
+  /** * Themes (color schemes) that define color used in the app. */
+  themes?: Theme[]
   /** Configure a tracker for the page (for web analytics). */
   tracker?: Tracker
   /** External Javascript files to load into the page. */
@@ -170,6 +196,7 @@ export const
       dialog,
       side_panel,
       theme,
+      themes,
       tracker,
       scripts,
       script,
@@ -200,6 +227,7 @@ export const
     if (icon) windowIconB(icon)
     if (typeof refresh === 'number' && refresh === 0) disconnect()
     if (theme) themeB(theme)
+    if (themes) themesB(themes)
     if (notification) showNotification(notification)
     if (tracker) setupTracker(tracker)
     if (layouts) layoutsB(layouts)

--- a/ui/src/theme.ts
+++ b/ui/src/theme.ts
@@ -254,9 +254,10 @@ export const
 on(themesB, newThemes => {
   newThemes.forEach(t => {
     const
-      primaryColor = Fluent.getColorFromString(t.colors.primary)!,
-      textColor = Fluent.getColorFromString(t.colors.text)!,
-      cardColor = Fluent.getColorFromString(t.colors.card)!
+      { text, primary, card, page } = t,
+      primaryColor = Fluent.getColorFromString(primary)!,
+      textColor = Fluent.getColorFromString(text)!,
+      cardColor = Fluent.getColorFromString(card)!
 
     Fluent.ThemeGenerator.setSlot(themeRules[Fluent.BaseSlots[Fluent.BaseSlots.primaryColor]], primaryColor, Fluent.isDark(primaryColor), true, true)
     Fluent.ThemeGenerator.setSlot(themeRules[Fluent.BaseSlots[Fluent.BaseSlots.foregroundColor]], textColor, Fluent.isDark(textColor), true, true)
@@ -268,7 +269,7 @@ on(themesB, newThemes => {
       isInverted: Fluent.isDark(cardColor),
     })
 
-    themes[t.name] = { fluentPalette: palette, palette: t.colors }
+    themes[t.name] = { fluentPalette: palette, palette: { text, card, page } }
   })
   changeTheme(themeB())
 })


### PR DESCRIPTION
This PR provides a way to easily generate color theme for a Wave app.

Custom theme specification:
```py
ui.meta_card(theme='<custom-theme-name>', themes=[ui.theme(name'<custom-theme-name>', text='\#000', card='\#fff', page=\'#e2e2e2', primary='\#000'])
```

Generator app is provided as a wave app, currently part of `Tour`, but can be distributed as separate app as well, same as `Dashboard demo`.

## Demo

https://user-images.githubusercontent.com/64769322/110339226-34ee1f00-8028-11eb-9348-c2fc0b640e75.mov

Blocked by #150 - to provide smooth dragging experience like in Demo above ^^

Minor additions:
* Picker uses Fluent label to be conssistent with Dropdown or Datepicker components.
* Color picker has 2 new attrs - `alpha` to forbid choosing transparency and `inline` that shows color picker in a Callout.

Dynamic theme generation based on [Fluent theming designer](https://github.com/microsoft/fluentui/tree/master/apps/theming-designer).

Possible improvements:
* make the layout responsive
* add a Copy to clipboard button

Closes #526