### PR TITLE
Fix legacy warning for Wave ML setup

### DIFF
--- a/py/Makefile
+++ b/py/Makefile
@@ -10,8 +10,8 @@ setup: ## Install dependencies
 	git clone --depth 1 --branch $(WAVE_ML_VERSION) https://github.com/h2oai/wave-ml.git h2o_wave_ml
 	python3 -m venv venv
 	./venv/bin/python -m pip install --upgrade pip
-	./venv/bin/python -m pip install h2o_wave_ml/
 	./venv/bin/python -m pip install setuptools wheel httpx uvicorn starlette pdoc3 pytest flake8
+	./venv/bin/python -m pip install h2o_wave_ml/
 	# TODO examples pip install is wasteful for CI
 	./venv/bin/python -m pip install -r examples/requirements.txt
 	./venv/bin/python -m pip install --editable .


### PR DESCRIPTION
If PR merged, the warning about using legacy install for Wave ML will vanish:
```
Using legacy 'setup.py install' for h2o-wave-ml, since package 'wheel' is not installed.
```
## Note
Wheel is needed if installing package locally by `setup.py` (`pip install .`). The message will not pop up if installed from indexed package (`pip install h2o-wave-ml`).