### PR TITLE
fix: Primary table column

### DIFF
--- a/py/examples/table.py
+++ b/py/examples/table.py
@@ -51,7 +51,7 @@ columns = [
 
 @app('/demo')
 async def serve(q: Q):
-    q.page['form'] = ui.form_card(box='1 1 -1 11', items=[
+    q.page['form'] = ui.form_card(box='1 1 -1 10', items=[
         ui.table(
             name='issues',
             columns=columns,

--- a/py/h2o_wave/types.py
+++ b/py/h2o_wave/types.py
@@ -3193,7 +3193,7 @@ class TableColumn:
         self.filterable = filterable
         """Indicates whether the contents of this column are displayed as filters in a dropdown."""
         self.link = link
-        """Indicates whether each cell in this column should be displayed as a clickable link."""
+        """Indicates whether each cell in this column should be displayed as a clickable link. Applies to exactly one text column in the table."""
         self.data_type = data_type
         """Defines the data type of this column. Defaults to `string`. One of 'string', 'number', 'time'. See enum h2o_wave.ui.TableColumnDataType."""
         self.cell_type = cell_type

--- a/py/h2o_wave/ui.py
+++ b/py/h2o_wave/ui.py
@@ -1257,7 +1257,7 @@ def table_column(
         sortable: Indicates whether the column is sortable.
         searchable: Indicates whether the contents of this column can be searched through. Enables a search box for the table if true.
         filterable: Indicates whether the contents of this column are displayed as filters in a dropdown.
-        link: Indicates whether each cell in this column should be displayed as a clickable link.
+        link: Indicates whether each cell in this column should be displayed as a clickable link. Applies to exactly one text column in the table.
         data_type: Defines the data type of this column. Defaults to `string`. One of 'string', 'number', 'time'. See enum h2o_wave.ui.TableColumnDataType.
         cell_type: Defines how to render each cell in this column. Defaults to plain text.
     Returns:

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -1433,7 +1433,7 @@ ui_icon_table_cell_type <- function(
 #' @param sortable Indicates whether the column is sortable.
 #' @param searchable Indicates whether the contents of this column can be searched through. Enables a search box for the table if true.
 #' @param filterable Indicates whether the contents of this column are displayed as filters in a dropdown.
-#' @param link Indicates whether each cell in this column should be displayed as a clickable link.
+#' @param link Indicates whether each cell in this column should be displayed as a clickable link. Applies to exactly one text column in the table.
 #' @param data_type Defines the data type of this column. Defaults to `string`.
 #'   One of 'string', 'number', 'time'. See enum h2o_wave.ui.TableColumnDataType.
 #' @param cell_type Defines how to render each cell in this column. Defaults to plain text.

--- a/ui/src/table.test.tsx
+++ b/ui/src/table.test.tsx
@@ -54,6 +54,16 @@ describe('Table.tsx', () => {
     expect(queryByTestId(name)).not.toBeVisible()
   })
 
+  it('Renders time column correctly', () => {
+    tableProps = {
+      ...tableProps,
+      rows: [{ name: 'rowname1', cells: ['1971-07-08T23:09:33'] }],
+      columns: [{ name: 'colname1', label: 'Col1', sortable: true, searchable: true, data_type: 'time' }]
+    }
+    const { getAllByRole } = render(<XTable model={tableProps} />)
+    expect(getAllByRole('gridcell')[0].textContent).toBe('7/8/1971, 11:09:33 PM')
+  })
+
   describe('Height compute', () => {
 
     it('Computes properly for simple table - header, rows', () => {
@@ -214,18 +224,15 @@ describe('Table.tsx', () => {
           { name: 'rowname2', cells: [date2] },
           { name: 'rowname3', cells: [date1] }
         ],
-        columns: [
-          { name: 'colname1', label: 'Col1', sortable: true, searchable: true, data_type: 'time' },
-          { name: 'colname2', label: 'Col2', sortable: true, filterable: true, data_type: 'time' },
-        ],
+        columns: [{ name: 'colname1', label: 'Col1', sortable: true, searchable: true, data_type: 'time' }]
       }
       const { container, getAllByRole } = render(<XTable model={tableProps} />)
 
-      expect(getAllByRole('gridcell')[0].textContent).toBe(date3)
+      expect(getAllByRole('gridcell')[0].textContent).toBe('3/28/2001, 3:09:31 AM')
       fireEvent.click(container.querySelector('i[class*=sortingIcon]')!)
-      expect(getAllByRole('gridcell')[0].textContent).toBe(date1)
+      expect(getAllByRole('gridcell')[0].textContent).toBe('7/8/1971, 11:09:33 PM')
       fireEvent.click(container.querySelector('i[class*=sortingIcon]')!)
-      expect(getAllByRole('gridcell')[0].textContent).toBe(date3)
+      expect(getAllByRole('gridcell')[0].textContent).toBe('3/28/2001, 3:09:31 AM')
     })
 
     it('Sorts by column and rerenders icon col', () => {

--- a/ui/src/table.tsx
+++ b/ui/src/table.tsx
@@ -43,7 +43,7 @@ interface TableColumn {
   searchable?: B
   /** Indicates whether the contents of this column are displayed as filters in a dropdown. */
   filterable?: B
-  /** Indicates whether each cell in this column should be displayed as a clickable link. */
+  /** Indicates whether each cell in this column should be displayed as a clickable link. Note that link can be applied to a single textual col only. */
   link?: B
   /** Defines the data type of this column. Defaults to `string`. */
   data_type?: 'string' | 'number' | 'time'
@@ -444,7 +444,10 @@ export const
       onRenderItemColumn = (item?: Fluent.IObjectWithKey & Dict<any>, _index?: number, col?: QColumn) => {
         if (!item || !col) return <span />
 
-        const v = item[col.fieldName as S]
+        let v = item[col.fieldName as S]
+        if (col.cellType?.progress) return <XProgressTableCellType model={col.cellType.progress} progress={item[col.key]} />
+        if (col.cellType?.icon) return <XIconTableCellType model={col.cellType.icon} icon={item[col.key]} />
+        if (col.dataType === 'time') v = new Date(v).toLocaleString()
         if (col.key === primaryColumnKey && !isMultiple) {
           const onClick = () => {
             wave.args[m.name] = [item.key as S]
@@ -453,11 +456,7 @@ export const
           return <Fluent.Link onClick={onClick}>{v}</Fluent.Link>
         }
 
-        if (col.cellType?.progress) return <XProgressTableCellType model={col.cellType.progress} progress={item[col.key]} />
-        if (col.cellType?.icon) return <XIconTableCellType model={col.cellType.icon} icon={item[col.key]} />
-        if (col.dataType === 'time') return <span>{new Date(v).toLocaleString()}</span>
-
-        return <span>{v}</span>
+        return v
       },
       computeHeight = () => {
         if (m.height) return m.height

--- a/ui/src/table.tsx
+++ b/ui/src/table.tsx
@@ -43,7 +43,7 @@ interface TableColumn {
   searchable?: B
   /** Indicates whether the contents of this column are displayed as filters in a dropdown. */
   filterable?: B
-  /** Indicates whether each cell in this column should be displayed as a clickable link. Note that link can be applied to a single textual col only. */
+  /** Indicates whether each cell in this column should be displayed as a clickable link. Applies to exactly one text column in the table. */
   link?: B
   /** Defines the data type of this column. Defaults to `string`. */
   data_type?: 'string' | 'number' | 'time'


### PR DESCRIPTION
Primary column prioritized `Fluent.Link`. This PR fixes this by prioritizing `cell_type` cols first and then wrapping col content in link if applicable. This also fixed unknown bug - if `time` col would be specified as first, it wouldn't be formatted properly - added unit test for it.

Needs discussion: 
Current logic - if first col is `cell_type` don't add link functionality (not clickable to emit `q.args.table_name`)
Alternative - wrap also `cell_type` within `Flluent.Link` which will make e.g. progress arc clickable - not sure if makes sense though.

Nits: Changed excessive example box height to avoid scrollbars. Updated `link` docstring.

Closes #890