### PR TITLE
Update Wave ML docs to 0.7.0

### DIFF
--- a/py/Makefile
+++ b/py/Makefile
@@ -1,4 +1,4 @@
-WAVE_ML_VERSION := v0.6.0
+WAVE_ML_VERSION := v0.7.0
 
 all: build ## Build h2o_wave wheel
 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -61,6 +61,7 @@ module.exports = {
       'api/h2o_wave_ml/index',
       'api/h2o_wave_ml/ml',
       'api/h2o_wave_ml/types',
+      'api/h2o_wave_ml/utils',
     ],
   },
 };


### PR DESCRIPTION
A new version of Wave ML is out. The PR updates the docs.