### PR TITLE
Update Wave ML docs to 0.8.0

### DIFF
--- a/py/Makefile
+++ b/py/Makefile
@@ -1,4 +1,4 @@
-WAVE_ML_VERSION := v0.7.0
+WAVE_ML_VERSION := v0.8.0
 
 all: build ## Build h2o_wave wheel
 


### PR DESCRIPTION
A new version of Wave ML is out. The PR updates the docs.