### PR TITLE
feat: Persona form component. #970

### DIFF
--- a/py/examples/persona.py
+++ b/py/examples/persona.py
@@ -1,0 +1,27 @@
+# Form / Button
+# Use #buttons to enable a user to commit a change or complete steps in a task.
+# #form
+# ---
+from h2o_wave import main, app, Q, ui
+
+
+@app('/demo')
+async def serve(q: Q):
+    if q.args.persona:
+        q.page['example'].items = [
+            ui.text_m(f'q.args.persona={q.args.persona}'),
+            ui.button(name='back', label='Back', primary=True),
+        ]
+    else:
+        image = 'https://images.pexels.com/photos/220453/pexels-photo-220453.jpeg?auto=compress&h=750&w=1260'
+        q.page['example'] = ui.form_card(box='1 1 2 7', items=[
+            ui.persona(title='John Doe', subtitle='Data Scientist', caption='Online', size='xs', image=image),
+            ui.persona(title='John Doe', subtitle='Data Scientist', caption='Online', size='s', image=image),
+            ui.persona(title='John Doe', subtitle='Data Scientist', caption='Online', size='m', image=image),
+            ui.persona(title='John Doe', subtitle='Data Scientist', caption='Online', size='l', image=image),
+            ui.persona(title='John Doe', subtitle='Data Scientist', caption='Online', size='xl', image=image),
+            ui.persona(title='', initials='JD', initials_color='$grey'),
+            ui.persona(name='persona', title='Click me', size='s', image=image)
+        ])
+
+    await q.page.save()

--- a/py/examples/persona.py
+++ b/py/examples/persona.py
@@ -1,5 +1,5 @@
-# Form / Button
-# Use #buttons to enable a user to commit a change or complete steps in a task.
+# Form / Persona
+# Create an individual's persona or avatar, a visual representation of a person across products.
 # #form
 # ---
 from h2o_wave import main, app, Q, ui

--- a/py/examples/tour.conf
+++ b/py/examples/tour.conf
@@ -49,6 +49,7 @@ date_picker.py
 date_picker_trigger.py
 color_picker.py
 swatch_picker.py
+persona.py
 tabs.py
 separator.py
 file_upload.py

--- a/py/h2o_wave/types.py
+++ b/py/h2o_wave/types.py
@@ -5802,6 +5802,117 @@ class Image:
         )
 
 
