### PR TITLE
feat: Header component and IconNotification form component. #994

### DIFF
--- a/py/examples/header_enhanced.py
+++ b/py/examples/header_enhanced.py
@@ -1,0 +1,47 @@
+# Header
+# Use a header card to display a page #header.
+# ---
+from h2o_wave import main, app, Q, ui
+
+image = 'https://images.pexels.com/photos/220453/pexels-photo-220453.jpeg?auto=compress&h=750&w=1260'
+
+@app('/demo')
+async def serve(q: Q):
+    q.page['meta'] = ui.meta_card(box='', theme='darkBlue', layouts = [
+        ui.layout(
+            breakpoint='xl',
+            zones=[
+                ui.zone('header'),
+            ]
+        ),
+    ])
+
+    q.page['example_header'] = ui.header_card(
+        box='header',
+        title='H2O Model Monitoring',
+        subtitle='Monitor your models and features',
+        icon='ExploreData',
+        icon_color='$themePrimary',
+        search_name="searchbox_icon",
+        items=[
+            ui.icon_notification(icon='Ringer', icon_color='$themePrimary', notification_count="12"), 
+            ui.icon_notification(icon='Settings', icon_color='$themePrimary', notification_count="!"), 
+            ui.frame(width='60px', height='0px'),
+            ui.persona(title='John Doe', subtitle='Frontend developer', caption='Online', size='xs', image=image),
+            ui.button(name="chevron_down", icon="ChevronDownSmall")
+        ],
+        nav=[
+            ui.nav_group('Menu', items=[
+                ui.nav_item(name='#menu/dashboard', label='Dashboard'),
+                ui.nav_item(name='#menu/all-projects', label='All projects'),
+                ui.nav_item(name='#menu/sample-data', label='Sample data'),
+                ui.nav_item(name='#menu/help', label='Help'),
+            ]),
+            ui.nav_group('Help', items=[
+                ui.nav_item(name='#about', label='About'),
+                ui.nav_item(name='#support', label='Support'),
+            ])
+        ]
+    )
+
+    await q.page.save()

--- a/py/examples/header_enhanced.py
+++ b/py/examples/header_enhanced.py
@@ -1,4 +1,4 @@
-# Header
+# Header enhanced
 # Use a header card to display a page #header.
 # ---
 from h2o_wave import main, app, Q, ui

