### PR TITLE
feat: make all asset paths relative #59

### DIFF
--- a/ui/config/paths.js
+++ b/ui/config/paths.js
@@ -1,25 +1,12 @@
-'use strict';
+'use strict'
 
-const path = require('path');
-const fs = require('fs');
-const getPublicUrlOrPath = require('react-dev-utils/getPublicUrlOrPath');
+const path = require('path')
+const fs = require('fs')
 
 // Make sure any symlinks in the project folder are resolved:
 // https://github.com/facebook/create-react-app/issues/637
-const appDirectory = fs.realpathSync(process.cwd());
-const resolveApp = relativePath => path.resolve(appDirectory, relativePath);
-
-// We use `PUBLIC_URL` environment variable or "homepage" field to infer
-// "public path" at which the app is served.
-// webpack needs to know it to put the right <script> hrefs into HTML even in
-// single-page apps that may serve index.html for nested URLs like /todos/42.
-// We can't use a relative path in HTML because we don't want to load something
-// like /todos/42/static/js/bundle.7289d.js. We have to know the root.
-const publicUrlOrPath = getPublicUrlOrPath(
-  process.env.NODE_ENV === 'development',
-  require(resolveApp('package.json')).homepage,
-  process.env.PUBLIC_URL
-);
+const appDirectory = fs.realpathSync(process.cwd())
+const resolveApp = relativePath => path.resolve(appDirectory, relativePath)
 
 const moduleFileExtensions = [
   'web.mjs',
@@ -33,20 +20,20 @@ const moduleFileExtensions = [
   'json',
   'web.jsx',
   'jsx',
-];
+]
 
 // Resolve file paths in the same order as webpack
 const resolveModule = (resolveFn, filePath) => {
   const extension = moduleFileExtensions.find(extension =>
     fs.existsSync(resolveFn(`${filePath}.${extension}`))
-  );
+  )
 
   if (extension) {
-    return resolveFn(`${filePath}.${extension}`);
+    return resolveFn(`${filePath}.${extension}`)
   }
 
-  return resolveFn(`${filePath}.js`);
-};
+  return resolveFn(`${filePath}.js`)
+}
 
 // config after eject: we're in ./config/
 module.exports = {
@@ -64,9 +51,9 @@ module.exports = {
   testsSetup: resolveModule(resolveApp, 'src/setupTests'),
   proxySetup: resolveApp('src/setupProxy.js'),
   appNodeModules: resolveApp('node_modules'),
-  publicUrlOrPath,
-};
+  publicUrlOrPath: '',
+}
 
 
 
-module.exports.moduleFileExtensions = moduleFileExtensions;
+module.exports.moduleFileExtensions = moduleFileExtensions

--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -3,8 +3,8 @@
 
 <head>
   <meta charset="utf-8" />
-  <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
-  <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+  <link rel="icon" href="favicon.ico" />
+  <link rel="apple-touch-icon" href="logo192.png" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="theme-color" content="#000000" />
   <meta name="description" content="Dashboard created using H2O Wave" />
@@ -12,7 +12,7 @@
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-  <link rel="manifest" href="%PUBLIC_URL%/manifest.json" crossorigin="use-credentials" />
+  <link rel="manifest" href="manifest.json" crossorigin="use-credentials" />
   <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.


### PR DESCRIPTION
All resources are loaded relative to the root document URL in order to allow path prefixes.
These are the necessary FE changes.

## Assumptions

It's assumed that only https://github.com/h2oai/wave/blob/424c77ab770d062ca99e5544b02a63e4d8cf791b/server.go#L109 will be affected by the prefix (let me know if I am wrong), so [file upload](https://github.com/h2oai/wave/blob/424c77ab770d062ca99e5544b02a63e4d8cf791b/server.go#L78) and [socket server](https://github.com/h2oai/wave/blob/424c77ab770d062ca99e5544b02a63e4d8cf791b/server.go#L75) can remain the same.

## Needs discussion

The aim of this PR is to allow path prefixes, this will break [initial websocket slug payload](https://github.com/h2oai/wave/blob/424c77ab770d062ca99e5544b02a63e4d8cf791b/ts/index.ts#L817) since `pathname` can now consist of `subpath` + `site/app` route. I can think of 2 solutions:
1. Constrain site route annotation to not include `/`.
2. Parse route payload within Go server and update (strip prefix) accordingly since the server will be able to tell the boundary between subpath and site/app path.

Second option seems better IMO.