### PR TITLE
Auto correct website URL

### DIFF
--- a/website/blog/2021-04-28-release.md
+++ b/website/blog/2021-04-28-release.md
@@ -1,6 +1,6 @@
 ---
 slug: release-0.14
-title: Wave 0.14 released 
+title: Wave 0.14 released
 author: Prithvi Prabhu
 author_title: Chief of Technology @ H2O.ai
 author_url: https://github.com/lo5
@@ -26,7 +26,7 @@ All the work that has gone into this release sets the stage for adding support f
 
 ## Wave ML
 
-[Wave ML](https://github.com/h2oai/wave-ml) API documentation is now [available online](https://wave.h2o.ai/docs/api/h2o_wave_ml/index).
+[Wave ML](https://github.com/h2oai/wave-ml) API documentation is now [available online](/docs/api/h2o_wave_ml/index).
 
 ## Download
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -132,4 +132,11 @@ module.exports = {
       },
     ],
   ],
+  scripts: [
+    {
+      src: '/fix-location.js',
+      async: false,
+      defer: false,
+    },
+  ],
 };

--- a/website/static/fix-location.js
+++ b/website/static/fix-location.js
@@ -1,0 +1,7 @@
+// A workaround for the auto-slash host services such as GitHub pages, AWS, Azure Webservice, etc ...
+// This code will remove the slash from the url if the host service adds one. More info here:
+// https://github.com/h2oai/wave/issues/778#issuecomment-831188177
+
+if (window && window.location && window.location.pathname.endsWith('/') && window.location.pathname !== '/') {
+  window.history.replaceState('', '', window.location.pathname.substr(0, window.location.pathname.length - 1))
+}


### PR DESCRIPTION
If PR merged, two changes will be introduced to the repo:
- The link from the blog will be changed to a relative one so jump from the blog to API should not end up with a trailing slash.
- The script `fix-location.js` will be introduced to prevent a trailing slash.

This is the expected flow of the events:
1. User loads the page on e.g. `https://wave.h2o.ai/docs/api/index`
2. Web server responds with 302 (`Moved Temporarily`)
3. User loads the redirected page `https://wave.h2o.ai/docs/api/index/`
4. Script `fix-location.js` executes and fixes the URL to `https://wave.h2o.ai/docs/api/index`
5. React resolves relative links using `https://wave.h2o.ai/docs/api/index`.

I haven't tested this on AWS but I have partially tested it with several tools and it should work.

## Notes
- I was trying to modify *pdoc* to export better paths. Without success.
- I was also looking into AWS with @michal-raska. It seems there is no way to switch auto-slash on/off.

Resolves #778 #445