--- a/py/examples/icon_notification.py
+++ b/py/examples/icon_notification.py
@@ -5,7 +5,7 @@ from h2o_wave import site, ui
 
 page = site['/demo']
 page['icon_notification1'] = ui.form_card(
-    box='1 1 2 2',
+    box='1 1 1 2',
     items=[
         ui.icon_notification(icon='Ringer', icon_color='$red', notification_count="12"),
         ui.icon_notification(icon='Settings', icon_color='$red', notification_count="!")

--- a/py/examples/icon_notification.py
+++ b/py/examples/icon_notification.py
@@ -1,0 +1,14 @@
+# Form / Icon Notificaton
+# Use an icon notification to show number of unread notifications.
+# ---
+from h2o_wave import site, ui
+
+page = site['/demo']
+page['icon_notification1'] = ui.form_card(
+    box='1 1 2 2',
+    items=[
+        ui.icon_notification(icon='Ringer', icon_color='$red', notification_count="12"),
+        ui.icon_notification(icon='Settings', icon_color='$red', notification_count="!")
+    ]
+)
+page.save()

--- a/py/examples/tour.conf
+++ b/py/examples/tour.conf
@@ -35,6 +35,7 @@ buttons.py
 checkbox.py
 checklist.py
 checklist_inline.py
+icon_notification.py
 picker.py
 picker_selection.py
 dropdown.py

--- a/py/h2o_wave/types.py
+++ b/py/h2o_wave/types.py
@@ -5913,6 +5913,65 @@ class Persona:
         )
 
 
+class IconNotification:
+    """Create an icon with a notification badge.
+    """
+    def __init__(
+            self,
+            icon: str,
+            notification_count: str,
+            icon_color: Optional[str] = None,
+            name: Optional[str] = None,
+    ):
+        _guard_scalar('IconNotification.icon', icon, (str,), False, False, False)
+        _guard_scalar('IconNotification.notification_count', notification_count, (str,), False, False, False)
+        _guard_scalar('IconNotification.icon_color', icon_color, (str,), False, True, False)
+        _guard_scalar('IconNotification.name', name, (str,), False, True, False)
+        self.icon = icon
+        """Icon."""
+        self.notification_count = notification_count
+        """Number of notifications"""
+        self.icon_color = icon_color
+        """The icon's color."""
+        self.name = name
+        """An identifying name for this component."""
+
+    def dump(self) -> Dict:
+        """Returns the contents of this object as a dict."""
+        _guard_scalar('IconNotification.icon', self.icon, (str,), False, False, False)
+        _guard_scalar('IconNotification.notification_count', self.notification_count, (str,), False, False, False)
+        _guard_scalar('IconNotification.icon_color', self.icon_color, (str,), False, True, False)
+        _guard_scalar('IconNotification.name', self.name, (str,), False, True, False)
+        return _dump(
+            icon=self.icon,
+            notification_count=self.notification_count,
+            icon_color=self.icon_color,
+            name=self.name,
+        )
+
+    @staticmethod
+    def load(__d: Dict) -> 'IconNotification':
+        """Creates an instance of this class using the contents of a dict."""
+        __d_icon: Any = __d.get('icon')
+        _guard_scalar('IconNotification.icon', __d_icon, (str,), False, False, False)
+        __d_notification_count: Any = __d.get('notification_count')
+        _guard_scalar('IconNotification.notification_count', __d_notification_count, (str,), False, False, False)
+        __d_icon_color: Any = __d.get('icon_color')
+        _guard_scalar('IconNotification.icon_color', __d_icon_color, (str,), False, True, False)
+        __d_name: Any = __d.get('name')
+        _guard_scalar('IconNotification.name', __d_name, (str,), False, True, False)
+        icon: str = __d_icon
+        notification_count: str = __d_notification_count
+        icon_color: Optional[str] = __d_icon_color
+        name: Optional[str] = __d_name
+        return IconNotification(
+            icon,
+            notification_count,
+            icon_color,
+            name,
+        )
+
+
 class Component:
     """Create a component.
     """
@@ -5958,6 +6017,7 @@ class Component:
             inline: Optional[Inline] = None,
             image: Optional[Image] = None,
             persona: Optional[Persona] = None,
+            icon_notification: Optional[IconNotification] = None,
     ):
         _guard_scalar('Component.text', text, (Text,), False, True, False)
         _guard_scalar('Component.text_xl', text_xl, (TextXl,), False, True, False)
@@ -5999,6 +6059,7 @@ class Component:
         _guard_scalar('Component.inline', inline, (Inline,), False, True, False)
         _guard_scalar('Component.image', image, (Image,), False, True, False)
         _guard_scalar('Component.persona', persona, (Persona,), False, True, False)
+        _guard_scalar('Component.icon_notification', icon_notification, (IconNotification,), False, True, False)
         self.text = text
         """Text block."""
         self.text_xl = text_xl
@@ -6078,7 +6139,9 @@ class Component:
         self.image = image
         """Image"""
         self.persona = persona
-        """Persona"""
+        """Persona."""
+        self.icon_notification = icon_notification
+        """Icon notification."""
 
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""
@@ -6122,6 +6185,7 @@ class Component:
         _guard_scalar('Component.inline', self.inline, (Inline,), False, True, False)
         _guard_scalar('Component.image', self.image, (Image,), False, True, False)
         _guard_scalar('Component.persona', self.persona, (Persona,), False, True, False)
+        _guard_scalar('Component.icon_notification', self.icon_notification, (IconNotification,), False, True, False)
         return _dump(
             text=None if self.text is None else self.text.dump(),
             text_xl=None if self.text_xl is None else self.text_xl.dump(),
@@ -6163,6 +6227,7 @@ class Component:
             inline=None if self.inline is None else self.inline.dump(),
             image=None if self.image is None else self.image.dump(),
             persona=None if self.persona is None else self.persona.dump(),
+            icon_notification=None if self.icon_notification is None else self.icon_notification.dump(),
         )
 
     @staticmethod
