### PR TITLE
Stop scroll propagation for plots

### DIFF
--- a/ui/src/plot.tsx
+++ b/ui/src/plot.tsx
@@ -708,7 +708,6 @@ const
         geometries,
         annotations,
         interactions: [
-          { type: 'view-zoom' },
           { type: 'drag-move' }, // custom
         ],
         tooltip: {

--- a/ui/src/plot.tsx
+++ b/ui/src/plot.tsx
@@ -777,18 +777,11 @@ export const
           init()
         }
       },
-      onScroll = (e: WheelEvent) => {
-        const isFirefox = window.navigator.userAgent.includes('Firefox')
-        // Plot zoom-view doesn't work on Firefox so no need to prevent scrolling.
-        if (!isFirefox) e.preventDefault()
-      },
       init = () => {
         // Map CSS var colors to their hex values.
         cat10 = cat10.map(cssVarValue)
         const el = container.current
         if (!el) return
-        // Prevent page scroll from interfering with plot zooming.
-        if (!el.onwheel) el.onwheel = onScroll
         // If card does not have specified height, it uses content. Since the wrapper is empty, it takes very little space - set to 300px by default.
         if (el.clientHeight < 30) el.style.height = '300px'
         const
@@ -835,9 +828,6 @@ export const
           data = refactorData(raw_data, currentPlot.marks)
         currentChart.changeData(data)
       },
-      dispose = () => {
-        container.current?.removeEventListener('wheel', onScroll)
-      },
       render = () => {
         const
           { width = 'auto', height = 'auto', visible, name } = model,
@@ -846,7 +836,7 @@ export const
             : { width, height }
         return <div data-test={name} style={{ ...style, ...displayMixin(visible) }} className={css.plot} ref={container} />
       }
-    return { init, update, render, dispose }
+    return { init, update, render }
   })
 
 /** Create a card displaying a plot. */

--- a/ui/src/plot.tsx
+++ b/ui/src/plot.tsx
@@ -777,11 +777,18 @@ export const
           init()
         }
       },
+      onScroll = (e: WheelEvent) => {
+        const isFirefox = window.navigator.userAgent.includes('Firefox')
+        // Plot zoom-view doesn't work on Firefox so no need to prevent scrolling.
+        if (!isFirefox) e.preventDefault()
+      },
       init = () => {
         // Map CSS var colors to their hex values.
         cat10 = cat10.map(cssVarValue)
         const el = container.current
         if (!el) return
+        // Prevent page scroll from interfering with plot zooming.
+        if (!el.onwheel) el.onwheel = onScroll
         // If card does not have specified height, it uses content. Since the wrapper is empty, it takes very little space - set to 300px by default.
         if (el.clientHeight < 30) el.style.height = '300px'
         const
@@ -828,6 +835,9 @@ export const
           data = refactorData(raw_data, currentPlot.marks)
         currentChart.changeData(data)
       },
+      dispose = () => {
+        container.current?.removeEventListener('wheel', onScroll)
+      },
       render = () => {
         const
           { width = 'auto', height = 'auto', visible, name } = model,
@@ -836,7 +846,7 @@ export const
             : { width, height }
         return <div data-test={name} style={{ ...style, ...displayMixin(visible) }} className={css.plot} ref={container} />
       }
-    return { init, update, render }
+    return { init, update, render, dispose }
   })
 
 /** Create a card displaying a plot. */


### PR DESCRIPTION
It seems like this is a bug from the plotting lib. There are 2 possible solutions:
* Since `zoom-view` is not working on Firefox, one option is to remove it so that we get consistent behavior across all the browsers.
* If we however don't want to do that, this PR stops further event propagation thus page scroll does not happen. This behavior is turned off for Firefox as it makes no sense to forbid the page scroll and not provide zoom-view as well.

Fix in action:

https://user-images.githubusercontent.com/64769322/112176610-8980c500-8bf8-11eb-8b3b-ab5f0219aa0d.mov1

Closes #659