### PR TITLE
fix: Drop dups and sort filenames from dir

### DIFF
--- a/py/sync_examples.py
+++ b/py/sync_examples.py
@@ -223,11 +223,14 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 
 def main():
-    filenames = [line.strip() for line in read_lines(os.path.join(example_dir, 'tour.conf')) if
-                 not line.strip().startswith('#')]
+    tour_filenames = [line.strip() for line in read_lines(os.path.join(example_dir, 'tour.conf'))
+                      if not line.strip().startswith('#')]
 
-    filenames += [f for f in os.listdir(example_dir) if f.startswith('db') or f.startswith('ml')]
+    dir_filenames = [f for f in os.listdir(example_dir)
+                     if f.startswith('db') or f.startswith('ml') and f not in tour_filenames]
+    dir_filenames.sort()
 
+    filenames = tour_filenames + dir_filenames
     examples = [load_example(filename) for filename in filenames]
 
     example_md_dir = os.path.join(website_dir, 'docs', 'examples')


### PR DESCRIPTION
PR will fix the examples list on Wave page.

There are 2 errors currently:

- Examples are added twice if listed in `tour.conf` and have the prefix `ml` or `db`.
- Examples read by `listdir()` are unsorted (seemingly random).