@@ -6248,6 +6313,8 @@ class Component:
         _guard_scalar('Component.image', __d_image, (dict,), False, True, False)
         __d_persona: Any = __d.get('persona')
         _guard_scalar('Component.persona', __d_persona, (dict,), False, True, False)
+        __d_icon_notification: Any = __d.get('icon_notification')
+        _guard_scalar('Component.icon_notification', __d_icon_notification, (dict,), False, True, False)
         text: Optional[Text] = None if __d_text is None else Text.load(__d_text)
         text_xl: Optional[TextXl] = None if __d_text_xl is None else TextXl.load(__d_text_xl)
         text_l: Optional[TextL] = None if __d_text_l is None else TextL.load(__d_text_l)
@@ -6288,6 +6355,7 @@ class Component:
         inline: Optional[Inline] = None if __d_inline is None else Inline.load(__d_inline)
         image: Optional[Image] = None if __d_image is None else Image.load(__d_image)
         persona: Optional[Persona] = None if __d_persona is None else Persona.load(__d_persona)
+        icon_notification: Optional[IconNotification] = None if __d_icon_notification is None else IconNotification.load(__d_icon_notification)
         return Component(
             text,
             text_xl,
@@ -6329,6 +6397,7 @@ class Component:
             inline,
             image,
             persona,
+            icon_notification,
         )
 
 
@@ -6721,7 +6790,7 @@ class NavGroup:
 
 
 class HeaderCard:
-    """Render a page header displaying a title, subtitle and an optional navigation menu.
+    """Render a page header displaying a title, subtitle and an optional navigation menu, searchbar or custom items.
     Header cards are typically used for top-level navigation.
     """
     def __init__(
@@ -6732,6 +6801,8 @@ class HeaderCard:
             icon: Optional[str] = None,
             icon_color: Optional[str] = None,
             nav: Optional[List[NavGroup]] = None,
+            search_name: Optional[str] = None,
+            items: Optional[List[Component]] = None,
             commands: Optional[List[Command]] = None,
     ):
         _guard_scalar('HeaderCard.box', box, (str,), False, False, False)
@@ -6740,6 +6811,8 @@ class HeaderCard:
         _guard_scalar('HeaderCard.icon', icon, (str,), False, True, False)
         _guard_scalar('HeaderCard.icon_color', icon_color, (str,), False, True, False)
         _guard_vector('HeaderCard.nav', nav, (NavGroup,), False, True, False)
+        _guard_scalar('HeaderCard.search_name', search_name, (str,), False, True, False)
+        _guard_vector('HeaderCard.items', items, (Component,), False, True, False)
         _guard_vector('HeaderCard.commands', commands, (Command,), False, True, False)
         self.box = box
         """A string indicating how to place this component on the page."""
@@ -6753,6 +6826,10 @@ class HeaderCard:
         """The icon's color."""
         self.nav = nav
         """The navigation menu to display when the header's icon is clicked."""
+        self.search_name = search_name
+        """An identifying name of the search."""
+        self.items = items
+        """List of components aligned to the right of the header."""
         self.commands = commands
         """Contextual menu commands for this component."""
 
@@ -6764,6 +6841,8 @@ class HeaderCard:
         _guard_scalar('HeaderCard.icon', self.icon, (str,), False, True, False)
         _guard_scalar('HeaderCard.icon_color', self.icon_color, (str,), False, True, False)
         _guard_vector('HeaderCard.nav', self.nav, (NavGroup,), False, True, False)
