### PR TITLE
feat: Update default Scopes and add `-oidc-scopes` cmd argument

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -342,7 +342,6 @@ func (h *AuthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	session.username = claims.PreferredUsername
 
 	echo(Log{"t": "login", "subject": session.subject, "username": session.username})
-	echo(Log{"t": "tokens", "a": session.token.AccessToken, "r": session.token.RefreshToken})
 
 	h.auth.set(session)
 

--- a/cmd/wave/main.go
+++ b/cmd/wave/main.go
@@ -71,6 +71,7 @@ func main() {
 		createAccessKey      bool
 		listAccessKeys       bool
 		removeAccessKeyID    string
+		scopes               string
 	)
 
 	flag.BoolVar(&version, "version", false, "print version and exit")
@@ -103,6 +104,7 @@ func main() {
 		oidcProviderURL   = "oidc-provider-url"
 		oidcRedirectURL   = "oidc-redirect-url"
 		oidcEndSessionURL = "oidc-end-session-url"
+		oidcScopes        = "oidc-scopes"
 		oidcSkipLogin     = "oidc-skip-login"
 	)
 
@@ -121,10 +123,15 @@ func main() {
 	auth.EndSessionURL = os.Getenv(toEnvVar(oidcEndSessionURL))
 	flag.StringVar(&auth.EndSessionURL, oidcEndSessionURL, auth.EndSessionURL, "OIDC end session URL")
 
+	scopes = os.Getenv(toEnvVar(oidcScopes))
+	flag.StringVar(&scopes, oidcScopes, scopes, "OIDC scopes separated by comma (default \"openid,profile\")")
+
 	auth.SkipLogin = getEnvBool(toEnvVar(oidcSkipLogin))
 	flag.BoolVar(&auth.SkipLogin, oidcSkipLogin, auth.SkipLogin, "don't show the login form during OIDC authorization")
 
 	flag.Parse()
+
+	auth.Scopes = strings.Split(scopes, ",")
 
 	if version {
 		fmt.Printf("Wave Daemon\nVersion %s Build %s (%s/%s)\nCopyright (c) H2O.ai, Inc.\n", Version, BuildDate, runtime.GOOS, runtime.GOARCH)

--- a/conf.go
+++ b/conf.go
@@ -47,5 +47,6 @@ type AuthConf struct {
 	ProviderURL   string
 	RedirectURL   string
 	EndSessionURL string
+	Scopes        []string
 	SkipLogin     bool
 }

--- a/website/docs/security.md
+++ b/website/docs/security.md
@@ -6,7 +6,7 @@ title: Security
 
 Wave apps and scripts access the Wave server using access keys via [HTTP Basic Authentication](https://tools.ietf.org/html/rfc7617).
 
-An application access key is a pair of strings: ID and Secret. 
+An application access key is a pair of strings: ID and Secret.
 
 ### Development
 
@@ -111,6 +111,7 @@ To enable OpenID Connect, pass the following flags when starting the Wave server
 - `-oidc-end-session-url`: URL to log out (refer to your identity provider's documentation). This flag is optional and might not be supported by your identity provider.
 - `-oidc-client-id`: Client ID (refer to your identity provider's documentation).
 - `-oidc-client-secret`:  Client secret (refer to your identity provider's documentation).
+- `-oidc-scopes`: Comma-separated scopes that will override defaults (`openid,profile`).
 
 Once authenticated, you can access user's authentication and authorization information from your app using `q.auth` (see the [Auth](api/server#auth) class for details):
 


### PR DESCRIPTION
If PR merged, the default scopes for OAuth request will be updated of `profile` and a new command-line argument `-oidc-scopes` will be introduced.

## Changes

The `profile` scope is added so `openid` and `profile` are now default. This change will ensure the `preferred_username` will be available in ID token making `q.auth.username` not to be empty while using e.g. *Okta*. Note that the `profile` scope is listed as a standard scope for OpenID and should always be available.

The `-oidc-scopes` is added so if `openid` and `profile` are not enough, it's possible to list values that override the defaults. Values are comma-separated:

```bash
./waved -oidc-scopes openid,profile,offline_access
```

## Notes
I was considering adding `offline_access` to default scopes as well to enable the `q.auth.refresh_token` in *Okta* but:
1. It actually not enables refresh token in *Okta* right away, there is one other step to allow it in UI as described in #925.
1. *Keycloak* will end up with an error and some setup in UI is necessary as well.
1. Refresh token is not needed for every Wave app.

cc @gaduimovich @jagadeeshrajarajan 

Resolves #925