### PR TITLE
Fix CI by updating npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Update npm
+        run: npm i -g npm@7.11.1
+
       - name: Build
         run: |
           cd ui
@@ -35,6 +38,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           token: ${{ secrets.GIT_TOKEN }}
+
+      - name: Update npm
+        run: npm i -g npm@7.11.1
 
       - name: Setup
         run: make setup


### PR DESCRIPTION
Fixes release CI workflow.

This PR updates `npm` to version `7.11.1` in order to be able to work with `packge-lock` file v2.

Each job can run on different machine so npm has to be updated for both. I am not sure why we even have 2 workflows anyway. I would put unit tests as a separate step within `release` workflow, which would be cleaner and wouldn't require 2 npm installs for `ui` folder.