+        _guard_scalar('HeaderCard.search_name', self.search_name, (str,), False, True, False)
+        _guard_vector('HeaderCard.items', self.items, (Component,), False, True, False)
         _guard_vector('HeaderCard.commands', self.commands, (Command,), False, True, False)
         return _dump(
             view='header',
@@ -6773,6 +6852,8 @@ class HeaderCard:
             icon=self.icon,
             icon_color=self.icon_color,
             nav=None if self.nav is None else [__e.dump() for __e in self.nav],
+            search_name=self.search_name,
+            items=None if self.items is None else [__e.dump() for __e in self.items],
             commands=None if self.commands is None else [__e.dump() for __e in self.commands],
         )
 
@@ -6791,6 +6872,10 @@ class HeaderCard:
         _guard_scalar('HeaderCard.icon_color', __d_icon_color, (str,), False, True, False)
         __d_nav: Any = __d.get('nav')
         _guard_vector('HeaderCard.nav', __d_nav, (dict,), False, True, False)
+        __d_search_name: Any = __d.get('search_name')
+        _guard_scalar('HeaderCard.search_name', __d_search_name, (str,), False, True, False)
+        __d_items: Any = __d.get('items')
+        _guard_vector('HeaderCard.items', __d_items, (dict,), False, True, False)
         __d_commands: Any = __d.get('commands')
         _guard_vector('HeaderCard.commands', __d_commands, (dict,), False, True, False)
         box: str = __d_box
@@ -6799,6 +6884,8 @@ class HeaderCard:
         icon: Optional[str] = __d_icon
         icon_color: Optional[str] = __d_icon_color
         nav: Optional[List[NavGroup]] = None if __d_nav is None else [NavGroup.load(__e) for __e in __d_nav]
+        search_name: Optional[str] = __d_search_name
+        items: Optional[List[Component]] = None if __d_items is None else [Component.load(__e) for __e in __d_items]
         commands: Optional[List[Command]] = None if __d_commands is None else [Command.load(__e) for __e in __d_commands]
         return HeaderCard(
             box,
@@ -6807,6 +6894,8 @@ class HeaderCard:
             icon,
             icon_color,
             nav,
+            search_name,
+            items,
             commands,
         )
 

--- a/py/h2o_wave/ui.py
+++ b/py/h2o_wave/ui.py
@@ -2197,6 +2197,30 @@ def persona(
     ))
 
 
