### PR TITLE
fix: make tall / wide info cards clickable based on name parameter #1117

### DIFF
--- a/py/h2o_wave/types.py
+++ b/py/h2o_wave/types.py
@@ -10473,7 +10473,7 @@ class TallInfoCard:
         self.box = box
         """A string indicating how to place this component on the page."""
         self.name = name
-        """An identifying name for this card. Makes the card clickable, similar to a button."""
+        """An identifying name for this card. Makes the card clickable only if name is not empty and label is empty"""
         self.title = title
         """The card's title."""
         self.caption = caption

--- a/py/h2o_wave/ui.py
+++ b/py/h2o_wave/ui.py
@@ -3761,7 +3761,7 @@ def tall_info_card(
 
     Args:
         box: A string indicating how to place this component on the page.
-        name: An identifying name for this card. Makes the card clickable, similar to a button.
+        name: An identifying name for this card. Makes the card clickable only if name is not empty and label is empty
         title: The card's title.
         caption: The card's caption, displayed below the title. Supports markdown.
         label: Label of a button rendered at the bottom of the card. If specified, whole card is not clickable anymore.

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -4343,7 +4343,7 @@ ui_tall_gauge_stat_card <- function(
 #' Create a tall information card displaying a title, caption and either an icon or image.
 #'
 #' @param box A string indicating how to place this component on the page.
-#' @param name An identifying name for this card. Makes the card clickable, similar to a button.
+#' @param name An identifying name for this card. Makes the card clickable only if name is not empty and label is empty
 #' @param title The card's title.
 #' @param caption The card's caption, displayed below the title. Supports markdown.
 #' @param label Label of a button rendered at the bottom of the card. If specified, whole card is not clickable anymore.

--- a/ui/src/tall_info.test.tsx
+++ b/ui/src/tall_info.test.tsx
@@ -82,7 +82,7 @@ describe('TallInfo.tsx', () => {
     expect(wave.args[name]).toBe(name)
   })
 
-  it('Makes card unclickable if name was not provided', () => {
+  it('Makes card unclickable if name is empty', () => {
     tallInfoProps.state.name = ''
     const { getByTestId } = render(<View {...tallInfoProps} />)
     fireEvent.click(getByTestId(name))

--- a/ui/src/tall_info.test.tsx
+++ b/ui/src/tall_info.test.tsx
@@ -17,11 +17,12 @@ import { wave } from './ui'
 import React from 'react'
 import { View } from './tall_info'
 import { box, Model } from 'h2o-wave'
+import { State } from './tall_info'
 
 const
   name = 'tall_info',
   pushMock = jest.fn()
-let tallInfoProps: Model<any>
+let tallInfoProps: Model<State>
 
 describe('TallInfo.tsx', () => {
   beforeAll(() => wave.push = pushMock)
@@ -30,7 +31,7 @@ describe('TallInfo.tsx', () => {
     wave.args = [] as any
     tallInfoProps = {
       name,
-      state: { title: name },
+      state: { title: name, caption: '', name },
       changed: box(false)
     }
   })
@@ -51,9 +52,9 @@ describe('TallInfo.tsx', () => {
 
   it('Submits data to server if label specified and name without #', () => {
     tallInfoProps.state.name = name
-    tallInfoProps.state.label = 'label'
+    tallInfoProps.state.label = 'Click me'
     const { getByTestId } = render(<View {...tallInfoProps} />)
-    fireEvent.click(getByTestId(name))
+    fireEvent.click(getByTestId('Click me'))
     expect(pushMock).toHaveBeenCalled()
     expect(wave.args[name]).toBe(name)
   })
@@ -73,4 +74,33 @@ describe('TallInfo.tsx', () => {
     expect(pushMock).toHaveBeenCalled()
     expect(wave.args[name]).toBe(name)
   })
+
+  it('Makes card clickable only if name was specified but label was not', () => {
+    const { getByTestId } = render(<View {...tallInfoProps} />)
+    fireEvent.click(getByTestId(name))
+    expect(pushMock).toHaveBeenCalled()
+    expect(wave.args[name]).toBe(name)
+  })
+
+  it('Makes card unclickable if name was not provided', () => {
+    tallInfoProps.state.name = ''
+    const { getByTestId } = render(<View {...tallInfoProps} />)
+    fireEvent.click(getByTestId(name))
+    expect(pushMock).not.toHaveBeenCalled()
+    expect(wave.args[name]).not.toBe(name)
+  })
+
+  it('Makes only the button (label) clickable if label was provided', () => {
+    tallInfoProps.state.label = 'Click me'
+    const { getByTestId } = render(<View {...tallInfoProps} />)
+    fireEvent.click(getByTestId(name))
+    expect(pushMock).not.toHaveBeenCalled()
+    expect(wave.args[name]).not.toBe(name)
+
+    fireEvent.click(getByTestId('Click me'))
+    expect(pushMock).toHaveBeenCalled()
+    expect(wave.args[name]).toBe(name)
+  })
+
+
 })

--- a/ui/src/tall_info.test.tsx
+++ b/ui/src/tall_info.test.tsx
@@ -53,8 +53,8 @@ describe('TallInfo.tsx', () => {
   it('Submits data to server if label specified and name without #', () => {
     tallInfoProps.state.name = name
     tallInfoProps.state.label = 'Click me'
-    const { getByTestId } = render(<View {...tallInfoProps} />)
-    fireEvent.click(getByTestId('Click me'))
+    const { getByText } = render(<View {...tallInfoProps} />)
+    fireEvent.click(getByText('Click me'))
     expect(pushMock).toHaveBeenCalled()
     expect(wave.args[name]).toBe(name)
   })
@@ -92,15 +92,13 @@ describe('TallInfo.tsx', () => {
 
   it('Makes only the button (label) clickable if label was provided', () => {
     tallInfoProps.state.label = 'Click me'
-    const { getByTestId } = render(<View {...tallInfoProps} />)
+    const { getByText, getByTestId } = render(<View {...tallInfoProps} />)
     fireEvent.click(getByTestId(name))
     expect(pushMock).not.toHaveBeenCalled()
     expect(wave.args[name]).not.toBe(name)
 
-    fireEvent.click(getByTestId('Click me'))
+    fireEvent.click(getByText('Click me'))
     expect(pushMock).toHaveBeenCalled()
     expect(wave.args[name]).toBe(name)
   })
-
-
 })

--- a/ui/src/tall_info.tsx
+++ b/ui/src/tall_info.tsx
@@ -64,7 +64,7 @@ const
   })
 
 /** Create a tall information card displaying a title, caption and either an icon or image. */
-interface State {
+export interface State {
   /** An identifying name for this card. Makes the card clickable, similar to a button. */
   name: S
   /** The card's title. */
@@ -96,9 +96,9 @@ export const View = bond(({ name, state, changed }: Model<State>) => {
     },
     render = () => (
       <div
-        data-test={label ? undefined : name}
-        onClick={!name ? undefined : onClick}
-        className={clas(css.card, !name ? '' : css.clickable)}
+        data-test={name}
+        onClick={stateName && !label ? onClick : undefined}
+        className={clas(css.card, stateName && !label ? css.clickable : '')}
       >
         <div className={css.imgContainer}>
           {
@@ -113,7 +113,7 @@ export const View = bond(({ name, state, changed }: Model<State>) => {
             {category && <div className={clas('wave-s14 wave-w4 wave-t5', css.category)}>{category}</div>}
           </div>
           {caption && <div className='wave-s14 wave-w4 wave-t7'><Markdown source={caption} /></div>}
-          {label && <Fluent.DefaultButton data-test={name} text={label} styles={{ root: { marginTop: 16 } }} onClick={onClick} />}
+          {label && <Fluent.DefaultButton data-test={label} text={label} styles={{ root: { marginTop: 16 } }} onClick={onClick} />}
         </div>
       </div >
     )

--- a/ui/src/tall_info.tsx
+++ b/ui/src/tall_info.tsx
@@ -65,7 +65,7 @@ const
 
 /** Create a tall information card displaying a title, caption and either an icon or image. */
 export interface State {
-  /** An identifying name for this card. Makes the card clickable, similar to a button. */
+  /** An identifying name for this card. Makes the card clickable only if name is not empty and label is empty */
   name: S
   /** The card's title. */
   title: S

--- a/ui/src/tall_info.tsx
+++ b/ui/src/tall_info.tsx
@@ -113,7 +113,7 @@ export const View = bond(({ name, state, changed }: Model<State>) => {
             {category && <div className={clas('wave-s14 wave-w4 wave-t5', css.category)}>{category}</div>}
           </div>
           {caption && <div className='wave-s14 wave-w4 wave-t7'><Markdown source={caption} /></div>}
-          {label && <Fluent.DefaultButton data-test={label} text={label} styles={{ root: { marginTop: 16 } }} onClick={onClick} />}
+          {label && <Fluent.DefaultButton text={label} styles={{ root: { marginTop: 16 } }} onClick={onClick} />}
         </div>
       </div >
     )

--- a/ui/src/tall_info.tsx
+++ b/ui/src/tall_info.tsx
@@ -97,8 +97,8 @@ export const View = bond(({ name, state, changed }: Model<State>) => {
     render = () => (
       <div
         data-test={label ? undefined : name}
-        onClick={label ? undefined : onClick}
-        className={clas(css.card, label ? '' : css.clickable)}
+        onClick={!name ? undefined : onClick}
+        className={clas(css.card, !name ? '' : css.clickable)}
       >
         <div className={css.imgContainer}>
           {

--- a/ui/src/wide_info.test.tsx
+++ b/ui/src/wide_info.test.tsx
@@ -81,7 +81,7 @@ describe('WideInfo.tsx', () => {
     expect(wave.args[name]).toBe(name)
   })
 
-  it('Makes card unclickable if name was not provided', () => {
+  it('Makes card unclickable if name is empty', () => {
     wideInfoProps.state.name = ''
     const { getByTestId } = render(<View {...wideInfoProps} />)
     fireEvent.click(getByTestId(name))

--- a/ui/src/wide_info.test.tsx
+++ b/ui/src/wide_info.test.tsx
@@ -16,12 +16,12 @@ import { fireEvent, render } from '@testing-library/react'
 import * as T from 'h2o-wave'
 import React from 'react'
 import { wave } from './ui'
-import { View } from './wide_info'
+import { View, State } from './wide_info'
 
 const
   name = 'wide_info',
   pushMock = jest.fn()
-let wideInfoProps: T.Model<any>
+let wideInfoProps: T.Model<State>
 
 describe('WideInfo.tsx', () => {
   beforeAll(() => wave.push = pushMock)
@@ -30,7 +30,7 @@ describe('WideInfo.tsx', () => {
     wave.args = [] as any
     wideInfoProps = {
       name,
-      state: { title: name },
+      state: { title: name, name, caption: '' },
       changed: T.box(false)
     }
   })
@@ -52,8 +52,8 @@ describe('WideInfo.tsx', () => {
   it('Submits data to server if label specified and name without #', () => {
     wideInfoProps.state.name = name
     wideInfoProps.state.label = 'label'
-    const { getByTestId } = render(<View {...wideInfoProps} />)
-    fireEvent.click(getByTestId(name))
+    const { getByText } = render(<View {...wideInfoProps} />)
+    fireEvent.click(getByText('label'))
     expect(pushMock).toHaveBeenCalled()
     expect(wave.args[name]).toBe(name)
   })
@@ -70,6 +70,33 @@ describe('WideInfo.tsx', () => {
     wideInfoProps.state.name = name
     const { getByTestId } = render(<View {...wideInfoProps} />)
     fireEvent.click(getByTestId(name))
+    expect(pushMock).toHaveBeenCalled()
+    expect(wave.args[name]).toBe(name)
+  })
+
+  it('Makes card clickable only if name was specified but label was not', () => {
+    const { getByTestId } = render(<View {...wideInfoProps} />)
+    fireEvent.click(getByTestId(name))
+    expect(pushMock).toHaveBeenCalled()
+    expect(wave.args[name]).toBe(name)
+  })
+
+  it('Makes card unclickable if name was not provided', () => {
+    wideInfoProps.state.name = ''
+    const { getByTestId } = render(<View {...wideInfoProps} />)
+    fireEvent.click(getByTestId(name))
+    expect(pushMock).not.toHaveBeenCalled()
+    expect(wave.args[name]).not.toBe(name)
+  })
+
+  it('Makes only the button (label) clickable if label was provided', () => {
+    wideInfoProps.state.label = 'Click me'
+    const { getByText, getByTestId } = render(<View {...wideInfoProps} />)
+    fireEvent.click(getByTestId(name))
+    expect(pushMock).not.toHaveBeenCalled()
+    expect(wave.args[name]).not.toBe(name)
+
+    fireEvent.click(getByText('Click me'))
     expect(pushMock).toHaveBeenCalled()
     expect(wave.args[name]).toBe(name)
   })

--- a/ui/src/wide_info.tsx
+++ b/ui/src/wide_info.tsx
@@ -115,8 +115,8 @@ export const View = bond(({ name, state, changed }: Model<State>) => {
     render = () => (
       <div
         data-test={label ? undefined : name}
-        onClick={label ? undefined : onClick}
-        className={clas(css.card, label ? '' : css.clickable, align === 'right' ? css.right : '')}
+        onClick={!name ? undefined : onClick}
+        className={clas(css.card, !name ? '' : css.clickable, align === 'right' ? css.right : '')}
       >
         <div className={clas(css.lhs, !icon && image ? css.imgSpecified : '')}>
           {

--- a/ui/src/wide_info.tsx
+++ b/ui/src/wide_info.tsx
@@ -80,7 +80,7 @@ const
   })
 
 /** Create a wide information card displaying a title, caption, and either an icon or image. */
-interface State {
+export interface State {
   /** An identifying name for this card. Makes the card clickable, similar to a button. */
   name: S
   /** The card's title. */
@@ -114,9 +114,9 @@ export const View = bond(({ name, state, changed }: Model<State>) => {
     },
     render = () => (
       <div
-        data-test={label ? undefined : name}
-        onClick={!name ? undefined : onClick}
-        className={clas(css.card, !name ? '' : css.clickable, align === 'right' ? css.right : '')}
+        data-test={name}
+        onClick={stateName && !label ? onClick : undefined}
+        className={clas(css.card, stateName && !label ? css.clickable : '', align === 'right' ? css.right : '')}
       >
         <div className={clas(css.lhs, !icon && image ? css.imgSpecified : '')}>
           {
@@ -132,7 +132,7 @@ export const View = bond(({ name, state, changed }: Model<State>) => {
             {subtitle && <div className={clas('wave-s14 wave-w5 wave-t7', css.subtitle)}>{subtitle}</div>}
           </div>
           {caption && <div className='wave-s14 wave-w4 wave-t7' style={{ marginBottom: label ? 16 : undefined }}><Markdown source={caption} /></div>}
-          {label && <Fluent.PrimaryButton data-test={name} onClick={onClick} text={label} styles={{ root: { marginTop: 'auto', alignSelf: 'flex-start' } }} />}
+          {label && <Fluent.PrimaryButton onClick={onClick} text={label} styles={{ root: { marginTop: 'auto', alignSelf: 'flex-start' } }} />}
         </div>
       </div>
     )


### PR DESCRIPTION

![2021-11-18 12 14 31](https://user-images.githubusercontent.com/15820796/142405460-8684699f-7c2c-41bc-b3ca-ac2060aca964.gif)

![2021-11-18 12 16 39](https://user-images.githubusercontent.com/15820796/142405703-568e2606-7443-4eae-a739-56908536ef13.gif)

closes #1117