### PR TITLE
feat: Side panel. #898

### DIFF
--- a/py/examples/meta_side_panel.py
+++ b/py/examples/meta_side_panel.py
@@ -14,7 +14,7 @@ async def serve(q: Q):
         q.client.initialized = True
     else:
         if q.args.show_side_panel:
-            q.page['meta'].side_panel = ui.side_panel(items=[
+            q.page['meta'].side_panel = ui.side_panel(title='Welcome to store', items=[
                 ui.text('Donuts cost $1.99. Proceed?'),
                 ui.buttons([ui.button(name='next_step', label='Next', primary=True)])
             ])

--- a/py/examples/meta_side_panel.py
+++ b/py/examples/meta_side_panel.py
@@ -1,0 +1,37 @@
+# Meta / SidePanel
+# Display a #sidePanel. #meta
+# ---
+from h2o_wave import main, app, Q, ui
+
+
+@app('/demo')
+async def serve(q: Q):
+    if not q.client.initialized:
+        q.page['meta'] = ui.meta_card(box='')
+        q.page['example'] = ui.form_card(box='1 1 11 10', items=[
+            ui.button(name='show_side_panel', label='Order donuts', primary=True)
+        ])
+        q.client.initialized = True
+    else:
+        if q.args.show_side_panel:
+            q.page['meta'].side_panel = ui.side_panel(items=[
+                ui.text('Donuts cost $1.99. Proceed?'),
+                ui.buttons([ui.button(name='next_step', label='Next', primary=True)])
+            ])
+        elif q.args.next_step:
+            q.page['meta'].side_panel.items = [
+                ui.text('You will be charged $1.99. Proceed?'),
+                ui.buttons([
+                    ui.button(name='cancel', label='Back to safety'),
+                    ui.button(name='submit', label='Place order', primary=True),
+                ])
+            ]
+        elif q.args.submit:
+            q.page['example'].items = [ui.message_bar('success', 'Order placed!')]
+            q.page['meta'].side_panel = None
+
+        elif q.args.cancel:
+            q.page['example'].items = [ui.message_bar('info', 'Order canceled!')]
+            q.page['meta'].side_panel = None
+
+    await q.page.save()

--- a/py/examples/tour.conf
+++ b/py/examples/tour.conf
@@ -172,6 +172,7 @@ meta_stylesheet.py
 meta_inline_stylesheet.py
 meta_dialog.py
 meta_dialog_closable.py
+meta_side_panel.py
 meta_title.py
 meta_icon.py
 meta_notification.py

--- a/py/h2o_wave/types.py
+++ b/py/h2o_wave/types.py
@@ -3375,9 +3375,9 @@ class TableCellType:
         _guard_scalar('TableCellType.progress', progress, (ProgressTableCellType,), False, True, False)
         _guard_scalar('TableCellType.icon', icon, (IconTableCellType,), False, True, False)
         self.progress = progress
-        """No documentation available."""
+        """Renders a progress arc with a percentage value in the middle."""
         self.icon = icon
-        """No documentation available."""
+        """Renders an icon."""
 
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""
@@ -7648,7 +7648,7 @@ class SidePanel:
         self.items = items
         """The components displayed in this side panel."""
         self.width = width
-        """The width of the dialog, e.g. '400px', defaults to '600px'."""
+        """The width of the dialog, e.g. '400px'. Defaults to '600px'."""
         self.name = name
         """An identifying name for this component."""
         self.events = events
@@ -7862,7 +7862,7 @@ class InlineScript:
 
 
 class InlineStylesheet:
-    """No documentation available.
+    """Create an inline CSS to be injected into a page.
     """
     def __init__(
             self,

--- a/py/h2o_wave/types.py
+++ b/py/h2o_wave/types.py
@@ -7632,15 +7632,19 @@ class SidePanel:
     """
     def __init__(
             self,
+            title: str,
             items: List[Component],
             width: Optional[str] = None,
             name: Optional[str] = None,
             events: Optional[List[str]] = None,
     ):
+        _guard_scalar('SidePanel.title', title, (str,), False, False, False)
         _guard_vector('SidePanel.items', items, (Component,), False, False, False)
         _guard_scalar('SidePanel.width', width, (str,), False, True, False)
         _guard_scalar('SidePanel.name', name, (str,), True, True, False)
         _guard_vector('SidePanel.events', events, (str,), False, True, False)
+        self.title = title
+        """The side panel's title."""
         self.items = items
         """The components displayed in this side panel."""
         self.width = width
@@ -7652,11 +7656,13 @@ class SidePanel:
 
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""
+        _guard_scalar('SidePanel.title', self.title, (str,), False, False, False)
         _guard_vector('SidePanel.items', self.items, (Component,), False, False, False)
         _guard_scalar('SidePanel.width', self.width, (str,), False, True, False)
         _guard_scalar('SidePanel.name', self.name, (str,), True, True, False)
         _guard_vector('SidePanel.events', self.events, (str,), False, True, False)
         return _dump(
+            title=self.title,
             items=[__e.dump() for __e in self.items],
             width=self.width,
             name=self.name,
@@ -7666,6 +7672,8 @@ class SidePanel:
     @staticmethod
     def load(__d: Dict) -> 'SidePanel':
         """Creates an instance of this class using the contents of a dict."""
+        __d_title: Any = __d.get('title')
+        _guard_scalar('SidePanel.title', __d_title, (str,), False, False, False)
         __d_items: Any = __d.get('items')
         _guard_vector('SidePanel.items', __d_items, (dict,), False, False, False)
         __d_width: Any = __d.get('width')
@@ -7674,11 +7682,13 @@ class SidePanel:
         _guard_scalar('SidePanel.name', __d_name, (str,), True, True, False)
         __d_events: Any = __d.get('events')
         _guard_vector('SidePanel.events', __d_events, (str,), False, True, False)
+        title: str = __d_title
         items: List[Component] = [Component.load(__e) for __e in __d_items]
         width: Optional[str] = __d_width
         name: Optional[str] = __d_name
         events: Optional[List[str]] = __d_events
         return SidePanel(
+            title,
             items,
             width,
             name,

--- a/py/h2o_wave/types.py
+++ b/py/h2o_wave/types.py
@@ -7625,6 +7625,67 @@ class Dialog:
         )
 
 
+class SidePanel:
+    """A dialog box (Dialog) is a temporary pop-up that takes focus from the page or app
+    and requires people to interact with it. It’s primarily used for confirming actions,
+    such as deleting a file, or asking people to make a choice.
+    """
+    def __init__(
+            self,
+            items: List[Component],
+            width: Optional[str] = None,
+            name: Optional[str] = None,
+            events: Optional[List[str]] = None,
+    ):
+        _guard_vector('SidePanel.items', items, (Component,), False, False, False)
+        _guard_scalar('SidePanel.width', width, (str,), False, True, False)
+        _guard_scalar('SidePanel.name', name, (str,), True, True, False)
+        _guard_vector('SidePanel.events', events, (str,), False, True, False)
+        self.items = items
+        """The components displayed in this side panel."""
+        self.width = width
+        """The width of the dialog, e.g. '400px', defaults to '600px'."""
+        self.name = name
+        """An identifying name for this component."""
+        self.events = events
+        """The events to capture on this side panel."""
+
+    def dump(self) -> Dict:
+        """Returns the contents of this object as a dict."""
+        _guard_vector('SidePanel.items', self.items, (Component,), False, False, False)
+        _guard_scalar('SidePanel.width', self.width, (str,), False, True, False)
+        _guard_scalar('SidePanel.name', self.name, (str,), True, True, False)
+        _guard_vector('SidePanel.events', self.events, (str,), False, True, False)
+        return _dump(
+            items=[__e.dump() for __e in self.items],
+            width=self.width,
+            name=self.name,
+            events=self.events,
+        )
+
+    @staticmethod
+    def load(__d: Dict) -> 'SidePanel':
+        """Creates an instance of this class using the contents of a dict."""
+        __d_items: Any = __d.get('items')
+        _guard_vector('SidePanel.items', __d_items, (dict,), False, False, False)
+        __d_width: Any = __d.get('width')
+        _guard_scalar('SidePanel.width', __d_width, (str,), False, True, False)
+        __d_name: Any = __d.get('name')
+        _guard_scalar('SidePanel.name', __d_name, (str,), True, True, False)
+        __d_events: Any = __d.get('events')
+        _guard_vector('SidePanel.events', __d_events, (str,), False, True, False)
+        items: List[Component] = [Component.load(__e) for __e in __d_items]
+        width: Optional[str] = __d_width
+        name: Optional[str] = __d_name
+        events: Optional[List[str]] = __d_events
+        return SidePanel(
+            items,
+            width,
+            name,
+            events,
+        )
+
+
 _TrackerType = ['ga', 'gtag']
 
 
@@ -7894,6 +7955,7 @@ class MetaCard:
             icon: Optional[str] = None,
             layouts: Optional[List[Layout]] = None,
             dialog: Optional[Dialog] = None,
+            side_panel: Optional[SidePanel] = None,
             theme: Optional[str] = None,
             tracker: Optional[Tracker] = None,
             scripts: Optional[List[Script]] = None,
@@ -7910,6 +7972,7 @@ class MetaCard:
         _guard_scalar('MetaCard.icon', icon, (str,), False, True, False)
         _guard_vector('MetaCard.layouts', layouts, (Layout,), False, True, False)
         _guard_scalar('MetaCard.dialog', dialog, (Dialog,), False, True, False)
+        _guard_scalar('MetaCard.side_panel', side_panel, (SidePanel,), False, True, False)
         _guard_scalar('MetaCard.theme', theme, (str,), False, True, False)
         _guard_scalar('MetaCard.tracker', tracker, (Tracker,), False, True, False)
         _guard_vector('MetaCard.scripts', scripts, (Script,), False, True, False)
@@ -7933,6 +7996,8 @@ class MetaCard:
         """The layouts supported by this page."""
         self.dialog = dialog
         """Display a dialog on the page."""
+        self.side_panel = side_panel
+        """Display a side panel on the page."""
         self.theme = theme
         """Specify the name of the theme (color scheme) to use on this page. One of 'light' or 'neon'."""
         self.tracker = tracker
@@ -7958,6 +8023,7 @@ class MetaCard:
         _guard_scalar('MetaCard.icon', self.icon, (str,), False, True, False)
         _guard_vector('MetaCard.layouts', self.layouts, (Layout,), False, True, False)
         _guard_scalar('MetaCard.dialog', self.dialog, (Dialog,), False, True, False)
+        _guard_scalar('MetaCard.side_panel', self.side_panel, (SidePanel,), False, True, False)
         _guard_scalar('MetaCard.theme', self.theme, (str,), False, True, False)
         _guard_scalar('MetaCard.tracker', self.tracker, (Tracker,), False, True, False)
         _guard_vector('MetaCard.scripts', self.scripts, (Script,), False, True, False)
@@ -7975,6 +8041,7 @@ class MetaCard:
             icon=self.icon,
             layouts=None if self.layouts is None else [__e.dump() for __e in self.layouts],
             dialog=None if self.dialog is None else self.dialog.dump(),
+            side_panel=None if self.side_panel is None else self.side_panel.dump(),
             theme=self.theme,
             tracker=None if self.tracker is None else self.tracker.dump(),
             scripts=None if self.scripts is None else [__e.dump() for __e in self.scripts],
@@ -8003,6 +8070,8 @@ class MetaCard:
         _guard_vector('MetaCard.layouts', __d_layouts, (dict,), False, True, False)
         __d_dialog: Any = __d.get('dialog')
         _guard_scalar('MetaCard.dialog', __d_dialog, (dict,), False, True, False)
+        __d_side_panel: Any = __d.get('side_panel')
+        _guard_scalar('MetaCard.side_panel', __d_side_panel, (dict,), False, True, False)
         __d_theme: Any = __d.get('theme')
         _guard_scalar('MetaCard.theme', __d_theme, (str,), False, True, False)
         __d_tracker: Any = __d.get('tracker')
@@ -8025,6 +8094,7 @@ class MetaCard:
         icon: Optional[str] = __d_icon
         layouts: Optional[List[Layout]] = None if __d_layouts is None else [Layout.load(__e) for __e in __d_layouts]
         dialog: Optional[Dialog] = None if __d_dialog is None else Dialog.load(__d_dialog)
+        side_panel: Optional[SidePanel] = None if __d_side_panel is None else SidePanel.load(__d_side_panel)
         theme: Optional[str] = __d_theme
         tracker: Optional[Tracker] = None if __d_tracker is None else Tracker.load(__d_tracker)
         scripts: Optional[List[Script]] = None if __d_scripts is None else [Script.load(__e) for __e in __d_scripts]
@@ -8041,6 +8111,7 @@ class MetaCard:
             icon,
             layouts,
             dialog,
+            side_panel,
             theme,
             tracker,
             scripts,

--- a/py/h2o_wave/ui.py
+++ b/py/h2o_wave/ui.py
@@ -2694,6 +2694,7 @@ def dialog(
 
 
 def side_panel(
+        title: str,
         items: List[Component],
         width: Optional[str] = None,
         name: Optional[str] = None,
@@ -2704,6 +2705,7 @@ def side_panel(
     such as deleting a file, or asking people to make a choice.
 
     Args:
+        title: The side panel's title.
         items: The components displayed in this side panel.
         width: The width of the dialog, e.g. '400px', defaults to '600px'.
         name: An identifying name for this component.
@@ -2712,6 +2714,7 @@ def side_panel(
         A `h2o_wave.types.SidePanel` instance.
     """
     return SidePanel(
+        title,
         items,
         width,
         name,

--- a/py/h2o_wave/ui.py
+++ b/py/h2o_wave/ui.py
@@ -2707,7 +2707,7 @@ def side_panel(
     Args:
         title: The side panel's title.
         items: The components displayed in this side panel.
-        width: The width of the dialog, e.g. '400px', defaults to '600px'.
+        width: The width of the dialog, e.g. '400px'. Defaults to '600px'.
         name: An identifying name for this component.
         events: The events to capture on this side panel.
     Returns:
@@ -2792,7 +2792,7 @@ def inline_stylesheet(
         content: str,
         media: Optional[str] = None,
 ) -> InlineStylesheet:
-    """No documentation available.
+    """Create an inline CSS to be injected into a page.
 
     Args:
         content: The CSS to be applied to this page.

--- a/py/h2o_wave/ui.py
+++ b/py/h2o_wave/ui.py
@@ -2693,6 +2693,32 @@ def dialog(
     )
 
 
+def side_panel(
+        items: List[Component],
+        width: Optional[str] = None,
+        name: Optional[str] = None,
+        events: Optional[List[str]] = None,
+) -> SidePanel:
+    """A dialog box (Dialog) is a temporary pop-up that takes focus from the page or app
+    and requires people to interact with it. It’s primarily used for confirming actions,
+    such as deleting a file, or asking people to make a choice.
+
+    Args:
+        items: The components displayed in this side panel.
+        width: The width of the dialog, e.g. '400px', defaults to '600px'.
+        name: An identifying name for this component.
+        events: The events to capture on this side panel.
+    Returns:
+        A `h2o_wave.types.SidePanel` instance.
+    """
+    return SidePanel(
+        items,
+        width,
+        name,
+        events,
+    )
+
+
 def tracker(
         type: str,
         id: str,
@@ -2807,6 +2833,7 @@ def meta_card(
         icon: Optional[str] = None,
         layouts: Optional[List[Layout]] = None,
         dialog: Optional[Dialog] = None,
+        side_panel: Optional[SidePanel] = None,
         theme: Optional[str] = None,
         tracker: Optional[Tracker] = None,
         scripts: Optional[List[Script]] = None,
@@ -2829,6 +2856,7 @@ def meta_card(
         icon: Shortcut icon path. Preferably a `.png` file (`.ico` files may not work in mobile browsers). Not supported in Safari.
         layouts: The layouts supported by this page.
         dialog: Display a dialog on the page.
+        side_panel: Display a side panel on the page.
         theme: Specify the name of the theme (color scheme) to use on this page. One of 'light' or 'neon'.
         tracker: Configure a tracker for the page (for web analytics).
         scripts: External Javascript files to load into the page.
@@ -2848,6 +2876,7 @@ def meta_card(
         icon,
         layouts,
         dialog,
+        side_panel,
         theme,
         tracker,
         scripts,

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -3157,7 +3157,7 @@ ui_dialog <- function(
 #'
 #' @param title The side panel's title.
 #' @param items The components displayed in this side panel.
-#' @param width The width of the dialog, e.g. '400px', defaults to '600px'.
+#' @param width The width of the dialog, e.g. '400px'. Defaults to '600px'.
 #' @param name An identifying name for this component.
 #' @param events The events to capture on this side panel.
 #' @return A SidePanel instance.
@@ -3254,7 +3254,7 @@ ui_inline_script <- function(
   return(.o)
 }
 
-#' No documentation available.
+#' Create an inline CSS to be injected into a page.
 #'
 #' @param content The CSS to be applied to this page.
 #' @param media A valid media query to set conditions for when the style should be applied. More info at https://developer.mozilla.org/en-US/docs/Web/HTML/Element/style#attr-media.

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -3151,6 +3151,34 @@ ui_dialog <- function(
   return(.o)
 }
 
+#' A dialog box (Dialog) is a temporary pop-up that takes focus from the page or app
+#' and requires people to interact with it. It’s primarily used for confirming actions,
+#' such as deleting a file, or asking people to make a choice.
+#'
+#' @param items The components displayed in this side panel.
+#' @param width The width of the dialog, e.g. '400px', defaults to '600px'.
+#' @param name An identifying name for this component.
+#' @param events The events to capture on this side panel.
+#' @return A SidePanel instance.
+#' @export
+ui_side_panel <- function(
+  items,
+  width = NULL,
+  name = NULL,
+  events = NULL) {
+  .guard_vector("items", "WaveComponent", items)
+  .guard_scalar("width", "character", width)
+  .guard_scalar("name", "character", name)
+  .guard_vector("events", "character", events)
+  .o <- list(
+    items=items,
+    width=width,
+    name=name,
+    events=events)
+  class(.o) <- append(class(.o), c(.wave_obj, "WaveSidePanel"))
+  return(.o)
+}
+
 #' Configure user interaction tracking (analytics) for a page.
 #'
 #' @param type The tracking provider. Supported providers are `ga` (Google Analytics) and `gtag` (Google Global Site Tags or gtag.js)
@@ -3276,6 +3304,7 @@ ui_stylesheet <- function(
 #'   Not supported in Safari.
 #' @param layouts The layouts supported by this page.
 #' @param dialog Display a dialog on the page.
+#' @param side_panel Display a side panel on the page.
 #' @param theme Specify the name of the theme (color scheme) to use on this page. One of 'light' or 'neon'.
 #' @param tracker Configure a tracker for the page (for web analytics).
 #' @param scripts External Javascript files to load into the page.
@@ -3294,6 +3323,7 @@ ui_meta_card <- function(
   icon = NULL,
   layouts = NULL,
   dialog = NULL,
+  side_panel = NULL,
   theme = NULL,
   tracker = NULL,
   scripts = NULL,
@@ -3309,6 +3339,7 @@ ui_meta_card <- function(
   .guard_scalar("icon", "character", icon)
   .guard_vector("layouts", "WaveLayout", layouts)
   .guard_scalar("dialog", "WaveDialog", dialog)
+  .guard_scalar("side_panel", "WaveSidePanel", side_panel)
   .guard_scalar("theme", "character", theme)
   .guard_scalar("tracker", "WaveTracker", tracker)
   .guard_vector("scripts", "WaveScript", scripts)
@@ -3325,6 +3356,7 @@ ui_meta_card <- function(
     icon=icon,
     layouts=layouts,
     dialog=dialog,
+    side_panel=side_panel,
     theme=theme,
     tracker=tracker,
     scripts=scripts,

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -3155,6 +3155,7 @@ ui_dialog <- function(
 #' and requires people to interact with it. It’s primarily used for confirming actions,
 #' such as deleting a file, or asking people to make a choice.
 #'
+#' @param title The side panel's title.
 #' @param items The components displayed in this side panel.
 #' @param width The width of the dialog, e.g. '400px', defaults to '600px'.
 #' @param name An identifying name for this component.
@@ -3162,15 +3163,18 @@ ui_dialog <- function(
 #' @return A SidePanel instance.
 #' @export
 ui_side_panel <- function(
+  title,
   items,
   width = NULL,
   name = NULL,
   events = NULL) {
+  .guard_scalar("title", "character", title)
   .guard_vector("items", "WaveComponent", items)
   .guard_scalar("width", "character", width)
   .guard_scalar("name", "character", name)
   .guard_vector("events", "character", events)
   .o <- list(
+    title=title,
     items=items,
     width=width,
     name=name,

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -17,6 +17,7 @@ import { box, WaveErrorCode, WaveEventType } from 'h2o-wave'
 import React from 'react'
 import { stylesheet } from 'typestyle'
 import Dialog from './dialog'
+import SidePanel from './side_panel'
 import { LayoutPicker } from './editor'
 import { Logo } from './logo'
 import { PageLayout } from './page'
@@ -117,6 +118,7 @@ const
                       <PageLayout key={page.key} page={page} />
                       <BusyOverlay />
                       <Dialog />
+                      <SidePanel />
                     </div>
                   </Fluent.Fabric>
                 )

--- a/ui/src/file_upload.test.tsx
+++ b/ui/src/file_upload.test.tsx
@@ -20,7 +20,7 @@ import { wave } from './ui'
 
 const name = 'fileUpload'
 const fileUploadProps: FileUpload = { name }
-interface FileObj { name: T.S; size?: T.F }
+type FileObj = { name: T.S; size?: T.F }
 
 describe('FileUpload.tsx', () => {
   beforeEach(() => {

--- a/ui/src/meta.tsx
+++ b/ui/src/meta.tsx
@@ -26,6 +26,10 @@ import { bond } from './ui'
 
 export type FlexBox = Partial<{ zone: S, order: U, size: S, width: S, height: S }>
 
+
+/**
+ * Create an inline CSS to be injected into a page.
+ */
 interface InlineStylesheet {
   /** The CSS to be applied to this page. */
   content: S

--- a/ui/src/meta.tsx
+++ b/ui/src/meta.tsx
@@ -18,6 +18,7 @@ import { Dialog, dialogB } from './dialog'
 import { cards } from './layout'
 import { showNotification } from './notification'
 import { executeScript, InlineScript, installScripts, Script } from './script'
+import { SidePanel, sidePanelB } from './side_panel'
 import { themeB } from './theme'
 import { setupTracker, Tracker } from './tracking'
 import { bond } from './ui'
@@ -122,6 +123,8 @@ interface State {
   layouts?: Layout[]
   /** Display a dialog on the page. */
   dialog?: Dialog
+  /** Display a side panel on the page. */
+  side_panel?: SidePanel
   /** Specify the name of the theme (color scheme) to use on this page. One of 'light' or 'neon'. */
   theme?: S
   /** Configure a tracker for the page (for web analytics). */
@@ -153,7 +156,22 @@ on(windowIconB, icon => {
 export const
   layoutsB = box<Layout[]>([]),
   preload = ({ state }: Model<State>) => {
-    const { title, icon, refresh, notification, redirect, layouts, dialog, theme, tracker, scripts, script, stylesheet, stylesheets } = state
+    const {
+      title,
+      icon,
+      refresh,
+      notification,
+      redirect,
+      layouts,
+      dialog,
+      side_panel,
+      theme,
+      tracker,
+      scripts,
+      script,
+      stylesheet,
+      stylesheets
+    } = state
 
     if (redirect) {
       try {
@@ -172,6 +190,7 @@ export const
     }
 
     dialogB(dialog ? { ...dialog } : null)
+    sidePanelB(side_panel ? { ...side_panel } : null)
 
     if (title) windowTitleB(title)
     if (icon) windowIconB(icon)

--- a/ui/src/side_panel.test.tsx
+++ b/ui/src/side_panel.test.tsx
@@ -14,58 +14,50 @@
 
 import { fireEvent, render, wait } from '@testing-library/react'
 import React from 'react'
-import Dialog, { dialogB } from './dialog'
+import SidePanel, { sidePanelB } from './side_panel'
 import { wave } from './ui'
 
 const
-  name = 'dialog',
-  dialogProps = {
-    name,
-    title: 'Dialog Title',
-    items: [],
-  }
-describe('Dialog.tsx', () => {
+  name = 'sidePanel',
+  sidePanelProps = { name, items: [] }
 
-  beforeEach(() => dialogB(dialogProps))
+describe('SidePanel.tsx', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    sidePanelB(sidePanelProps)
+  })
 
-  it('should open dialog when global qd.dialogB is set', () => {
-    const { queryByRole } = render(<Dialog />)
+  it('should open side panel when global sidePanel is set', () => {
+    const { queryByRole } = render(<SidePanel />)
     expect(queryByRole('dialog')).toBeInTheDocument()
   })
 
-  it('should close dialog when global qd.dialogB is null', async () => {
-    const { queryByRole } = render(<Dialog />)
+  it('should close side panel when global sidePanel is null', async () => {
+    const { queryByRole } = render(<SidePanel />)
     expect(queryByRole('dialog')).toBeInTheDocument()
-    dialogB(null)
+    sidePanelB(null)
     await wait(() => expect(queryByRole('dialog')).not.toBeInTheDocument())
   })
 
-  it('should render correct title when specified', () => {
-    const title = 'New Title'
-    dialogB({ ...dialogProps, title })
-    const { queryByText } = render(<Dialog />)
-    expect(queryByText(title)).toBeInTheDocument()
-  })
-
   it('should render X closing button when specified', () => {
-    dialogB({ ...dialogProps, closable: true })
-    const { queryByTitle } = render(<Dialog />)
-    expect(queryByTitle('Close')).toBeInTheDocument()
+    sidePanelB(sidePanelProps)
+    const { container } = render(<SidePanel />)
+    expect(container.parentElement?.querySelector('.ms-Panel-closeButton')).toBeInTheDocument()
   })
 
-  it('should close dialog when clicking on X', async () => {
-    dialogB({ ...dialogProps, closable: true })
-    const { getByTitle, queryByRole } = render(<Dialog />)
-    fireEvent.click(getByTitle('Close'))
+  it('should close side panel when clicking on X', async () => {
+    sidePanelB(sidePanelProps)
+    const { container, queryByRole } = render(<SidePanel />)
+    fireEvent.click(container.parentElement?.querySelector('.ms-Panel-closeButton') as any)
     await wait(() => expect(queryByRole('dialog')).not.toBeInTheDocument())
   })
 
   it('should fire event if specified when clicking on X', () => {
-    dialogB({ ...dialogProps, closable: true, events: ['dismissed'] })
-    const { getByTitle } = render(<Dialog />)
+    sidePanelB({ ...sidePanelProps, events: ['dismissed'] })
+    const { container } = render(<SidePanel />)
     const emitMock = jest.fn()
     wave.emit = emitMock
-    fireEvent.click(getByTitle('Close'))
+    fireEvent.click(container.parentElement?.querySelector('.ms-Panel-closeButton') as any)
     expect(emitMock).toHaveBeenCalled()
   })
 })

--- a/ui/src/side_panel.test.tsx
+++ b/ui/src/side_panel.test.tsx
@@ -19,7 +19,7 @@ import { wave } from './ui'
 
 const
   name = 'sidePanel',
-  sidePanelProps = { name, items: [] }
+  sidePanelProps = { name, items: [], title: 'Title' }
 
 describe('SidePanel.tsx', () => {
   beforeEach(() => {
@@ -40,13 +40,11 @@ describe('SidePanel.tsx', () => {
   })
 
   it('should render X closing button when specified', () => {
-    sidePanelB(sidePanelProps)
     const { container } = render(<SidePanel />)
     expect(container.parentElement?.querySelector('.ms-Panel-closeButton')).toBeInTheDocument()
   })
 
   it('should close side panel when clicking on X', async () => {
-    sidePanelB(sidePanelProps)
     const { container, queryByRole } = render(<SidePanel />)
     fireEvent.click(container.parentElement?.querySelector('.ms-Panel-closeButton') as any)
     await wait(() => expect(queryByRole('dialog')).not.toBeInTheDocument())

--- a/ui/src/side_panel.tsx
+++ b/ui/src/side_panel.tsx
@@ -1,0 +1,57 @@
+// Copyright 2020 H2O.ai, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as Fluent from '@fluentui/react'
+import { Box, box, Id, S } from 'h2o-wave'
+import React from 'react'
+import { Component, XComponents } from './form'
+import { bond, wave } from './ui'
+
+export const sidePanelB: Box<SidePanel | null> = box(null)
+
+/**
+ * A dialog box (Dialog) is a temporary pop-up that takes focus from the page or app
+ * and requires people to interact with it. It’s primarily used for confirming actions,
+ * such as deleting a file, or asking people to make a choice.
+ */
+export interface SidePanel {
+  /** The components displayed in this side panel. */
+  items: Component[]
+  /** The width of the dialog, e.g. '400px', defaults to '600px'. */
+  width?: S
+  /** An identifying name for this component. */
+  name?: Id
+  /** The events to capture on this side panel. */
+  events?: S[]
+}
+
+export default bond(() => {
+  const
+    onDismiss = () => {
+      const { name, events } = sidePanelB() || {}
+      if (name) {
+        events?.forEach(e => { if (e === 'dismissed') wave.emit(name, e, true) })
+      }
+      sidePanelB(null)
+    },
+    render = () => {
+      const { width = '600px', items = [] } = sidePanelB() || {}
+      return (
+        <Fluent.Panel isOpen={!!sidePanelB()} type={Fluent.PanelType.custom} customWidth={width} onDismiss={onDismiss}>
+          <XComponents items={items} />
+        </Fluent.Panel >
+      )
+    }
+  return { render, sidePanelB }
+})

--- a/ui/src/side_panel.tsx
+++ b/ui/src/side_panel.tsx
@@ -41,10 +41,11 @@ export interface SidePanel {
 export default bond(() => {
   const
     onDismiss = () => {
-      const { name, events } = sidePanelB() || {}
-      if (name) {
-        events?.forEach(e => { if (e === 'dismissed') wave.emit(name, e, true) })
-      }
+      const
+        { name, events } = sidePanelB() || {},
+        ev = events?.find(e => e === 'dismissed')
+
+      if (ev && name) wave.emit(name, ev, true)
       sidePanelB(null)
     },
     render = () => {

--- a/ui/src/side_panel.tsx
+++ b/ui/src/side_panel.tsx
@@ -30,7 +30,7 @@ export interface SidePanel {
   title: S
   /** The components displayed in this side panel. */
   items: Component[]
-  /** The width of the dialog, e.g. '400px', defaults to '600px'. */
+  /** The width of the dialog, e.g. '400px'. Defaults to '600px'. */
   width?: S
   /** An identifying name for this component. */
   name?: Id

--- a/ui/src/side_panel.tsx
+++ b/ui/src/side_panel.tsx
@@ -26,6 +26,8 @@ export const sidePanelB: Box<SidePanel | null> = box(null)
  * such as deleting a file, or asking people to make a choice.
  */
 export interface SidePanel {
+  /** The side panel's title. */
+  title: S
   /** The components displayed in this side panel. */
   items: Component[]
   /** The width of the dialog, e.g. '400px', defaults to '600px'. */
@@ -46,9 +48,9 @@ export default bond(() => {
       sidePanelB(null)
     },
     render = () => {
-      const { width = '600px', items = [] } = sidePanelB() || {}
+      const { title, width = '600px', items = [] } = sidePanelB() || {}
       return (
-        <Fluent.Panel isOpen={!!sidePanelB()} type={Fluent.PanelType.custom} customWidth={width} onDismiss={onDismiss}>
+        <Fluent.Panel isOpen={!!sidePanelB()} headerText={title} type={Fluent.PanelType.custom} customWidth={width} onDismiss={onDismiss}>
           <XComponents items={items} />
         </Fluent.Panel >
       )

--- a/ui/src/table.tsx
+++ b/ui/src/table.tsx
@@ -23,7 +23,9 @@ import { wave } from './ui'
 
 /** Defines cell content to be rendered instead of a simple text. */
 interface TableCellType {
+  /** Renders a progress arc with a percentage value in the middle. */
   progress?: ProgressTableCellType
+  /** Renders an icon. */
   icon?: IconTableCellType
 }
 


### PR DESCRIPTION
Current demo:

https://user-images.githubusercontent.com/64769322/129548308-83eaab7d-58d5-4855-86f5-d300d2d5f3f3.mov

@lo5 
* I added `width` prop as well which I think might be handy - same as dialog.
* Added support for `q.events` on close - same as dialog.
* Needs discussion: It might be a good idea to introduce a `title` prop as well.

@sandruparo 
* As discussed, the designs need more work on colors. They are currently hardcoded and need to be themable instead.
* Current implementation doesn't use any offsets (top, right, bottom). The proposed design has them, but these seem like random values (top 223px, right 50px, bottom 244px). There are 2 options we have here:
1. Make the offset fixed - what is presented in the proposed design, but with reasonable values.
2. Use percentage value.
Please let me know which one to pick.

Closes #898