### PR TITLE
WaveML DAI examples

### DIFF
--- a/py/examples/ml_dai.py
+++ b/py/examples/ml_dai.py
@@ -1,0 +1,117 @@
+# WaveML / DAI
+# Build Wave Models for training and prediction of classification or regression using Driverless AI.
+# ---
+import os
+
+from h2o_wave import main, app, Q, ui
+from h2o_wave_ml import build_model, ModelType
+from h2o_wave_ml.utils import list_dai_instances
+
+from sklearn.datasets import load_wine
+from sklearn.model_selection import train_test_split
+
+STEAM_URL = os.environ.get('STEAM_URL')
+MLOPS_URL = os.environ.get('MLOPS_URL')
+
+
+@app('/demo')
+async def serve(q: Q):
+    if 'H2_CLOUD_ENVIRONMENT' not in os.environ:
+        q.page['example'] = ui.form_card(
+            box='1 1 -1 -1',
+            items=[
+                ui.text('''This example requires access to Driverless AI running on
+                    <a href="https://h2oai.github.io/h2o-ai-cloud" target="_blank">H2O AI Hybrid Cloud</a> 
+                    and does not support standalone app instances.'''),
+                ui.text('''Sign up at <a href="https://h2o.ai/free" target="_blank">https://h2o.ai/free</a>
+                    to run apps on cloud.''')
+            ]
+        )
+    elif q.args.train:
+        # get DAI instance name
+        for dai_instance in q.client.dai_instances:
+            if dai_instance['id'] == int(q.client.dai_instance_id):
+                dai_instance_name = dai_instance['name']
+
+        # show training progress and details
+        q.page['example'].items[1].dropdown.value = q.args.dai_instance_id
+        q.page['example'].items[3].buttons.visible = False
+        q.page['example'].items[4].message_bar.type = 'info'
+        q.page['example'].items[4].message_bar.text = 'Training in progress...'
+        q.page['example'].items[5].progress.visible = True
+        q.page['example'].items[6].text.content = f'''Driverless AI Experiment:
+            <a href="{STEAM_URL}/oidc-login-start?forward=/proxy/driverless/{q.args.dai_instance_id}/openid/callback" target="_blank">{dai_instance_name}</a>'''
+        q.page['example'].items[7].text.content = ''
+        await q.page.save()
+
+        # train WaveML Model using Driverless AI
+        q.client.wave_model = await q.run(
+            build_model,
+            train_df=q.client.train_df,
+            target_column='target',
+            model_type=ModelType.DAI,
+            refresh_token=q.auth.refresh_token,
+            _steam_dai_instance_name=dai_instance_name,
+            _dai_accuracy=1,
+            _dai_time=1,
+            _dai_interpretability=10
+        )
+
+        # show prediction option
+        q.page['example'].items[3].buttons.items[1].button.disabled = False
+        q.page['example'].items[4].message_bar.type = 'success'
+        q.page['example'].items[4].message_bar.text = 'Training successfully completed!'
+        q.page['example'].items[5].progress.visible = False
+    elif q.args.predict:
+        # predict on test data
+        preds = q.client.wave_model.predict(test_df=q.client.test_df)
+
+        # show predictions
+        q.page['example'].items[4].message_bar.text = 'Prediction successfully completed!'
+        q.page['example'].items[7].text.content = f'''**Example predictions:** <br />
+            {preds[0]} <br /> {preds[1]} <br /> {preds[2]}'''
+    else:
+        # prepare sample train and test dataframes
+        data = load_wine(as_frame=True)['frame']
+        q.client.train_df, q.client.test_df = train_test_split(data, train_size=0.8)
+
+        # DAI instances
+        q.client.dai_instances = list_dai_instances(refresh_token=q.auth.refresh_token)
+        choices_dai_instances = [
+            ui.choice(
+                name=str(x['id']),
+                label=f'{x["name"]} ({x["status"].capitalize()})',
+                disabled=False if x['status'] == 'running' else True
+            ) for x in q.client.dai_instances
+        ]
+
+        running_dai_instances = [x['id'] for x in q.client.dai_instances if x['status'] == 'running']
+        if len(running_dai_instances) == 0:
+            disable_training = True
+            dai_instance_id = ''
+        else:
+            disable_training = False
+            dai_instance_id = str(running_dai_instances[0])
+
+        # display ui
+        q.page['example'] = ui.form_card(
+            box='1 1 -1 -1',
+            items=[
+                ui.text(content='''The sample dataset used is the
+                    <a href="https://scikit-learn.org/stable/modules/generated/sklearn.datasets.load_wine.html" target="_blank">wine dataset</a>.'''),
+                ui.dropdown(name='dai_instance_id', choices=choices_dai_instances, value=dai_instance_id,
+                            required=True),
+                ui.text(content=f'''Manage your <a href="{STEAM_URL}" target="_blank">AI Engines</a>''',
+                        visible=disable_training),
+                ui.buttons(items=[
+                    ui.button(name='train', label='Train', primary=True, disabled=disable_training),
+                    ui.button(name='predict', label='Predict', primary=True, disabled=True),
+                ]),
+                ui.message_bar(type='warning', text='Training will take a few seconds'),
+                ui.progress(label='This can take a few minutes...', visible=False),
+                ui.text(content=''),
+                ui.text(content='')
+            ]
+        )
+
+    await q.page.save()