+_PersonaSize = ['xl', 'l', 'm', 's', 'xs']
+
+
+class PersonaSize:
+    XL = 'xl'
+    L = 'l'
+    M = 'm'
+    S = 's'
+    XS = 'xs'
+
+
+class Persona:
+    """Create an individual's persona or avatar, a visual representation of a person across products.
+    Can be used to display an individual's avatar (or a composition of the person’s initials on a background color), their name or identification, and online status.
+    """
+    def __init__(
+            self,
+            title: str,
+            subtitle: Optional[str] = None,
+            caption: Optional[str] = None,
+            size: Optional[str] = None,
+            image: Optional[str] = None,
+            initials: Optional[str] = None,
+            initials_color: Optional[str] = None,
+            name: Optional[str] = None,
+    ):
+        _guard_scalar('Persona.title', title, (str,), False, False, False)
+        _guard_scalar('Persona.subtitle', subtitle, (str,), False, True, False)
+        _guard_scalar('Persona.caption', caption, (str,), False, True, False)
+        _guard_enum('Persona.size', size, _PersonaSize, True)
+        _guard_scalar('Persona.image', image, (str,), False, True, False)
+        _guard_scalar('Persona.initials', initials, (str,), False, True, False)
+        _guard_scalar('Persona.initials_color', initials_color, (str,), False, True, False)
+        _guard_scalar('Persona.name', name, (str,), True, True, False)
+        self.title = title
+        """Primary text, displayed next to the persona coin."""
+        self.subtitle = subtitle
+        """Secondary text, displayed under the title."""
+        self.caption = caption
+        """Tertiary text, displayed under the subtitle. Only visible for sizes >= 'm'."""
+        self.size = size
+        """The size of the persona coin. Defaults to 'm'. One of 'xl', 'l', 'm', 's', 'xs'. See enum h2o_wave.ui.PersonaSize."""
+        self.image = image
+        """Image, URL or base64-encoded (`data:image/png;base64,???`)."""
+        self.initials = initials
+        """Initials, if `image` is not specified."""
+        self.initials_color = initials_color
+        """Initials background color (CSS-compatible string)."""
+        self.name = name
+        """An identifying name for this component."""
+
+    def dump(self) -> Dict:
+        """Returns the contents of this object as a dict."""
+        _guard_scalar('Persona.title', self.title, (str,), False, False, False)
+        _guard_scalar('Persona.subtitle', self.subtitle, (str,), False, True, False)
+        _guard_scalar('Persona.caption', self.caption, (str,), False, True, False)
+        _guard_enum('Persona.size', self.size, _PersonaSize, True)
+        _guard_scalar('Persona.image', self.image, (str,), False, True, False)
+        _guard_scalar('Persona.initials', self.initials, (str,), False, True, False)
+        _guard_scalar('Persona.initials_color', self.initials_color, (str,), False, True, False)
+        _guard_scalar('Persona.name', self.name, (str,), True, True, False)
+        return _dump(
+            title=self.title,
+            subtitle=self.subtitle,
+            caption=self.caption,
+            size=self.size,
+            image=self.image,
+            initials=self.initials,
+            initials_color=self.initials_color,
+            name=self.name,
+        )
+
+    @staticmethod
+    def load(__d: Dict) -> 'Persona':
+        """Creates an instance of this class using the contents of a dict."""
+        __d_title: Any = __d.get('title')
+        _guard_scalar('Persona.title', __d_title, (str,), False, False, False)
+        __d_subtitle: Any = __d.get('subtitle')
+        _guard_scalar('Persona.subtitle', __d_subtitle, (str,), False, True, False)
+        __d_caption: Any = __d.get('caption')
+        _guard_scalar('Persona.caption', __d_caption, (str,), False, True, False)
+        __d_size: Any = __d.get('size')
+        _guard_enum('Persona.size', __d_size, _PersonaSize, True)
+        __d_image: Any = __d.get('image')
+        _guard_scalar('Persona.image', __d_image, (str,), False, True, False)
+        __d_initials: Any = __d.get('initials')
+        _guard_scalar('Persona.initials', __d_initials, (str,), False, True, False)
+        __d_initials_color: Any = __d.get('initials_color')
+        _guard_scalar('Persona.initials_color', __d_initials_color, (str,), False, True, False)
+        __d_name: Any = __d.get('name')
+        _guard_scalar('Persona.name', __d_name, (str,), True, True, False)
+        title: str = __d_title
+        subtitle: Optional[str] = __d_subtitle
+        caption: Optional[str] = __d_caption
+        size: Optional[str] = __d_size
+        image: Optional[str] = __d_image
+        initials: Optional[str] = __d_initials
+        initials_color: Optional[str] = __d_initials_color
+        name: Optional[str] = __d_name
+        return Persona(
+            title,
+            subtitle,
+            caption,
+            size,
+            image,
+            initials,
+            initials_color,
+            name,
+        )
+
+
 class Component:
     """Create a component.
     """
@@ -5846,6 +5957,7 @@ class Component:
             stats: Optional[Stats] = None,
             inline: Optional[Inline] = None,
             image: Optional[Image] = None,
+            persona: Optional[Persona] = None,
     ):
         _guard_scalar('Component.text', text, (Text,), False, True, False)
         _guard_scalar('Component.text_xl', text_xl, (TextXl,), False, True, False)
@@ -5886,6 +5998,7 @@ class Component:
         _guard_scalar('Component.stats', stats, (Stats,), False, True, False)
         _guard_scalar('Component.inline', inline, (Inline,), False, True, False)
         _guard_scalar('Component.image', image, (Image,), False, True, False)
+        _guard_scalar('Component.persona', persona, (Persona,), False, True, False)
         self.text = text
         """Text block."""
         self.text_xl = text_xl
