### PR TITLE
Update Wave ML docs to 0.6.0

### DIFF
--- a/py/Makefile
+++ b/py/Makefile
@@ -1,4 +1,4 @@
-WAVE_ML_VERSION := v0.5.0
+WAVE_ML_VERSION := v0.6.0
 
 all: build ## Build h2o_wave wheel
 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -59,6 +59,7 @@ module.exports = {
       'api/test',
       'api/h2o_wave_ml/index',
       'api/h2o_wave_ml/ml',
+      'api/h2o_wave_ml/types',
     ],
   },
 };


### PR DESCRIPTION
A new version of Wave ML is out. This PR updates the docs.