--- a/py/examples/ml_dai.py
+++ b/py/examples/ml_dai.py
@@ -19,19 +19,113 @@ STEAM_TEXT = f'''No Driverless AI instances available. You may create one in
     <a href="{STEAM_URL}/#/driverless/instances" target="_blank">AI Engines</a> and refresh the page.'''
 
 
+def dai_experiment_url(instance_id: str, instance_name: str):
+    # URL link to Driverless AI experiment
+    return f'''**Driverless AI Experiment:**
+        <a href="{STEAM_URL}/oidc-login-start?forward=/proxy/driverless/{instance_id}/openid/callback" target="_blank">{instance_name}</a>'''
+
+
+def mlops_deployment_url(project_id: str):
+    # URL link to MLOps deployment
+    return f'**MLOps Deployment: **<a href="{MLOPS_URL}/projects/{project_id}" target="_blank">{project_id}'
+
+
+def form_unsupported():
+    # display when app is not running on cloud
+    return [
+        ui.text('''This example requires access to Driverless AI running on
+            <a href="https://h2oai.github.io/h2o-ai-cloud" target="_blank">H2O AI Hybrid Cloud</a> 
+            and does not support standalone app instances.'''),
+        ui.text('''Sign up at <a href="https://h2o.ai/free" target="_blank">https://h2o.ai/free</a>
+            to run apps on cloud.''')
+    ]
+
+
+def form_default(q: Q):
+    # display when app is initialized
+    return [
+        ui.text(content=DATASET_TEXT),
+        ui.dropdown(
+            name='dai_instance_id',
+            label='Select Driverless AI instance',
+            choices=q.client.choices_dai_instances,
+            value=q.client.dai_instance_id,
+            required=True),
+        ui.text(content=STEAM_TEXT, visible=q.client.disable_training),
+        ui.buttons(items=[
+            ui.button(name='train', label='Train', primary=True, disabled=q.client.disable_training),
+            ui.button(name='predict', label='Predict', primary=True, disabled=True),
+        ]),
+        ui.message_bar(type='warning', text='Training will take a few seconds')
+    ]
+
+
+def form_training_progress(q: Q):
+    # display when model training is in progress
+    return [
+        ui.text(content=DATASET_TEXT),
+        ui.dropdown(
+            name='dai_instance_id',
+            label='Select Driverless AI instance',
+            choices=q.client.choices_dai_instances,
+            value=q.client.dai_instance_id,
+            required=True),
+        ui.buttons(items=[
+            ui.button(name='train', label='Train', primary=True, disabled=True),
+            ui.button(name='predict', label='Predict', primary=True, disabled=True)
+        ]),
+        ui.progress(label='Training in progress...', caption='This can take a few minutes...'),
+        ui.text(content=q.client.model_details)
+    ]
+
+
+def form_training_completed(q: Q):
+    # display when model training is completed
+    return [
+        ui.text(content=DATASET_TEXT),
+        ui.dropdown(
+            name='dai_instance_id',
+            label='Select Driverless AI instance',
+            choices=q.client.choices_dai_instances,
+            value=q.client.dai_instance_id,
+            required=True),
+        ui.buttons(items=[
+            ui.button(name='train', label='Train', primary=True),
+            ui.button(name='predict', label='Predict', primary=True)
+        ]),
+        ui.message_bar(type='success', text='Training successfully completed!'),
+        ui.text(content=q.client.model_details)
+    ]
+
+
+def form_prediction_completed(q: Q):
+    # display when model prediction is completed
+    return [
+        ui.text(content=DATASET_TEXT),
+        ui.dropdown(
+            name='dai_instance_id',
+            label='Select Driverless AI instance',
+            choices=q.client.choices_dai_instances,
+            value=q.client.dai_instance_id,
+            required=True),
+        ui.buttons(items=[
+            ui.button(name='train', label='Train', primary=True),
+            ui.button(name='predict', label='Predict', primary=True)
+        ]),
+        ui.message_bar(type='success', text='Prediction successfully completed!'),
+        ui.text(content=q.client.model_details),
+        ui.text(content=f'''**Example predictions:** <br />
+            {q.client.preds[0]} <br /> {q.client.preds[1]} <br /> {q.client.preds[2]}''')
+    ]
+
+
 @app('/demo')
 async def serve(q: Q):
     if 'H2O_CLOUD_ENVIRONMENT' not in os.environ:
         # show appropriate message if app is not running on cloud
         q.page['example'] = ui.form_card(
             box='1 1 -1 -1',
-            items=[
-                ui.text('''This example requires access to Driverless AI running on
-                    <a href="https://h2oai.github.io/h2o-ai-cloud" target="_blank">H2O AI Hybrid Cloud</a> 
-                    and does not support standalone app instances.'''),
-                ui.text('''Sign up at <a href="https://h2o.ai/free" target="_blank">https://h2o.ai/free</a>
-                    to run apps on cloud.''')
-            ]
+            items=form_unsupported()
         )
     elif q.args.train:
         # get DAI instance name
