### PR TITLE
fix: Increase tab card min height to prevent overflow. #904

### DIFF
--- a/ui/src/tab.tsx
+++ b/ui/src/tab.tsx
@@ -38,7 +38,7 @@ const
       display: 'flex',
       flexDirection: 'column',
       justifyContent: 'center',
-      minHeight: 46
+      minHeight: 46 // HACK: Prevent overflow - https://github.com/h2oai/wave/issues/904.
     },
   })
 

--- a/ui/src/tab.tsx
+++ b/ui/src/tab.tsx
@@ -38,6 +38,7 @@ const
       display: 'flex',
       flexDirection: 'column',
       justifyContent: 'center',
+      minHeight: 46
     },
   })
 


### PR DESCRIPTION
The overflow was caused by [overflow auto](https://github.com/h2oai/wave/blob/5c2e4549cab38f85948f12b4cabf4afc91693de6/ui/src/layout.tsx#L164) on our side cascading down to `Fluent.Pivot` which didn't account for extra 2px height of pseudo `::before` in addition to existing `44px` pivot button `height` and `line-height` of its text. Increasing container `min-height` by 2px fixes the issue.

Also the reason this happens with flex layout only is that it uses intrinsic element height as opposed to strictly set calculated height of the old grid. 

Closes #904