@@ -5964,6 +6077,8 @@ class Component:
         """Inline components"""
         self.image = image
         """Image"""
+        self.persona = persona
+        """Persona"""
 
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""
@@ -6006,6 +6121,7 @@ class Component:
         _guard_scalar('Component.stats', self.stats, (Stats,), False, True, False)
         _guard_scalar('Component.inline', self.inline, (Inline,), False, True, False)
         _guard_scalar('Component.image', self.image, (Image,), False, True, False)
+        _guard_scalar('Component.persona', self.persona, (Persona,), False, True, False)
         return _dump(
             text=None if self.text is None else self.text.dump(),
             text_xl=None if self.text_xl is None else self.text_xl.dump(),
@@ -6046,6 +6162,7 @@ class Component:
             stats=None if self.stats is None else self.stats.dump(),
             inline=None if self.inline is None else self.inline.dump(),
             image=None if self.image is None else self.image.dump(),
+            persona=None if self.persona is None else self.persona.dump(),
         )
 
     @staticmethod
@@ -6129,6 +6246,8 @@ class Component:
         _guard_scalar('Component.inline', __d_inline, (dict,), False, True, False)
         __d_image: Any = __d.get('image')
         _guard_scalar('Component.image', __d_image, (dict,), False, True, False)
+        __d_persona: Any = __d.get('persona')
+        _guard_scalar('Component.persona', __d_persona, (dict,), False, True, False)
         text: Optional[Text] = None if __d_text is None else Text.load(__d_text)
         text_xl: Optional[TextXl] = None if __d_text_xl is None else TextXl.load(__d_text_xl)
         text_l: Optional[TextL] = None if __d_text_l is None else TextL.load(__d_text_l)
@@ -6168,6 +6287,7 @@ class Component:
         stats: Optional[Stats] = None if __d_stats is None else Stats.load(__d_stats)
         inline: Optional[Inline] = None if __d_inline is None else Inline.load(__d_inline)
         image: Optional[Image] = None if __d_image is None else Image.load(__d_image)
+        persona: Optional[Persona] = None if __d_persona is None else Persona.load(__d_persona)
         return Component(
             text,
             text_xl,
@@ -6208,6 +6328,7 @@ class Component:
             stats,
             inline,
             image,
+            persona,
         )
 
 

--- a/py/h2o_wave/ui.py
+++ b/py/h2o_wave/ui.py
@@ -2160,6 +2160,43 @@ def image(
     ))
 
 