@@ -39,85 +133,40 @@ async def serve(q: Q):
 
         for dai_instance in q.client.dai_instances:
             if dai_instance['id'] == int(q.client.dai_instance_id):
-                dai_instance_name = dai_instance['name']
+                q.client.dai_instance_name = dai_instance['name']
 
         # set DAI model details
-        q.client.model_details = f'''**Driverless AI Experiment:**
-            <a href="{STEAM_URL}/oidc-login-start?forward=/proxy/driverless/{q.client.dai_instance_id}/openid/callback" target="_blank">{dai_instance_name}</a>'''
+        q.client.model_details = dai_experiment_url(q.client.dai_instance_id, q.client.dai_instance_name)
 
         # show training progress and details
-        q.page['example'].items = [
-            ui.text(content=DATASET_TEXT),
-            ui.dropdown(
-                name='dai_instance_id',
-                label='Select Driverless AI instance',
-                choices=q.client.choices_dai_instances,
-                value=q.client.dai_instance_id,
-                required=True),
-            ui.buttons(items=[
-                ui.button(name='train', label='Train', primary=True, disabled=True),
-                ui.button(name='predict', label='Predict', primary=True, disabled=True)
-            ]),
-            ui.progress(label='Training in progress...', caption='This can take a few minutes...'),
-            ui.text(content=q.client.model_details)
-        ]
+        q.page['example'].items = form_training_progress(q)
         await q.page.save()
 
         # train WaveML Model using Driverless AI
         q.client.wave_model = await q.run(
-            build_model,
+            func=build_model,
             train_df=q.client.train_df,
             target_column='target',
             model_type=ModelType.DAI,
             refresh_token=q.auth.refresh_token,
-            _steam_dai_instance_name=dai_instance_name,
+            _steam_dai_instance_name=q.client.dai_instance_name,
             _dai_accuracy=1,
             _dai_time=1,
             _dai_interpretability=10
         )
 
         # update DAI model details
-        project_id = q.client.wave_model.project_id
-        q.client.model_details += f'''<br />**MLOps Deployment:**
-            <a href="{MLOPS_URL}/projects/{project_id}" target="_blank">{project_id}'''
+        q.client.project_id = q.client.wave_model.project_id
+        q.client.model_details += f'<br />{mlops_deployment_url(q.client.project_id)}'
 
         # show prediction option
-        q.page['example'].items = [
-            ui.text(content=DATASET_TEXT),
-            ui.dropdown(
-                name='dai_instance_id',
-                label='Select Driverless AI instance',
-                choices=q.client.choices_dai_instances,
-                value=q.client.dai_instance_id,
-                required=True),
-            ui.buttons(items=[
-                ui.button(name='train', label='Train', primary=True),
-                ui.button(name='predict', label='Predict', primary=True)
-            ]),
-            ui.message_bar(type='success', text='Training successfully completed!'),
-            ui.text(content=q.client.model_details)
-        ]
+        q.page['example'].items = form_training_completed(q)
     elif q.args.predict:
         # predict on test data
-        preds = q.client.wave_model.predict(test_df=q.client.test_df)
+        q.client.preds = q.client.wave_model.predict(test_df=q.client.test_df)
 
         # show predictions