+def icon_notification(
+        icon: str,
+        notification_count: str,
+        icon_color: Optional[str] = None,
+        name: Optional[str] = None,
+) -> Component:
+    """Create an icon with a notification badge.
+
+    Args:
+        icon: Icon.
+        notification_count: Number of notifications
+        icon_color: The icon's color.
+        name: An identifying name for this component.
+    Returns:
+        A `h2o_wave.types.IconNotification` instance.
+    """
+    return Component(icon_notification=IconNotification(
+        icon,
+        notification_count,
+        icon_color,
+        name,
+    ))
+
+
 def form_card(
         box: str,
         items: Union[List[Component], str],
@@ -2362,9 +2386,11 @@ def header_card(
         icon: Optional[str] = None,
         icon_color: Optional[str] = None,
         nav: Optional[List[NavGroup]] = None,
+        search_name: Optional[str] = None,
+        items: Optional[List[Component]] = None,
         commands: Optional[List[Command]] = None,
 ) -> HeaderCard:
-    """Render a page header displaying a title, subtitle and an optional navigation menu.
+    """Render a page header displaying a title, subtitle and an optional navigation menu, searchbar or custom items.
     Header cards are typically used for top-level navigation.
 
     Args:
@@ -2374,6 +2400,8 @@ def header_card(
         icon: The icon, displayed to the left.
         icon_color: The icon's color.
         nav: The navigation menu to display when the header's icon is clicked.
+        search_name: An identifying name of the search.
+        items: List of components aligned to the right of the header.
         commands: Contextual menu commands for this component.
     Returns:
         A `h2o_wave.types.HeaderCard` instance.
@@ -2385,6 +2413,8 @@ def header_card(
         icon,
         icon_color,
         nav,
+        search_name,
+        items,
         commands,
     )
 

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -2572,6 +2572,32 @@ ui_persona <- function(
   return(.o)
 }
 
+#' Create an icon with a notification badge.
+#'
+#' @param icon Icon.
+#' @param notification_count Number of notifications
+#' @param icon_color The icon's color.
+#' @param name An identifying name for this component.
+#' @return A IconNotification instance.
+#' @export
+ui_icon_notification <- function(
+  icon,
+  notification_count,
+  icon_color = NULL,
+  name = NULL) {
+  .guard_scalar("icon", "character", icon)
+  .guard_scalar("notification_count", "character", notification_count)
+  .guard_scalar("icon_color", "character", icon_color)
+  .guard_scalar("name", "character", name)
+  .o <- list(icon_notification=list(
+    icon=icon,
+    notification_count=notification_count,
+    icon_color=icon_color,
+    name=name))
+  class(.o) <- append(class(.o), c(.wave_obj, "WaveComponent"))
+  return(.o)
+}
+
 #' Create a form.
 #'
 #' @param box A string indicating how to place this component on the page.
@@ -2751,7 +2777,7 @@ ui_nav_group <- function(
   return(.o)
 }
 
-#' Render a page header displaying a title, subtitle and an optional navigation menu.
+#' Render a page header displaying a title, subtitle and an optional navigation menu, searchbar or custom items.
 #' Header cards are typically used for top-level navigation.
 #'
 #' @param box A string indicating how to place this component on the page.
@@ -2760,6 +2786,8 @@ ui_nav_group <- function(
 #' @param icon The icon, displayed to the left.
 #' @param icon_color The icon's color.
 #' @param nav The navigation menu to display when the header's icon is clicked.
+#' @param search_name An identifying name of the search.
+#' @param items List of components aligned to the right of the header.
 #' @param commands Contextual menu commands for this component.
 #' @return A HeaderCard instance.
 #' @export
@@ -2770,6 +2798,8 @@ ui_header_card <- function(
   icon = NULL,
   icon_color = NULL,
   nav = NULL,
+  search_name = NULL,
+  items = NULL,
   commands = NULL) {
   .guard_scalar("box", "character", box)
   .guard_scalar("title", "character", title)
@@ -2777,6 +2807,8 @@ ui_header_card <- function(
   .guard_scalar("icon", "character", icon)
   .guard_scalar("icon_color", "character", icon_color)
   .guard_vector("nav", "WaveNavGroup", nav)
+  .guard_scalar("search_name", "character", search_name)
+  .guard_vector("items", "WaveComponent", items)
   .guard_vector("commands", "WaveCommand", commands)
   .o <- list(
     box=box,
@@ -2785,6 +2817,8 @@ ui_header_card <- function(
     icon=icon,
     icon_color=icon_color,
     nav=nav,
+    search_name=search_name,
+    items=items,
     commands=commands)
   class(.o) <- append(class(.o), c(.wave_obj, "WaveHeaderCard"))
   return(.o)

--- a/ui/src/form.tsx
+++ b/ui/src/form.tsx
@@ -53,6 +53,7 @@ import { Toggle, XToggle } from './toggle'
 import { XToolTip } from './tooltip'
 import { VegaVisualization, XVegaVisualization } from './vega'
 import { Persona, XPersona } from "./persona"
+import { IconNotification, XIconNotification } from './icon_notification'
 
 /** Create a component. */
 export interface Component {
@@ -136,6 +137,8 @@ export interface Component {
   image?: Image
   /** Persona. */
   persona?: Persona
+  /** Icon notification. */
+  icon_notification?: IconNotification
 }
 
 /** Create an inline (horizontal) list of components. */
@@ -267,6 +270,7 @@ const
     if (m.inline) return <XInline model={m.inline} />
     if (m.image) return <XImage model={m.image} />
     if (m.persona) return <XPersona model={m.persona} />
+    if (m.icon_notification) return <XIconNotification model={m.icon_notification} />
     return <Fluent.MessageBar messageBarType={Fluent.MessageBarType.severeWarning}>This component could not be rendered.</Fluent.MessageBar>
   }
 

--- a/ui/src/header.test.tsx
+++ b/ui/src/header.test.tsx
@@ -16,13 +16,15 @@ import { fireEvent, render } from '@testing-library/react'
 import * as T from 'h2o-wave'
 import React from 'react'
 import { View } from './header'
+import { wave } from './ui'
 
 const
   name = 'header',
   label = 'label',
+  placeholder= "Search anything here...",
   headerProps: T.Model<any> = {
     name,
-    state: { nav: [{ label: 'group1', items: [{ name, label }] }] },
+    state: { nav: [{ label: 'group1', items: [{ name, label }] }], search_name: "searchbox_icon", items: [{icon_notification: {icon: 'Ringer', icon_color: '$themePrimary', notification_count: "12"}}] },
     changed: T.box(false)
   }
 
@@ -41,5 +43,28 @@ describe('Header.tsx', () => {
 
     fireEvent.click(menuItem!)
     expect(menuItem).not.toBeVisible()
+  })
+
+  it('Searchbar visible when specified in props', () => {
+    const { queryByPlaceholderText } = render(<View {...headerProps} />)
+
+    const searchbar = queryByPlaceholderText(placeholder)
+    expect(searchbar).toBeVisible()
+  })
+
+  it('Calls push on click', () => {
+    const { queryByPlaceholderText } = render(<View {...headerProps} />)
+    
+    window.location.hash = ''
+    wave.args[headerProps.state.search_name] = null
+    jest.clearAllMocks()
+
+    const pushMock = jest.fn()
+    wave.push = pushMock
+
+    fireEvent.change(queryByPlaceholderText('Search anything here...')!, { target: { value: 'text' } })
+
+    expect(wave.args[headerProps.state.search_name]).toBe('text')
+    expect(pushMock).toHaveBeenCalled()
   })
 })

--- a/ui/src/icon_notification.test.tsx
+++ b/ui/src/icon_notification.test.tsx
@@ -1,0 +1,34 @@
+// Copyright 2020 H2O.ai, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { render } from '@testing-library/react'
+import React from 'react'
+import { IconNotification, XIconNotification } from './icon_notification'
+
+const
+    name="icon_notification",
+    props: IconNotification = {name, icon:'Ringer', icon_color:'$themePrimary', notification_count:"12" }
+  
+describe('IconNotification.tsx', () => {
+  it('Renders data-test attr', () => {
+    const { queryByTestId } = render(<XIconNotification model={props} />)
+    expect(queryByTestId(name)).toBeInTheDocument()
+    })
+
+  it('Render badge text', () => {
+    const { queryByText } = render(<XIconNotification model={props} />)
+    const iconNotification = queryByText('12')
+    expect(iconNotification).toBeInTheDocument()
+  })
+})

--- a/ui/src/icon_notification.tsx
+++ b/ui/src/icon_notification.tsx
@@ -22,7 +22,6 @@ const
   iconSize = 28,
   css = stylesheet({
     icon: {
-      display: 'inline-table',
       verticalAlign: 'middle',
       height: iconSize,
       width: iconSize,
@@ -30,6 +29,7 @@ const
     },
     notification: {
       position: 'relative',
+      display: 'inline-block',
       marginLeft: 12,
       marginRight: 12,
     },

--- a/ui/src/icon_notification.tsx
+++ b/ui/src/icon_notification.tsx
@@ -1,0 +1,73 @@
+// Copyright 2020 H2O.ai, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { FontIcon } from '@fluentui/react'
+import { S } from 'h2o-wave'
+import React from 'react'
+import { stylesheet } from 'typestyle'
+import { cssVar } from './theme'
+
+const
+  iconSize = 28,
+  css = stylesheet({
+    icon: {
+      display: 'inline-table',
+      verticalAlign: 'middle',
+      height: iconSize,
+      width: iconSize,
+      fontSize: iconSize,
+    },
+    notification: {
+      position: 'relative',
+      marginLeft: 12,
+      marginRight: 12,
+    },
+    badge: {
+      position: 'absolute',
+      height: 16,
+      width: 16,
+      top: -8,
+      right: -8,
+      borderRadius: '50%',
+      verticalAlign: 'middle',
+      alignContent: 'center',
+      textAlign: 'center',
+      fontSize: 11,
+      fontWeight: 'bold',
+      color: 'black',
+      background: cssVar("$themeLighterAlt"),
+      border: `2px solid ${cssVar("$text")}`
+    }
+  })
+
+/** Create an icon with a notification badge. */
+export interface IconNotification {
+  /** Icon. */
+  icon: S
+  /** Number of notifications */
+  notification_count: S
+  /** The icon's color. */
+  icon_color?: S
+  /** An identifying name for this component. */
+  name?: S
+}
+
+export const
+  XIconNotification = ({ model }: { model: IconNotification }) => {
+    const { icon, notification_count, icon_color, name } = model
+    return <div data-test={model.name} className={css.notification}>
+      <FontIcon key={name} className={css.icon} iconName={icon ?? 'WebComponents'} style={{color: cssVar(icon_color)}} />
+      <span className={css.badge}>{notification_count}</span>
+    </div> 
+  }

--- a/ui/src/theme.ts
+++ b/ui/src/theme.ts
@@ -127,6 +127,37 @@ const
         // TODO: Generate dark fluent color palette.
       },
     },
+    darkBlue: {
+      palette: {
+        text: '#ffffff',
+        card: '#1d2d49',
+        page: '#101f3b',
+      },
+      fluentPalette: {
+        themePrimary: '#ffffff',
+        themeLighterAlt: '#fdc888',
+        themeLighter: '#a6a6a6',
+        themeLight: '#c8c8c8',
+        themeTertiary: '#d0d0d0',
+        themeSecondary: '#dadada',
+        themeDarkAlt: '#eaeaea',
+        themeDark: '#f4f4f4',
+        themeDarker: '#f8f8f8',
+        neutralLighterAlt: '#fdc888',
+        neutralLighter: '#0f1d38',
+        neutralLight: '#0f1c36',
+        neutralQuaternaryAlt: '#0e1a32',
+        neutralQuaternary: '#0d1930',
+        neutralTertiaryAlt: '#0c182e',
+        neutralTertiary: '#c8c8c8',
+        neutralSecondary: '#a4aab5',
+        neutralPrimaryAlt: '#dadada',
+        neutralPrimary: '#ffffff',
+        neutralDark: '#4A576D',
+        black: '#f8f8f8',
+        white: '#101f3b',
+      },
+    },
     neon: {
       palette: {
         text: '#ffffff',


### PR DESCRIPTION
_This is the interview PR only._

Added header and icon notification form component:

![image](https://user-images.githubusercontent.com/23740173/134418068-0ea516be-2725-4888-9424-06034dc4af6c.png)
![image](https://user-images.githubusercontent.com/23740173/134418149-78e8b3dc-baba-47ee-abd2-91911dff0186.png)
![image](https://user-images.githubusercontent.com/23740173/134418191-791b7e4c-9731-495e-8328-1628a4f10530.png)
![image](https://user-images.githubusercontent.com/23740173/134418324-475b7d6c-92e6-4344-a3e2-10e3238125a2.png)
### API changes
Added `search_name` and `items` optional props to Header component

Possible improvements:

- breakpoint is currently based on viewport width - we can also consider breakpoint size based on parent component width
- persona name can be bolder to match proposed [UI design](https://xd.adobe.com/view/714ead4b-4020-4ba6-ab95-efdc3a61bb0d-241d/)
- we can set default light theme for side panel to match the [proposal](https://user-images.githubusercontent.com/64769322/133071517-dfc455c5-b82c-49ea-922b-fd308f5b3908.png)
- add support for additional components passed through `items` prop, eg. text. link, image, toggle, dropdown, etc.
- remove padding around header card
- improve the `header_enhanced.py` app to keep text in search field before pushing
- change the header icon to match proposed [UI design](https://xd.adobe.com/view/714ead4b-4020-4ba6-ab95-efdc3a61bb0d-241d/)
- change styling when searchbar is active/focused