### PR TITLE
Fix table footer overflow menu

### DIFF
--- a/ui/src/table.tsx
+++ b/ui/src/table.tsx
@@ -352,7 +352,6 @@ export const
           </Fluent.Sticky>
         )
       },
-
       onRenderDetailsFooter = (props?: Fluent.IDetailsFooterProps) => {
         const searchOrFilter = searchableKeys.length || m.columns.some(c => c.filterable)
         if (!props || (!m.downloadable && !m.resettable && !searchOrFilter)) return null
@@ -368,12 +367,14 @@ export const
             <Fluent.Stack horizontal horizontalAlign={searchOrFilter ? 'space-between' : 'end'} verticalAlign='center'>
               {
                 searchOrFilter && (
-                  <Fluent.Text variant='smallPlus' block >Rows:
+                  <Fluent.Text variant='smallPlus' block styles={{ root: { whiteSpace: 'nowrap' } }}>Rows:
                     <b style={{ paddingLeft: 5 }}>{formatNum(filteredItemsB().length)} of {formatNum(items.length)}</b>
                   </Fluent.Text>
                 )
               }
-              <Fluent.CommandBar items={footerItems} styles={{ root: { background: cssVar('$card') } }} />
+              <div style={{ width: '80%' }}>
+                <Fluent.CommandBar items={footerItems} styles={{ root: { background: cssVar('$card') }, primarySet: { justifyContent: 'flex-end' } }} />
+              </div>
             </Fluent.Stack>
           </Fluent.Sticky>
         )


### PR DESCRIPTION
https://user-images.githubusercontent.com/64769322/111309172-e0682680-865b-11eb-827f-4519dafba540.mov

* Prevented _Rows x of y_ text from wrapping when screen size reduced.
* Added enough space for Download & Reset toolbar.

Closes #609