### PR TITLE
Fix failure of missing OS environmental variable in setup.

### DIFF
--- a/py/setup.py
+++ b/py/setup.py
@@ -23,7 +23,7 @@ with open('README.md', 'r') as readme_markdown:
 
 setuptools.setup(
     name='h2o_wave',
-    version=os.environ['VERSION'] or '0.18.0',
+    version=os.getenv('VERSION', '0.18.0'),
     author='Prithvi Prabhu',
     author_email='prithvi@h2o.ai',
     description='Python driver for H2O Wave Realtime Apps',


### PR DESCRIPTION
I ran into the following error when building the website locally (OS X), I'm not sure if we expect non-existent variables to through errors, but using the default setting worked for me rather than relying on the `or`:

> Obtaining file:///Users/mtanco/Desktop/wave/py
    ERROR: Command errored out with exit status 1:
     command: /Users/mtanco/Desktop/wave/py/venv/bin/python -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/Users/mtanco/Desktop/wave/py/setup.py'"'"'; __file__='"'"'/Users/mtanco/Desktop/wave/py/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /private/var/folders/57/_ldb2v5s7jd1tc8yhrd7xhwc0000gp/T/pip-pip-egg-info-ruurup6o
         cwd: /Users/mtanco/Desktop/wave/py/
    Complete output (7 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/Users/mtanco/Desktop/wave/py/setup.py", line 26, in <module>
        version=os.environ['VERSION'] or '0.18.0',
      File "/usr/local/Cellar/python@3.7/3.7.11/Frameworks/Python.framework/Versions/3.7/lib/python3.7/os.py", line 681, in __getitem__
        raise KeyError(key) from None
    KeyError: 'VERSION'
    ----------------------------------------
WARNING: Discarding file:///Users/mtanco/Desktop/wave/py. Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.