### PR TITLE
feat: WidePlotCard. #1030

### DIFF
--- a/py/examples/tour.conf
+++ b/py/examples/tour.conf
@@ -4,6 +4,7 @@ wizard.py
 issue_tracker.py
 dashboard.py
 wide_info.py
+wide_plot.py
 stat_small.py
 stat_large.py
 stat_wide_gauge.py

--- a/py/examples/wide_plot.py
+++ b/py/examples/wide_plot.py
@@ -1,0 +1,23 @@
+# Plot / Wide
+# Create a wide information card displaying a plot with title and caption.
+# ---
+from h2o_wave import site, ui, data
+from synth import FakeCategoricalSeries
+
+page = site['/demo']
+
+f = FakeCategoricalSeries()
+n = 10
+v = page.add('example', ui.wide_plot_card(
+    box='1 1 5 4',
+    title='Wide Plot Card',
+    caption='''
+    Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quia aliquam maxime quos facere
+    necessitatibus tempore eum odio, qui illum. Repellat modi dolor facilis odio ex possimus
+    ''',
+    data=data('product price', n),
+    plot=ui.plot([ui.mark(type='interval', x='=product', y='=price', y_min=0)])
+))
+v.data = [(c, x) for c, x, dx in [f.next() for _ in range(n)]]
+
+page.save()

--- a/py/examples/wide_plot.py
+++ b/py/examples/wide_plot.py
@@ -1,5 +1,5 @@
 # Plot / Wide
-# Create a wide information card displaying a plot with title and caption.
+# Create a wide plot card displaying a plot with title and caption.
 # ---
 from h2o_wave import site, ui, data
 from synth import FakeCategoricalSeries

--- a/py/h2o_wave/types.py
+++ b/py/h2o_wave/types.py
@@ -10104,6 +10104,83 @@ class WideInfoCard:
         )
 
 
+class WidePlotCard:
+    """Create a wide plot card displaying a title, caption and a plot.
+    """
+    def __init__(
+            self,
+            box: str,
+            title: str,
+            caption: str,
+            plot: Plot,
+            data: PackedRecord,
+            commands: Optional[List[Command]] = None,
+    ):
+        _guard_scalar('WidePlotCard.box', box, (str,), False, False, False)
+        _guard_scalar('WidePlotCard.title', title, (str,), False, False, False)
+        _guard_scalar('WidePlotCard.caption', caption, (str,), False, False, False)
+        _guard_scalar('WidePlotCard.plot', plot, (Plot,), False, False, False)
+        _guard_vector('WidePlotCard.commands', commands, (Command,), False, True, False)
+        self.box = box
+        """A string indicating how to place this component on the page."""
+        self.title = title
+        """The card's title."""
+        self.caption = caption
+        """The card's caption, displayed below the title."""
+        self.plot = plot
+        """The card's plot."""
+        self.data = data
+        """The card's plot data."""
+        self.commands = commands
+        """Contextual menu commands for this component."""
+
+    def dump(self) -> Dict:
+        """Returns the contents of this object as a dict."""
+        _guard_scalar('WidePlotCard.box', self.box, (str,), False, False, False)
+        _guard_scalar('WidePlotCard.title', self.title, (str,), False, False, False)
+        _guard_scalar('WidePlotCard.caption', self.caption, (str,), False, False, False)
+        _guard_scalar('WidePlotCard.plot', self.plot, (Plot,), False, False, False)
+        _guard_vector('WidePlotCard.commands', self.commands, (Command,), False, True, False)
+        return _dump(
+            view='wide_plot',
+            box=self.box,
+            title=self.title,
+            caption=self.caption,
+            plot=self.plot.dump(),
+            data=self.data,
+            commands=None if self.commands is None else [__e.dump() for __e in self.commands],
+        )
+
+    @staticmethod
+    def load(__d: Dict) -> 'WidePlotCard':
+        """Creates an instance of this class using the contents of a dict."""
+        __d_box: Any = __d.get('box')
+        _guard_scalar('WidePlotCard.box', __d_box, (str,), False, False, False)
+        __d_title: Any = __d.get('title')
+        _guard_scalar('WidePlotCard.title', __d_title, (str,), False, False, False)
+        __d_caption: Any = __d.get('caption')
+        _guard_scalar('WidePlotCard.caption', __d_caption, (str,), False, False, False)
+        __d_plot: Any = __d.get('plot')
+        _guard_scalar('WidePlotCard.plot', __d_plot, (dict,), False, False, False)
+        __d_data: Any = __d.get('data')
+        __d_commands: Any = __d.get('commands')
+        _guard_vector('WidePlotCard.commands', __d_commands, (dict,), False, True, False)
+        box: str = __d_box
+        title: str = __d_title
+        caption: str = __d_caption
+        plot: Plot = Plot.load(__d_plot)
+        data: PackedRecord = __d_data
+        commands: Optional[List[Command]] = None if __d_commands is None else [Command.load(__e) for __e in __d_commands]
+        return WidePlotCard(
+            box,
+            title,
+            caption,
+            plot,
+            data,
+            commands,
+        )
+
+
 _WideSeriesStatCardPlotType = ['area', 'interval']
 
 

