### PR TITLE
fix: Transpose plot when needed #801

### DIFF
--- a/ui/src/plot.tsx
+++ b/ui/src/plot.tsx
@@ -786,7 +786,7 @@ export const
         if (el.clientHeight < 30) el.style.height = '300px'
         const
           raw_data = unpack<any[]>(model.data),
-          raw_plot = unpack<Plot>(model.plot),
+          raw_plot = unpack<Plot>(JSON.parse(JSON.stringify(model.plot))), //HACK: Plot may be transposed so always work with own copy.
           marks = raw_plot.marks.map(refactorMark),
           plot: Plot = { marks: marks },
           space = spaceTypeOf(raw_data, marks),


### PR DESCRIPTION
Caused by: https://github.com/h2oai/wave/blob/7564195bdb5f9b5297ca294948672196edf971eb/ui/src/plot.tsx#L660

The problem was that transpose happens in place, mutating the original `model.plot` (due to obj reference) all the way up to page object stored in `contentB` in `App.tsx`. The issue happens with `form_card` only because currently, all the form items are recreated on every form render (#150). Flow:

1. Transpose plot marks.
2. Correctly return `coordinate` as [['transpose']] so that plot can be rendered correctly.
3. Change theme, which triggers React to update whole app.
4. Since form always recreates its children, recreate new plot, but this time with previously transposed data.
5. Render incorrect plot.

This PR solves this by making a deep copy of `model.plot` that is later worked with, which keeps the original reference (stored in `page`) from mutation.

@lo5 please let me know if this is viable solution since I am not familiar with all the reasoning behind transpose hack.

Closes #801