-        q.page['example'].items = [
-            ui.text(content=DATASET_TEXT),
-            ui.dropdown(
-                name='dai_instance_id',
-                label='Select Driverless AI instance',
-                choices=q.client.choices_dai_instances,
-                value=q.client.dai_instance_id,
-                required=True),
-            ui.buttons(items=[
-                ui.button(name='train', label='Train', primary=True),
-                ui.button(name='predict', label='Predict', primary=True)
-            ]),
-            ui.message_bar(type='success', text='Prediction successfully completed!'),
-            ui.text(content=q.client.model_details),
-            ui.text(content=f'**Example predictions:** <br />{preds[0]} <br /> {preds[1]} <br /> {preds[2]}')
-        ]
+        q.page['example'].items = form_prediction_completed(q)
     else:
         # prepare sample train and test dataframes
         data = load_wine(as_frame=True)['frame']
@@ -129,36 +178,18 @@ async def serve(q: Q):
             ui.choice(
                 name=str(x['id']),
                 label=f'{x["name"]} ({x["status"].capitalize()})',
-                disabled=False if x['status'] == 'running' else True
+                disabled=x['status'] != 'running'
             ) for x in q.client.dai_instances
         ]
 
         running_dai_instances = [x['id'] for x in q.client.dai_instances if x['status'] == 'running']
-        if len(running_dai_instances) == 0:
-            disable_training = True
-            q.client.dai_instance_id = ''
-        else:
-            disable_training = False
-            q.client.dai_instance_id = str(running_dai_instances[0])
+        q.client.disable_training = False if running_dai_instances else True
+        q.client.dai_instance_id = str(running_dai_instances[0]) if running_dai_instances else ''
 
         # display ui
         q.page['example'] = ui.form_card(
             box='1 1 -1 -1',
-            items=[
-                ui.text(content=DATASET_TEXT),
-                ui.dropdown(
-                    name='dai_instance_id',
-                    label='Select Driverless AI instance',
-                    choices=q.client.choices_dai_instances,
-                    value=q.client.dai_instance_id,
-                    required=True),
-                ui.text(content=STEAM_TEXT, visible=disable_training),
-                ui.buttons(items=[
-                    ui.button(name='train', label='Train', primary=True, disabled=disable_training),
-                    ui.button(name='predict', label='Predict', primary=True, disabled=True),
-                ]),
-                ui.message_bar(type='warning', text='Training will take a few seconds')
-            ]
+            items=form_default(q)
         )
 
     await q.page.save()

--- a/py/examples/ml_dai.py
+++ b/py/examples/ml_dai.py
@@ -3,7 +3,7 @@
 # ---
 import os
 
-from h2o_wave import main, app, Q, ui
+from h2o_wave import main, app, Q, copy_expando, ui
 from h2o_wave_ml import build_model, ModelType
 from h2o_wave_ml.utils import list_dai_instances
 
@@ -13,10 +13,16 @@ from sklearn.model_selection import train_test_split
 STEAM_URL = os.environ.get('STEAM_URL')
 MLOPS_URL = os.environ.get('MLOPS_URL')
 
+DATASET_TEXT = '''The sample dataset used is the
+    <a href="https://scikit-learn.org/stable/modules/generated/sklearn.datasets.load_wine.html" target="_blank">wine dataset</a>.'''
+STEAM_TEXT = f'''No Driverless AI instances available. You may create one in 
+    <a href="{STEAM_URL}/#/driverless/instances" target="_blank">AI Engines</a> and refresh the page.'''
+
 
 @app('/demo')
 async def serve(q: Q):
     if 'H2O_CLOUD_ENVIRONMENT' not in os.environ:
+        # show appropriate message if app is not running on cloud
         q.page['example'] = ui.form_card(
             box='1 1 -1 -1',
             items=[
@@ -29,21 +35,32 @@ async def serve(q: Q):
         )
     elif q.args.train:
         # get DAI instance name
+        copy_expando(q.args, q.client)
+
         for dai_instance in q.client.dai_instances:
-            if dai_instance['id'] == int(q.args.dai_instance_id):
+            if dai_instance['id'] == int(q.client.dai_instance_id):
                 dai_instance_name = dai_instance['name']
 
-        model_details = f'''**Driverless AI Experiment:**
-            <a href="{STEAM_URL}/oidc-login-start?forward=/proxy/driverless/{q.args.dai_instance_id}/openid/callback" target="_blank">{dai_instance_name}</a>'''
+        # set DAI model details
+        q.client.model_details = f'''**Driverless AI Experiment:**
+            <a href="{STEAM_URL}/oidc-login-start?forward=/proxy/driverless/{q.client.dai_instance_id}/openid/callback" target="_blank">{dai_instance_name}</a>'''
 
         # show training progress and details
-        q.page['example'].items[1].dropdown.value = q.args.dai_instance_id
-        q.page['example'].items[3].buttons.visible = False
-        q.page['example'].items[4].message_bar.type = 'info'
-        q.page['example'].items[4].message_bar.text = 'Training in progress...'
-        q.page['example'].items[5].progress.visible = True
-        q.page['example'].items[6].text.content = model_details
-        q.page['example'].items[7].text.content = ''
+        q.page['example'].items = [
+            ui.text(content=DATASET_TEXT),
+            ui.dropdown(
+                name='dai_instance_id',
+                label='Select Driverless AI instance',
+                choices=q.client.choices_dai_instances,
+                value=q.client.dai_instance_id,
+                required=True),
+            ui.buttons(items=[
+                ui.button(name='train', label='Train', primary=True, disabled=True),
+                ui.button(name='predict', label='Predict', primary=True, disabled=True)
+            ]),
+            ui.progress(label='Training in progress...', caption='This can take a few minutes...'),
+            ui.text(content=q.client.model_details)
+        ]
         await q.page.save()
 
         # train WaveML Model using Driverless AI
@@ -59,25 +76,48 @@ async def serve(q: Q):
             _dai_interpretability=10
         )
 