--- a/py/h2o_wave/ui.py
+++ b/py/h2o_wave/ui.py
@@ -3613,6 +3613,36 @@ def wide_info_card(
     )
 
 
+def wide_plot_card(
+        box: str,
+        title: str,
+        caption: str,
+        plot: Plot,
+        data: PackedRecord,
+        commands: Optional[List[Command]] = None,
+) -> WidePlotCard:
+    """Create a wide plot card displaying a title, caption and a plot.
+
+    Args:
+        box: A string indicating how to place this component on the page.
+        title: The card's title.
+        caption: The card's caption, displayed below the title.
+        plot: The card's plot.
+        data: The card's plot data.
+        commands: Contextual menu commands for this component.
+    Returns:
+        A `h2o_wave.types.WidePlotCard` instance.
+    """
+    return WidePlotCard(
+        box,
+        title,
+        caption,
+        plot,
+        data,
+        commands,
+    )
+
+
 def wide_series_stat_card(
         box: str,
         title: str,

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -4207,6 +4207,40 @@ ui_wide_info_card <- function(
   return(.o)
 }
 
+#' Create a wide plot card displaying a title, caption and a plot.
+#'
+#' @param box A string indicating how to place this component on the page.
+#' @param title The card's title.
+#' @param caption The card's caption, displayed below the title.
+#' @param plot The card's plot.
+#' @param data The card's plot data.
+#' @param commands Contextual menu commands for this component.
+#' @return A WidePlotCard instance.
+#' @export
+ui_wide_plot_card <- function(
+  box,
+  title,
+  caption,
+  plot,
+  data,
+  commands = NULL) {
+  .guard_scalar("box", "character", box)
+  .guard_scalar("title", "character", title)
+  .guard_scalar("caption", "character", caption)
+  .guard_scalar("plot", "WavePlot", plot)
+  # TODO Validate data: Rec
+  .guard_vector("commands", "WaveCommand", commands)
+  .o <- list(
+    box=box,
+    title=title,
+    caption=caption,
+    plot=plot,
+    data=data,
+    commands=commands)
+  class(.o) <- append(class(.o), c(.wave_obj, "WaveWidePlotCard"))
+  return(.o)
+}
+
 #' Create a wide stat card displaying a primary value, an auxiliary value and a series plot.
 #'
 #' @param box A string indicating how to place this component on the page.

--- a/ui/src/cards.tsx
+++ b/ui/src/cards.tsx
@@ -50,5 +50,6 @@ import './vega'
 import './wide_bar_stat'
 import './wide_gauge_stat'
 import './wide_info'
+import './wide_plot'
 import './wide_series_stat'
 

--- a/ui/src/plot.tsx
+++ b/ui/src/plot.tsx
@@ -588,7 +588,7 @@ const
   },
   makeTextStyle = (fill_color?: S, fill_opacity?: F, stroke_color?: S, stroke_opacity?: F, stroke_size?: F, font_size?: F, font_weight?: S, line_height?: F, align?: S): Dict<any> | undefined => {
     const s: Dict<any> = {}
-    s.fill = cssVar(isS(fill_color) ? fill_color : '$text')
+    s.fill = cssVar(isS(fill_color) ? fill_color : '$neutralPrimaryAlt')
     if (isF(fill_opacity)) s.fillOpacity = fill_opacity
     if (isS(stroke_color)) s.stroke = cssVarValue(stroke_color)
     if (isF(stroke_opacity)) s.strokeOpacity = stroke_opacity
@@ -727,7 +727,7 @@ const
             },
             line: {
               style: {
-                fill: cssVar('$text'),
+                fill: cssVar('$neutralPrimaryAlt'),
               }
             },
             region: {
@@ -738,7 +738,7 @@ const
             },
             text: {
               style: {
-                fill: cssVar('$text'),
+                fill: cssVar('$neutralPrimaryAlt'),
               }
             },
           },
@@ -746,7 +746,7 @@ const
             common: {
               itemName: {
                 style: {
-                  fill: cssVar('$text'),
+                  fill: cssVar('$neutralPrimaryAlt'),
                 }
               },
               pageNavigator: {
@@ -758,7 +758,7 @@ const
                 },
                 text: {
                   style: {
-                    fill: cssVar('$text6')
+                    fill: cssVar('$neutralPrimaryAlt6')
                   }
                 }
               }
@@ -766,12 +766,12 @@ const
             continuous: {
               label: {
                 style: {
-                  fill: cssVar('$text'),
+                  fill: cssVar('$neutralPrimaryAlt'),
                 }
               },
               handler: {
                 style: {
-                  fill: cssVar('$text'),
+                  fill: cssVar('$neutralPrimaryAlt'),
                 }
               },
             }
