### PR TITLE
fix: Download files in new tab to prevent FF dropping WS connection. #899

### DIFF
--- a/py/examples/link.py
+++ b/py/examples/link.py
@@ -17,6 +17,7 @@ page['example'] = ui.form_card(
         ui.link(label='External link, new tab', path='https://h2o.ai', target=''),
         ui.link(label='External link, new tab', path='https://h2o.ai', target='_blank'),  # same as target=''
         ui.link(label='External link, disabled', path='https://h2o.ai', disabled=True),
+        ui.link(label='Download link', path='https://file-examples-com.github.io/uploads/2017/02/file-sample_100kB.doc', download=True),
     ]
 )
 page.save()

--- a/ui/src/link.test.tsx
+++ b/ui/src/link.test.tsx
@@ -18,15 +18,12 @@ import { Link, XLink } from './link'
 
 const
   name = 'link',
-  linkProps: Link = { name, path: name }
+  linkProps: Link = { name, path: name },
+  windowOpenMock = jest.fn()
 
 describe('Link.tsx', () => {
+  beforeAll(() => window.open = windowOpenMock)
   beforeEach(() => { jest.clearAllMocks() })
-
-  it('Does not render data-test attr', () => {
-    const { container } = render(<XLink model={{}} />)
-    expect(container.querySelectorAll('[data-test]')).toHaveLength(0)
-  })
 
   it('Renders data-test attr', () => {
     const { queryByTestId } = render(<XLink model={linkProps} />)
@@ -38,18 +35,21 @@ describe('Link.tsx', () => {
     expect(queryByText(name)).toBeInTheDocument()
   })
 
+  it('Sets label when specified', () => {
+    const label = 'label'
+    const { queryByText } = render(<XLink model={{ ...linkProps, label }} />)
+    expect(queryByText(label)).toBeInTheDocument()
+  })
+
   it('Opens button link in same tab', () => {
-    const windowOpenMock = jest.fn()
-    window.open = windowOpenMock
     const { getByText } = render(<XLink model={{ ...linkProps, button: true }} />)
 
     fireEvent.click(getByText(name))
     expect(windowOpenMock).toHaveBeenCalled()
     expect(windowOpenMock).toHaveBeenCalledWith(name, undefined)
   })
-  it('Opens button link in same tab', () => {
-    const windowOpenMock = jest.fn()
-    window.open = windowOpenMock
+
+  it('Opens button link in a new tab', () => {
     const { getByText } = render(<XLink model={{ ...linkProps, button: true, target: '' }} />)
 
     fireEvent.click(getByText(name))
@@ -60,6 +60,15 @@ describe('Link.tsx', () => {
   it('Renders link target attribute when new tab specified', () => {
     const { getByTestId } = render(<XLink model={{ ...linkProps, target: '' }} />)
     expect(getByTestId(name).getAttribute('target')).toEqual('_blank')
+  })
+
+  // Needed for FF - https://bugzilla.mozilla.org/show_bug.cgi?id=858538.
+  it('Downloads from a new tab', () => {
+    const { getByText } = render(<XLink model={{ ...linkProps, download: true }} />)
+
+    fireEvent.click(getByText(name))
+    expect(windowOpenMock).toHaveBeenCalled()
+    expect(windowOpenMock).toHaveBeenCalledWith(name, '_blank')
   })
 
 })

--- a/ui/src/link.test.tsx
+++ b/ui/src/link.test.tsx
@@ -45,7 +45,7 @@ describe('Link.tsx', () => {
 
     fireEvent.click(getByText(name))
     expect(windowOpenMock).toHaveBeenCalled()
-    expect(windowOpenMock).toHaveBeenCalledWith(name)
+    expect(windowOpenMock).toHaveBeenCalledWith(name, undefined)
   })
   it('Opens button link in same tab', () => {
     const windowOpenMock = jest.fn()
@@ -55,11 +55,6 @@ describe('Link.tsx', () => {
     fireEvent.click(getByText(name))
     expect(windowOpenMock).toHaveBeenCalled()
     expect(windowOpenMock).toHaveBeenCalledWith(name, '_blank')
-  })
-
-  it('Renders download attribute', () => {
-    const { getByTestId } = render(<XLink model={{ ...linkProps, download: true }} />)
-    expect(getByTestId(name).getAttribute('download')).toEqual('')
   })
 
   it('Renders link target attribute when new tab specified', () => {

--- a/ui/src/link.tsx
+++ b/ui/src/link.tsx
@@ -46,22 +46,22 @@ export interface Link {
 }
 
 export const
-  XLink = bond(({ model: m }: { model: Link }) => {
+  XLink = bond(({ model: { name, label, disabled, path, download, target, button } }: { model: Link }) => {
     const
-      label = m.label || m.path,
-      target = m.target === '' ? '_blank' : m.target,
-      onClick = () => target ? window.open(m.path, target) : window.open(m.path),
+      _label = label || path,
+      _target = target === '' ? '_blank' : target,
+      onBtnClick = () => window.open(path, _target),
+      onLinkClick = (ev: React.MouseEvent<HTMLAnchorElement>) => {
+        // HACK: Perform download in a new tab because FF drops WS connection - https://bugzilla.mozilla.org/show_bug.cgi?id=858538.
+        if (download && path) {
+          ev.preventDefault()
+          window.open(path, '_blank')
+        }
+      },
       render = () => (
-        m.button
-          ? <Fluent.DefaultButton data-test={m.name} text={label} disabled={m.disabled} onClick={onClick} />
-          : <Fluent.Link
-            data-test={m.name}
-            href={m.path}
-            download={m.download}
-            disabled={m.disabled}
-            target={target}>
-            {label}
-          </Fluent.Link>
+        button
+          ? <Fluent.DefaultButton data-test={name} text={_label} disabled={disabled} onClick={onBtnClick} />
+          : <Fluent.Link onClick={onLinkClick} data-test={name} href={path} disabled={disabled} target={target}>{_label}</Fluent.Link>
       )
     return { render }
   })

--- a/ui/src/link.tsx
+++ b/ui/src/link.tsx
@@ -61,7 +61,7 @@ export const
       render = () => (
         button
           ? <Fluent.DefaultButton data-test={name} text={_label} disabled={disabled} onClick={onBtnClick} />
-          : <Fluent.Link onClick={onLinkClick} data-test={name} href={path} disabled={disabled} target={target}>{_label}</Fluent.Link>
+          : <Fluent.Link onClick={onLinkClick} data-test={name} href={path} disabled={disabled} target={_target}>{_label}</Fluent.Link>
       )
     return { render }
   })


### PR DESCRIPTION
The only solution that I managed to get working so far - perform download in a new tab so that current tab is not touched.

Alternatives tried:
* Using JS to trigger download, but unfortunately it seems like this is a browser-level issue so it doesn't matter what triggered the download.

Closes #899