+def persona(
+        title: str,
+        subtitle: Optional[str] = None,
+        caption: Optional[str] = None,
+        size: Optional[str] = None,
+        image: Optional[str] = None,
+        initials: Optional[str] = None,
+        initials_color: Optional[str] = None,
+        name: Optional[str] = None,
+) -> Component:
+    """Create an individual's persona or avatar, a visual representation of a person across products.
+    Can be used to display an individual's avatar (or a composition of the person’s initials on a background color), their name or identification, and online status.
+
+    Args:
+        title: Primary text, displayed next to the persona coin.
+        subtitle: Secondary text, displayed under the title.
+        caption: Tertiary text, displayed under the subtitle. Only visible for sizes >= 'm'.
+        size: The size of the persona coin. Defaults to 'm'. One of 'xl', 'l', 'm', 's', 'xs'. See enum h2o_wave.ui.PersonaSize.
+        image: Image, URL or base64-encoded (`data:image/png;base64,???`).
+        initials: Initials, if `image` is not specified.
+        initials_color: Initials background color (CSS-compatible string).
+        name: An identifying name for this component.
+    Returns:
+        A `h2o_wave.types.Persona` instance.
+    """
+    return Component(persona=Persona(
+        title,
+        subtitle,
+        caption,
+        size,
+        image,
+        initials,
+        initials_color,
+        name,
+    ))
+
+
 def form_card(
         box: str,
         items: Union[List[Component], str],

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -2528,6 +2528,50 @@ ui_image <- function(
   return(.o)
 }
 
+#' Create an individual's persona or avatar, a visual representation of a person across products.
+#' Can be used to display an individual's avatar (or a composition of the person’s initials on a background color), their name or identification, and online status.
+#'
+#' @param title Primary text, displayed next to the persona coin.
+#' @param subtitle Secondary text, displayed under the title.
+#' @param caption Tertiary text, displayed under the subtitle. Only visible for sizes >= 'm'.
+#' @param size The size of the persona coin. Defaults to 'm'.
+#'   One of 'xl', 'l', 'm', 's', 'xs'. See enum h2o_wave.ui.PersonaSize.
+#' @param image Image, URL or base64-encoded (`data:image/png;base64,???`).
+#' @param initials Initials, if `image` is not specified.
+#' @param initials_color Initials background color (CSS-compatible string).
+#' @param name An identifying name for this component.
+#' @return A Persona instance.
+#' @export
+ui_persona <- function(
+  title,
+  subtitle = NULL,
+  caption = NULL,
+  size = NULL,
+  image = NULL,
+  initials = NULL,
+  initials_color = NULL,
+  name = NULL) {
+  .guard_scalar("title", "character", title)
+  .guard_scalar("subtitle", "character", subtitle)
+  .guard_scalar("caption", "character", caption)
+  # TODO Validate size
+  .guard_scalar("image", "character", image)
+  .guard_scalar("initials", "character", initials)
+  .guard_scalar("initials_color", "character", initials_color)
+  .guard_scalar("name", "character", name)
+  .o <- list(persona=list(
+    title=title,
+    subtitle=subtitle,
+    caption=caption,
+    size=size,
+    image=image,
+    initials=initials,
+    initials_color=initials_color,
+    name=name))
+  class(.o) <- append(class(.o), c(.wave_obj, "WaveComponent"))
+  return(.o)
+}
+
 #' Create a form.
 #'
 #' @param box A string indicating how to place this component on the page.

--- a/ui/src/form.tsx
+++ b/ui/src/form.tsx
@@ -52,6 +52,7 @@ import { clas, cssVar, padding } from './theme'
 import { Toggle, XToggle } from './toggle'
 import { XToolTip } from './tooltip'
 import { VegaVisualization, XVegaVisualization } from './vega'
+import { Persona, XPersona } from "./persona"
 
 /** Create a component. */
 export interface Component {
@@ -133,6 +134,8 @@ export interface Component {
   inline?: Inline
   /** Image */
   image?: Image
+  /** Persona. */
+  persona?: Persona
 }
 
 /** Create an inline (horizontal) list of components. */
@@ -263,6 +266,7 @@ const
     if (m.stats) return <XStats model={m.stats} />
     if (m.inline) return <XInline model={m.inline} />
     if (m.image) return <XImage model={m.image} />
+    if (m.persona) return <XPersona model={m.persona} />
     return <Fluent.MessageBar messageBarType={Fluent.MessageBarType.severeWarning}>This component could not be rendered.</Fluent.MessageBar>
   }
 

--- a/ui/src/persona.test.tsx
+++ b/ui/src/persona.test.tsx
@@ -1,0 +1,58 @@
+// Copyright 2020 H2O.ai, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { fireEvent, render } from '@testing-library/react'
+import React from 'react'
+import { wave } from './ui'
+import { Persona, XPersona } from "./persona"
+
+const
+  name = 'persona',
+  personaProps: Persona = { name, title: 'John Doe' },
+  pushMock = jest.fn()
+
+describe('Persona.tsx', () => {
+  beforeAll(() => {
+    wave.push = pushMock
+  })
+  beforeEach(() => {
+    jest.resetAllMocks()
+    wave.args[name] = null
+  })
+
+  it('Renders data-test attr', () => {
+    const { queryByTestId } = render(<XPersona model={personaProps} />)
+    expect(queryByTestId(name)).toBeInTheDocument()
+  })
+
+  it('Calls push on click', () => {
+    const { queryByTestId } = render(<XPersona model={personaProps} />)
+
+    fireEvent.click(queryByTestId(name)!)
+
+    expect(wave.args[name]).toBe(true)
+    expect(pushMock).toHaveBeenCalled()
+  })
+
+  it('Redirects on hash name', () => {
+    const hashName = `#${name}`
+    const { queryByTestId } = render(<XPersona model={{ ...personaProps, name: hashName }} />)
+
+    fireEvent.click(queryByTestId(hashName)!)
+
+    expect(wave.args[name]).toBe(null)
+    expect(pushMock).not.toHaveBeenCalled()
+    expect(window.location.hash).toBe(hashName)
+  })
+})

--- a/ui/src/persona.tsx
+++ b/ui/src/persona.tsx
@@ -5,9 +5,10 @@ import { cssVar } from './theme'
 import { wave } from './ui'
 
 
-/** Create an individual's persona or avatar, a visual representation of a person across products. 
+/** 
+  * Create an individual's persona or avatar, a visual representation of a person across products. 
   * Can be used to display an individual's avatar (or a composition of the person’s initials on a background color), their name or identification, and online status.
-  */
+*/
 export interface Persona {
   /** Primary text, displayed next to the persona coin. */
   title: S

--- a/ui/src/persona.tsx
+++ b/ui/src/persona.tsx
@@ -1,0 +1,64 @@
+import * as Fluent from '@fluentui/react'
+import { Id, S } from 'h2o-wave'
+import React from 'react'
+import { cssVar } from './theme'
+import { wave } from './ui'
+
+
+/** Create an individual's persona or avatar, a visual representation of a person across products. 
+  * Can be used to display an individual's avatar (or a composition of the person’s initials on a background color), their name or identification, and online status.
+  */
+export interface Persona {
+  /** Primary text, displayed next to the persona coin. */
+  title: S
+  /** Secondary text, displayed under the title. */
+  subtitle?: S
+  /** Tertiary text, displayed under the subtitle. Only visible for sizes >= 'm'. */
+  caption?: S
+  /** The size of the persona coin. Defaults to 'm'. */
+  size?: 'xl' | 'l' | 'm' | 's' | 'xs'
+  /** Image, URL or base64-encoded (`data:image/png;base64,???`). */
+  image?: S
+  /** Initials, if `image` is not specified. */
+  initials?: S
+  /** Initials background color (CSS-compatible string). */
+  initials_color?: S
+  /** An identifying name for this component. */
+  name?: Id
+}
+
+const fluentSizes: { [K in 'xs' | 's' | 'm' | 'l' | 'xl']: Fluent.PersonaSize } = {
+  'xs': Fluent.PersonaSize.size48,
+  's': Fluent.PersonaSize.size56,
+  'm': Fluent.PersonaSize.size72,
+  'l': Fluent.PersonaSize.size100,
+  'xl': Fluent.PersonaSize.size120,
+}
+
+export const XPersona = ({ model }: { model: Persona }) => {
+  const onClick = () => {
+    if (model.name) {
+      if (model.name.startsWith('#')) {
+        window.location.hash = model.name.substr(1)
+        return
+      }
+      wave.args[model.name] = true
+      wave.push()
+    }
+  }
+
+  return (
+    <div data-test={model.name} onClick={onClick}>
+      <Fluent.Persona
+        styles={{ root: { cursor: model.name ? 'pointer' : 'initial' } }}
+        text={model.title}
+        secondaryText={model.subtitle}
+        tertiaryText={model.caption}
+        imageUrl={model.image}
+        imageInitials={model.initials}
+        initialsColor={cssVar(model.initials_color)}
+        size={model.size ? fluentSizes[model.size] : Fluent.PersonaSize.size72}
+      />
+    </div>
+  )
+}


### PR DESCRIPTION
Demo:

https://user-images.githubusercontent.com/64769322/132238224-6aa37209-c773-4710-bfe9-1029064f7352.mov

In addition to the [proposed API](https://github.com/h2oai/wave/issues/970#issuecomment-909345128), I have also added 

```ts
/** Initials background color (CSS-compatible string). */
initials_color?: S
```
for color control over background.

changed `size` type to `'xl' | 'l' | 'm' | 's' | 'xs'` in order to avoid using Fluent types directly.

If `name` is specified, the whole component becomes clickable, supporting hash routing as well.

Closes #970