### PR TITLE
feat: Introduce more values to ui.inline justify. #534

### DIFF
--- a/py/demo/dashboard_red.py
+++ b/py/demo/dashboard_red.py
@@ -36,9 +36,9 @@ async def show_red_dashboard(q: Q):
         subtitle=next(sample_caption),
         items=[
             ui.label(label='Start:'),
-            ui.date_picker(name='target_date', label='', value='2020-12-20'),
+            ui.date_picker(name='target_date1', label='', value='2020-12-20'),
             ui.label(label='End:'),
-            ui.date_picker(name='target_date', label='', value='2020-12-25'),
+            ui.date_picker(name='target_date2', label='', value='2020-12-25'),
         ],
     )
 

--- a/py/h2o_wave/types.py
+++ b/py/h2o_wave/types.py
@@ -5666,12 +5666,15 @@ class Stats:
         )
 
 
-_InlineJustify = ['start', 'end']
+_InlineJustify = ['start', 'end', 'center', 'between', 'around']
 
 
 class InlineJustify:
     START = 'start'
     END = 'end'
+    CENTER = 'center'
+    BETWEEN = 'between'
+    AROUND = 'around'
 
 
 class Inline:
@@ -5689,7 +5692,7 @@ class Inline:
         self.items = items
         """The components laid out inline."""
         self.justify = justify
-        """Specifies how to lay out the individual components. Defaults to 'start'. One of 'start', 'end'. See enum h2o_wave.ui.InlineJustify."""
+        """Specifies how to lay out the individual components. Defaults to 'start'. One of 'start', 'end', 'center', 'between', 'around'. See enum h2o_wave.ui.InlineJustify."""
         self.inset = inset
         """Whether to display the components inset from the parent form, with a contrasting background."""
 

--- a/py/h2o_wave/ui.py
+++ b/py/h2o_wave/ui.py
@@ -2118,7 +2118,7 @@ def inline(
 
     Args:
         items: The components laid out inline.
-        justify: Specifies how to lay out the individual components. Defaults to 'start'. One of 'start', 'end'. See enum h2o_wave.ui.InlineJustify.
+        justify: Specifies how to lay out the individual components. Defaults to 'start'. One of 'start', 'end', 'center', 'between', 'around'. See enum h2o_wave.ui.InlineJustify.
         inset: Whether to display the components inset from the parent form, with a contrasting background.
     Returns:
         A `h2o_wave.types.Inline` instance.

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -2475,7 +2475,7 @@ ui_stats <- function(
 #'
 #' @param items The components laid out inline.
 #' @param justify Specifies how to lay out the individual components. Defaults to 'start'.
-#'   One of 'start', 'end'. See enum h2o_wave.ui.InlineJustify.
+#'   One of 'start', 'end', 'center', 'between', 'around'. See enum h2o_wave.ui.InlineJustify.
 #' @param inset Whether to display the components inset from the parent form, with a contrasting background.
 #' @return A Inline instance.
 #' @export

--- a/ui/src/flex.tsx
+++ b/ui/src/flex.tsx
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Data, Dict, Model, Rec, S } from 'h2o-wave'
+import { Data, Model, Rec, S } from 'h2o-wave'
 import React from 'react'
 import { cards, Repeat } from './layout'
+import { alignments, directions, justifications, wrappings } from './theme'
 import { bond } from './ui'
 
 /**
@@ -39,32 +40,6 @@ interface State {
 }
 
 const
-  directions: Dict<S> = {
-    horizontal: 'row',
-    vertical: 'column',
-  },
-  justifications: Dict<S> = {
-    start: 'flex-start',
-    end: 'flex-end',
-    center: 'center',
-    between: 'space-between',
-    around: 'space-around',
-  },
-  alignments: Dict<S> = {
-    start: 'flex-start',
-    end: 'flex-end',
-    center: 'center',
-    baseline: 'baseline',
-    stretch: 'stretch',
-  },
-  wrappings: Dict<S> = {
-    start: 'flex-start',
-    end: 'flex-end',
-    center: 'center',
-    between: 'space-between',
-    around: 'space-around',
-    stretch: 'stretch',
-  },
   toFlexStyle = (state: State): React.CSSProperties => {
     const
       css: React.CSSProperties = { display: 'flex' },

--- a/ui/src/form.tsx
+++ b/ui/src/form.tsx
@@ -36,7 +36,6 @@ import { MessageBar, XMessageBar } from './message_bar'
 import { Picker, XPicker } from './picker'
 import { Visualization, XVisualization } from './plot'
 import { Progress, XProgress } from './progress'
-import { bond } from './ui'
 import { RangeSlider, XRangeSlider } from './range_slider'
 import { Separator, XSeparator } from './separator'
 import { Slider, XSlider } from './slider'
@@ -48,9 +47,10 @@ import { Tabs, XTabs } from './tabs'
 import { Template, XTemplate } from './template'
 import { Text, TextL, TextM, TextS, TextXl, TextXs, XText } from './text'
 import { Textbox, XTextbox } from './textbox'
-import { clas, cssVar, padding } from './theme'
+import { clas, cssVar, justifications, padding } from './theme'
 import { Toggle, XToggle } from './toggle'
 import { XToolTip } from './tooltip'
+import { bond } from './ui'
 import { VegaVisualization, XVegaVisualization } from './vega'
 import { Persona, XPersona } from "./persona"
 
@@ -143,7 +143,7 @@ interface Inline {
   /** The components laid out inline. */
   items: Component[]
   /** Specifies how to lay out the individual components. Defaults to 'start'. */
-  justify?: 'start' | 'end'
+  justify?: 'start' | 'end' | 'center' | 'between' | 'around'
   /** Whether to display the components inset from the parent form, with a contrasting background. */
   inset?: B
 }