+        # update DAI model details
         project_id = q.client.wave_model.project_id
-        model_details += f'''<br />**MLOps Deployment:**
+        q.client.model_details += f'''<br />**MLOps Deployment:**
             <a href="{MLOPS_URL}/projects/{project_id}" target="_blank">{project_id}'''
 
         # show prediction option
-        q.page['example'].items[3].buttons.visible = True
-        q.page['example'].items[3].buttons.items[1].button.disabled = False
-        q.page['example'].items[4].message_bar.type = 'success'
-        q.page['example'].items[4].message_bar.text = 'Training successfully completed!'
-        q.page['example'].items[5].progress.visible = False
-        q.page['example'].items[6].text.content = model_details
+        q.page['example'].items = [
+            ui.text(content=DATASET_TEXT),
+            ui.dropdown(
+                name='dai_instance_id',
+                label='Select Driverless AI instance',
+                choices=q.client.choices_dai_instances,
+                value=q.client.dai_instance_id,
+                required=True),
+            ui.buttons(items=[
+                ui.button(name='train', label='Train', primary=True),
+                ui.button(name='predict', label='Predict', primary=True)
+            ]),
+            ui.message_bar(type='success', text='Training successfully completed!'),
+            ui.text(content=q.client.model_details)
+        ]
     elif q.args.predict:
         # predict on test data
         preds = q.client.wave_model.predict(test_df=q.client.test_df)
 
         # show predictions
-        q.page['example'].items[4].message_bar.text = 'Prediction successfully completed!'
-        q.page['example'].items[7].text.content = f'''**Example predictions:** <br />
-            {preds[0]} <br /> {preds[1]} <br /> {preds[2]}'''
+        q.page['example'].items = [
+            ui.text(content=DATASET_TEXT),
+            ui.dropdown(
+                name='dai_instance_id',
+                label='Select Driverless AI instance',
+                choices=q.client.choices_dai_instances,
+                value=q.client.dai_instance_id,
+                required=True),
+            ui.buttons(items=[
+                ui.button(name='train', label='Train', primary=True),
+                ui.button(name='predict', label='Predict', primary=True)
+            ]),
+            ui.message_bar(type='success', text='Prediction successfully completed!'),
+            ui.text(content=q.client.model_details),
+            ui.text(content=f'**Example predictions:** <br />{preds[0]} <br /> {preds[1]} <br /> {preds[2]}')
+        ]
     else:
         # prepare sample train and test dataframes
         data = load_wine(as_frame=True)['frame']
@@ -85,7 +125,7 @@ async def serve(q: Q):
 
         # DAI instances
         q.client.dai_instances = list_dai_instances(refresh_token=q.auth.refresh_token)
-        choices_dai_instances = [
+        q.client.choices_dai_instances = [
             ui.choice(
                 name=str(x['id']),
                 label=f'{x["name"]} ({x["status"].capitalize()})',
@@ -96,36 +136,28 @@ async def serve(q: Q):
         running_dai_instances = [x['id'] for x in q.client.dai_instances if x['status'] == 'running']
         if len(running_dai_instances) == 0:
             disable_training = True
-            dai_instance_id = ''
+            q.client.dai_instance_id = ''
         else:
             disable_training = False
-            dai_instance_id = str(running_dai_instances[0])
+            q.client.dai_instance_id = str(running_dai_instances[0])
 
         # display ui
         q.page['example'] = ui.form_card(
             box='1 1 -1 -1',
             items=[
-                ui.text(content='''The sample dataset used is the
-                    <a href="https://scikit-learn.org/stable/modules/generated/sklearn.datasets.load_wine.html" target="_blank">wine dataset</a>.'''),
+                ui.text(content=DATASET_TEXT),
                 ui.dropdown(
                     name='dai_instance_id',
                     label='Select Driverless AI instance',
-                    choices=choices_dai_instances,
-                    value=dai_instance_id,
+                    choices=q.client.choices_dai_instances,
+                    value=q.client.dai_instance_id,
                     required=True),
-                ui.text(
-                    content=f'''No Driverless AI instances available. You may create one in 
-                        <a href="{STEAM_URL}/#/driverless/instances" target="_blank">AI Engines</a> and 
-                        refresh the page.''',
-                    visible=disable_training),
+                ui.text(content=STEAM_TEXT, visible=disable_training),
                 ui.buttons(items=[
                     ui.button(name='train', label='Train', primary=True, disabled=disable_training),
                     ui.button(name='predict', label='Predict', primary=True, disabled=True),
                 ]),
-                ui.message_bar(type='warning', text='Training will take a few seconds'),
-                ui.progress(label='This can take a few minutes...', visible=False),
-                ui.text(content=''),
-                ui.text(content='')
+                ui.message_bar(type='warning', text='Training will take a few seconds')
             ]
         )
 

--- a/py/examples/ml_dai.py
+++ b/py/examples/ml_dai.py
@@ -16,7 +16,7 @@ MLOPS_URL = os.environ.get('MLOPS_URL')
 
 @app('/demo')
 async def serve(q: Q):
-    if 'H2_CLOUD_ENVIRONMENT' not in os.environ:
+    if 'H2O_CLOUD_ENVIRONMENT' not in os.environ:
         q.page['example'] = ui.form_card(
             box='1 1 -1 -1',
             items=[

--- a/py/examples/ml_dai_categorical.py
+++ b/py/examples/ml_dai_categorical.py
@@ -1,5 +1,5 @@
-# WaveML / DAI
-# Build Wave Models for training and prediction of classification or regression using Driverless AI.
+# WaveML / DAI / Categorical
+# Configure categorical columns for Wave Models built using Driverless AI.
 # ---
 import os
 
@@ -48,6 +48,8 @@ def form_default(q: Q):
         ui.dropdown(name='dai_instance_id', label='Select Driverless AI instance', value=q.client.dai_instance_id,
                     choices=q.client.choices_dai_instances, required=True),
         ui.text(content=STEAM_TEXT, visible=q.client.disable_training),
+        ui.dropdown(name='categorical_columns', label='Select categorical columns',
+                    choices=q.client.column_choices, values=[]),
         ui.buttons(items=[
             ui.button(name='train', label='Train', primary=True, disabled=q.client.disable_training),
             ui.button(name='predict', label='Predict', primary=True, disabled=True),
@@ -61,6 +63,8 @@ def form_training_progress(q: Q):
         ui.text(content=DATASET_TEXT),
         ui.dropdown(name='dai_instance_id', label='Select Driverless AI instance', value=q.client.dai_instance_id,
                     choices=q.client.choices_dai_instances, required=True),
+        ui.dropdown(name='categorical_columns', label='Select categorical columns',
+                    choices=q.client.column_choices, values=q.client.categorical_columns),
         ui.buttons(items=[
             ui.button(name='train', label='Train', primary=True, disabled=True),
             ui.button(name='predict', label='Predict', primary=True, disabled=True)
@@ -76,6 +80,8 @@ def form_training_completed(q: Q):
         ui.text(content=DATASET_TEXT),
         ui.dropdown(name='dai_instance_id', label='Select Driverless AI instance', value=q.client.dai_instance_id,
                     choices=q.client.choices_dai_instances, required=True),
+        ui.dropdown(name='categorical_columns', label='Select categorical columns',
+                    choices=q.client.column_choices, values=q.client.categorical_columns),
         ui.buttons(items=[
             ui.button(name='train', label='Train', primary=True),
             ui.button(name='predict', label='Predict', primary=True)
@@ -91,6 +97,8 @@ def form_prediction_completed(q: Q):
         ui.text(content=DATASET_TEXT),
         ui.dropdown(name='dai_instance_id', label='Select Driverless AI instance', value=q.client.dai_instance_id,
                     choices=q.client.choices_dai_instances, required=True),
+        ui.dropdown(name='categorical_columns', label='Select categorical columns',
+                    choices=q.client.column_choices, values=q.client.categorical_columns),
         ui.buttons(items=[
             ui.button(name='train', label='Train', primary=True),
             ui.button(name='predict', label='Predict', primary=True)
@@ -131,6 +139,7 @@ async def serve(q: Q):
             train_df=q.client.train_df,
             target_column='target',
             model_type=ModelType.DAI,
+            categorical_columns=q.client.categorical_columns,
             refresh_token=q.auth.refresh_token,
             _steam_dai_instance_name=q.client.dai_instance_name,
             _dai_accuracy=1,
@@ -154,6 +163,9 @@ async def serve(q: Q):
         # prepare sample train and test dataframes
         data = load_wine(as_frame=True)['frame']
         q.client.train_df, q.client.test_df = train_test_split(data, train_size=0.8)
+
+        # columns
+        q.client.column_choices = [ui.choice(x, x) for x in q.client.train_df.columns]
 
         # DAI instances
         q.client.dai_instances = list_dai_instances(refresh_token=q.auth.refresh_token)

--- a/py/examples/ml_dai_instances.py
+++ b/py/examples/ml_dai_instances.py
@@ -1,0 +1,93 @@
+# WaveML / DAI / Instances
+# List the Driverless AI instances of the user on Steam.
+# ---
+import os
+
+from h2o_wave import main, app, Q, ui
+from h2o_wave_ml.utils import list_dai_instances
+
+STEAM_URL = os.environ.get('STEAM_URL')
+STEAM_TEXT = f'''No Driverless AI instances available. You may create one in 
+    <a href="{STEAM_URL}/#/driverless/instances" target="_blank">AI Engines</a> and refresh the page.'''
+
+ICON_MAP = {
+    'created': 'Blocked2Solid',
+    'starting': 'Blocked2Solid',
+    'running': 'CompletedSolid',
+    'unreachable': 'AlertSolid',
+    'failed': 'AlertSolid',
+    'stopping': 'Blocked2Solid',
+    'stopped': 'Blocked2Solid',
+    'terminating': 'Blocked2Solid',
+    'terminated': 'Blocked2Solid'
+}
+
+
+def dai_instances_table(dai_instances: list):
+    # dai instances in ui.table
+    return ui.table(
+        name='table_dai',
+        columns=[
+            ui.table_column(name='id', label='Id', min_width='50px', max_width='51px', link=False),
+            ui.table_column(name='name', label='Name', link=False),
+            ui.table_column(name='status', label='Status', cell_type=ui.icon_table_cell_type(color='#CDDD38'),
+                            link=False),
+            ui.table_column(name='description', label='Description', link=False),
+            ui.table_column(name='version', label='Version', link=False)
+        ],
+        rows=[
+            ui.table_row(str(i), [
+                str(dai_instances[i]['id']),
+                dai_instances[i]['name'],
+                ICON_MAP[dai_instances[i]['status']],
+                dai_instances[i]['status'],
+                dai_instances[i]['version']
+            ]) for i in range(len(dai_instances))
+        ]
+    )
+
+
+def form_unsupported():
+    # display when app is not running on cloud
+    return [
+        ui.text('''This example requires access to Driverless AI running on
+            <a href="https://h2oai.github.io/h2o-ai-cloud" target="_blank">H2O AI Hybrid Cloud</a> 
+            and does not support standalone app instances.'''),
+        ui.text('''Sign up at <a href="https://h2o.ai/free" target="_blank">https://h2o.ai/free</a>
+            to run apps on cloud.''')
+    ]
+
+
+def form_default(q: Q):
+    # display when app is initialized
+    return [
+        ui.label(label='List of Driverless AI instances'),
+        dai_instances_table(dai_instances=q.client.dai_instances)
+    ]
+
+
+@app('/demo')
+async def serve(q: Q):
+    if 'H2O_CLOUD_ENVIRONMENT' not in os.environ:
+        # show appropriate message if app is not running on cloud
+        q.page['example'] = ui.form_card(
+            box='1 1 -1 -1',
+            items=form_unsupported()
+        )
+    else:
+        # DAI instances
+        q.client.dai_instances = list_dai_instances(refresh_token=q.auth.refresh_token)
+
+        # display ui
+        if q.client.dai_instances:
+            q.page['example'] = ui.form_card(
+                box='1 1 -1 -1',
+                items=form_default(q)
+            )
+        else:
+            q.page['example'] = ui.form_card(
+                box='1 1 -1 -1',
+                items=[ui.text(content=STEAM_TEXT)]
+            )
+
+    await q.page.save()

--- a/py/examples/ml_dai_parameters.py
+++ b/py/examples/ml_dai_parameters.py
@@ -1,5 +1,5 @@
-# WaveML / DAI
-# Build Wave Models for training and prediction of classification or regression using Driverless AI.
+# WaveML / DAI / Parameters
+# Configure hyperparameters for Wave Models built using Driverless AI.
 # ---
 import os
 
@@ -48,6 +48,8 @@ def form_default(q: Q):
         ui.dropdown(name='dai_instance_id', label='Select Driverless AI instance', value=q.client.dai_instance_id,
                     choices=q.client.choices_dai_instances, required=True),
         ui.text(content=STEAM_TEXT, visible=q.client.disable_training),
+        ui.slider(name='dai_interpretability', label='Interpretability', min=1, max=10, step=1, value=7),
+        ui.toggle(name='dai_reproducible', label='Reproducible', value=False),
         ui.buttons(items=[
             ui.button(name='train', label='Train', primary=True, disabled=q.client.disable_training),
             ui.button(name='predict', label='Predict', primary=True, disabled=True),
@@ -61,6 +63,9 @@ def form_training_progress(q: Q):
         ui.text(content=DATASET_TEXT),
         ui.dropdown(name='dai_instance_id', label='Select Driverless AI instance', value=q.client.dai_instance_id,
                     choices=q.client.choices_dai_instances, required=True),
+        ui.slider(name='dai_interpretability', label='Interpretability', min=1, max=10, step=1,
+                  value=q.client.dai_interpretability),
+        ui.toggle(name='dai_reproducible', label='Reproducible', value=q.client.dai_reproducible),
         ui.buttons(items=[
             ui.button(name='train', label='Train', primary=True, disabled=True),
             ui.button(name='predict', label='Predict', primary=True, disabled=True)
@@ -76,6 +81,9 @@ def form_training_completed(q: Q):
         ui.text(content=DATASET_TEXT),
         ui.dropdown(name='dai_instance_id', label='Select Driverless AI instance', value=q.client.dai_instance_id,
                     choices=q.client.choices_dai_instances, required=True),
+        ui.slider(name='dai_interpretability', label='Interpretability', min=1, max=10, step=1,
+                  value=q.client.dai_interpretability),
+        ui.toggle(name='dai_reproducible', label='Reproducible', value=q.client.dai_reproducible),
         ui.buttons(items=[
             ui.button(name='train', label='Train', primary=True),
             ui.button(name='predict', label='Predict', primary=True)
@@ -91,6 +99,9 @@ def form_prediction_completed(q: Q):
         ui.text(content=DATASET_TEXT),
         ui.dropdown(name='dai_instance_id', label='Select Driverless AI instance', value=q.client.dai_instance_id,
                     choices=q.client.choices_dai_instances, required=True),
+        ui.slider(name='dai_interpretability', label='Interpretability', min=1, max=10, step=1,
+                  value=q.client.dai_interpretability),
+        ui.toggle(name='dai_reproducible', label='Reproducible', value=q.client.dai_reproducible),
         ui.buttons(items=[
             ui.button(name='train', label='Train', primary=True),
             ui.button(name='predict', label='Predict', primary=True)
@@ -135,7 +146,8 @@ async def serve(q: Q):
             _steam_dai_instance_name=q.client.dai_instance_name,
             _dai_accuracy=1,
             _dai_time=1,
-            _dai_interpretability=10
+            _dai_interpretability=q.client.dai_interpretability,
+            _dai_reproducible=q.client.dai_reproducible
         )
 
         # update DAI model details

--- a/py/examples/tour.conf
+++ b/py/examples/tour.conf
@@ -194,3 +194,9 @@ ml_h2o_save.py
 ml_h2o_categorical.py
 ml_h2o_parameters.py
 ml_h2o_shap.py
+ml_dai.py
+ml_dai_save.py
+ml_dai_categorical.py
+ml_dai_parameters.py
+ml_dai_autodoc.py
+ml_dai_instances.py


### PR DESCRIPTION
This PR adds examples of using WaveML with DAI.
Closes h2oai/wave-ml#43

- [x] **WaveML / DAI:** Build model using train data and predict on test data
- [x] **WaveML / DAI / Save:** Save a trained model and load to predict on new data
- [x] **WaveML / DAI / Categorical:** Select columns as categorical for training
- [x] **WaveML / DAI / Parameters:** Set hyper-parameters while training model
- [x] **WaveML / DAI / AutoDoc:** Download AutoDoc of a trained model
- [x] **WaveML / DAI / Instances:** Get user's DAI instances on cloud

Comments:

* These only work on H2O AI Hybrid Cloud. If run locally, it displays a sign-up message.
* The default setup takes about a minute to run and the outputs are mainly links to DAI and MLOps.
* It requires some `toml` changes to publish on cloud, will ensure those get updated.