### PR TITLE
Preserve hash in docs url

### DIFF
--- a/website/static/fix-location.js
+++ b/website/static/fix-location.js
@@ -3,5 +3,5 @@
 // https://github.com/h2oai/wave/issues/778#issuecomment-831188177
 
 if (window && window.location && window.location.pathname.endsWith('/') && window.location.pathname !== '/') {
-  window.history.replaceState('', '', window.location.pathname.substr(0, window.location.pathname.length - 1))
+  window.history.replaceState('', '', window.location.pathname.substr(0, window.location.pathname.length - 1) + window.location.hash)
 }


### PR DESCRIPTION
This is a continuation of #783. @vopani realized the hashes in docs are mishandled, i.e.: `https://wave.h2o.ai/docs/api/h2o_wave_ml/ml/#build_model` redirects to `https://wave.h2o.ai/docs/api/h2o_wave_ml/ml`.

PR will preserve hash.

## Notes

- This fix was tested directly on `https://wave.h2o.ai/`. Actually, the page has fix already present.