@@ -185,12 +185,9 @@ const
       background: cssVar('$page'),
       padding: padding(10, 15)
     },
-    horizontalRight: {
-      justifyContent: 'flex-end',
-    },
   })
 
-export enum XComponentAlignment { Top, Left, Right }
+type XComponentAlignment = 'start' | 'end' | 'center' | 'between' | 'around'
 
 export const
   XComponents = ({ items, alignment, inset }: { items: Component[], alignment?: XComponentAlignment, inset?: B }) => {
@@ -208,18 +205,13 @@ export const
             <XComponent model={m} />
           </div>
         )
-      }),
-      className = alignment === XComponentAlignment.Left
-        ? clas(css.horizontal, inset ? css.inset : '')
-        : alignment === XComponentAlignment.Right
-          ? clas(css.horizontal, css.horizontalRight, inset ? css.inset : '')
-          : css.vertical
-    return <div className={className}>{components}</div>
+      })
+    return <div className={clas(alignment ? css.horizontal : css.vertical, inset ? css.inset : '')} style={{ justifyContent: justifications[alignment || ''] }}>{components}</div>
   },
   XInline = ({ model: m }: { model: Inline }) => (
     <XComponents
       items={m.items}
-      alignment={m.justify === 'end' ? XComponentAlignment.Right : XComponentAlignment.Left}
+      alignment={m.justify || 'start'}
       inset={m.inset}
     />
   )

--- a/ui/src/page.tsx
+++ b/ui/src/page.tsx
@@ -18,7 +18,7 @@ import { stylesheet } from 'typestyle'
 import { CardMenu } from './card_menu'
 import { CardEffect, CardView, getCardStyle, GridLayout } from './layout'
 import { FlexBox, Layout, layoutsB, preload, Zone } from './meta'
-import { clas, cssVar, margin } from './theme'
+import { alignments, clas, cssVar, justifications, margin, wrappings } from './theme'
 import { bond } from './ui'
 
 
@@ -163,28 +163,6 @@ const
         ? css.raised
         : effect == CardEffect.Flat
           ? css.flat : '')
-  },
-  justifications: Dict<S> = {
-    start: 'flex-start',
-    end: 'flex-end',
-    center: 'center',
-    between: 'space-between',
-    around: 'space-around',
-  },
-  alignments: Dict<S> = {
-    start: 'flex-start',
-    end: 'flex-end',
-    center: 'center',
-    baseline: 'baseline',
-    stretch: 'stretch',
-  },
-  wrappings: Dict<S> = {
-    start: 'flex-start',
-    end: 'flex-end',
-    center: 'center',
-    between: 'space-between',
-    around: 'space-around',
-    stretch: 'stretch',
   },
   toSectionStyle = (zone: Zone, direction?: S): React.CSSProperties => {
     const

--- a/ui/src/section.tsx
+++ b/ui/src/section.tsx
@@ -15,7 +15,7 @@
 import { Model, Packed, S, unpack } from 'h2o-wave'
 import React from 'react'
 import { stylesheet } from 'typestyle'
-import { Component, XComponentAlignment, XComponents } from './form'
+import { Component, XComponents } from './form'
 import { CardEffect, cards } from './layout'
 import { Markdown } from './markdown'
 import { clas } from './theme'
@@ -61,7 +61,7 @@ export const
           components = unpack<Component[]>(items), // XXX ugly
           form = items && (
             <div className={css.rhs}>
-              <XComponents items={components} alignment={XComponentAlignment.Right} />
+              <XComponents items={components} alignment='end' />
             </div>
           )
 

--- a/ui/src/theme.ts
+++ b/ui/src/theme.ts
@@ -167,7 +167,33 @@ const
 export const
   defaultThemeName = 'default',
   themeB = box(defaultThemeName),
-  defaultTheme = themes[defaultThemeName]
+  defaultTheme = themes[defaultThemeName],
+  directions: Dict<S> = {
+    horizontal: 'row',
+    vertical: 'column',
+  },
+  justifications: Dict<S> = {
+    start: 'flex-start',
+    end: 'flex-end',
+    center: 'center',
+    between: 'space-between',
+    around: 'space-around',
+  },
+  alignments: Dict<S> = {
+    start: 'flex-start',
+    end: 'flex-end',
+    center: 'center',
+    baseline: 'baseline',
+    stretch: 'stretch',
+  },
+  wrappings: Dict<S> = {
+    start: 'flex-start',
+    end: 'flex-end',
+    center: 'center',
+    between: 'space-between',
+    around: 'space-around',
+    stretch: 'stretch',
+  }
 
 
 on(themeB, themeName => {


### PR DESCRIPTION
@lo5 API for review:
`ui.inline.justify` changed from `'start' | 'end'` to `'start' | 'end' | 'center' | 'between' | 'around'`.

Closes #534