@@ -781,31 +781,31 @@ const
               grid: {
                 line: {
                   style: {
-                    stroke: cssVar('$text'),
+                    stroke: cssVar('$neutralPrimaryAlt'),
                     strokeOpacity: 0.2
                   }
                 }
               },
               line: {
                 style: {
-                  stroke: cssVar('$text'),
+                  stroke: cssVar('$neutralPrimaryAlt'),
                   strokeOpacity: 0.6
                 }
               },
               tickLine: {
                 style: {
-                  stroke: cssVar('$text'),
+                  stroke: cssVar('$neutralPrimaryAlt'),
                   strokeOpacity: 0.6
                 }
               },
               title: {
                 style: {
-                  fill: cssVar('$text'),
+                  fill: cssVar('$neutralPrimaryAlt'),
                 }
               },
               label: {
                 style: {
-                  fill: cssVar('$text'),
+                  fill: cssVar('$neutralPrimaryAlt'),
                 }
               }
             }

--- a/ui/src/wide_plot.test.tsx
+++ b/ui/src/wide_plot.test.tsx
@@ -1,0 +1,36 @@
+// Copyright 2020 H2O.ai, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { render } from '@testing-library/react'
+import * as T from 'h2o-wave'
+import React from 'react'
+import { View } from './wide_plot'
+
+const name = 'wide_plot'
+let widePlotProps: T.Model<any>
+
+describe('WidePlot.tsx', () => {
+  beforeEach(() => {
+    widePlotProps = {
+      name,
+      state: { title: name, data: [], plot: { marks: [] } },
+      changed: T.box(false)
+    }
+  })
+
+  it('Renders data-test attr', () => {
+    const { queryByTestId } = render(<View {...widePlotProps} />)
+    expect(queryByTestId(name)).toBeInTheDocument()
+  })
+})

--- a/ui/src/wide_plot.tsx
+++ b/ui/src/wide_plot.tsx
@@ -1,0 +1,71 @@
+// Copyright 2020 H2O.ai, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Model, Rec, S } from 'h2o-wave'
+import React from 'react'
+import { stylesheet } from 'typestyle'
+import { cards } from './layout'
+import { Plot, XVisualization } from './plot'
+import { clas, cssVar } from './theme'
+import { bond } from './ui'
+
+const css = stylesheet({
+  card: {
+    display: 'flex',
+    padding: 24
+  },
+  lhs: {
+    marginTop: -5,
+    marginRight: 8,
+    maxWidth: 200
+  },
+  rhs: {
+    flexGrow: 1
+  },
+  title: {
+    color: cssVar('$neutralPrimary'),
+    marginBottom: 13
+  },
+})
+
+/** Create a wide plot card displaying a title, caption and a plot. */
+interface State {
+  /** The card's title. */
+  title: S
+  /** The card's caption, displayed below the title. */
+  caption: S
+  /** The card's plot. */
+  plot: Plot
+  /** The card's plot data. */
+  data: Rec
+}
+
+export const View = bond(({ name, state, changed }: Model<State>) => {
+  const render = () => {
+    const { title, caption, data, plot } = state
+    return (
+      <div data-test={name} className={css.card}>
+        <div className={css.lhs}>
+          <div className={clas('wave-s20 wave-w5 wave-t9', css.title)}>{title}</div>
+          {caption && <div className='wave-s14 wave-w4 wave-t7'>{caption}</div>}
+        </div>
+        <div className={css.rhs}><XVisualization model={{ data, plot }} /></div>
+      </div>
+    )
+  }
+
+  return { render, changed }
+})
+
+cards.register('wide_plot', View)

--- a/ui/src/wide_plot.tsx
+++ b/ui/src/wide_plot.tsx
@@ -17,7 +17,7 @@ import React from 'react'
 import { stylesheet } from 'typestyle'
 import { cards } from './layout'
 import { Plot, XVisualization } from './plot'
-import { clas, cssVar } from './theme'
+import { clas, cssVar, pc } from './theme'
 import { bond } from './ui'
 
 const css = stylesheet({
@@ -27,11 +27,11 @@ const css = stylesheet({
   },
   lhs: {
     marginTop: -5,
-    marginRight: 8,
-    maxWidth: 200
+    marginRight: 16,
+    width: pc(35)
   },
   rhs: {
-    flexGrow: 1
+    width: pc(65)
   },
   title: {
     color: cssVar('$neutralPrimary'),


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/64769322/135435861-c6194340-dfe2-4273-a4cb-fbbb08d9310f.png)
![image](https://user-images.githubusercontent.com/64769322/135435954-4dff37a9-1505-4b40-b10a-1908eedbc07e.png)
![image](https://user-images.githubusercontent.com/64769322/135435999-2dce340b-f224-49c5-bbd6-bc4786ec2715.png)

## Proposed API

```ts
/** Create a wide plot card displaying a title, caption and a plot. */
interface State {
  /** The card's title. */
  title: S
  /** The card's caption, displayed below the title. */
  caption: S
  /** The card's plot. */
  plot: Plot
  /** The card's plot data. */
  data: Rec
}
```

possible to also add `events` if needed.

## Design questions

* What is the preferred text container width? I went with `200px` and let the plot take the rest of the space. We can also go for percentual ratio or something else.
* The space between text and plot seems to be too small (`8px` as per design)

Closes #1030