### PR TITLE
feat: set theme to scrollbar #1120

### DIFF
--- a/ui/src/index.scss
+++ b/ui/src/index.scss
@@ -13,16 +13,24 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-*::-webkit-scrollbar {
-  width: 6px;
-}
+* {
+  // For Firefox
+  scrollbar-width: thin;
+  scrollbar-color: var(--text2) var(--text0);
 
-*::-webkit-scrollbar-track {
-  background: var(--text0);
-}
-*::-webkit-scrollbar-thumb {
-  background-color: var(--text2);
-  border-radius: 6px;
+  &::-webkit-scrollbar-thumb {
+    background-color: var(--text2);
+    border-radius: 12px;
+    border: 3px solid var(--card8);
+  }
+
+  &::-webkit-scrollbar {
+    width: 12px;
+  }
+  
+  &::-webkit-scrollbar-track {
+    background: var(--text0);
+  }
 }
 
 body {

--- a/ui/src/index.scss
+++ b/ui/src/index.scss
@@ -13,6 +13,18 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
+*::-webkit-scrollbar {
+  width: 6px;
+}
+
+*::-webkit-scrollbar-track {
+  background: var(--text0);
+}
+*::-webkit-scrollbar-thumb {
+  background-color: var(--text2);
+  border-radius: 6px;
+}
+
 body {
   margin: 0;
   font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell",


### PR DESCRIPTION
Using colors: `--card8`, `--text0`, and `--text2`

Tested on MacOS.

![Frame 1](https://user-images.githubusercontent.com/15820796/144252646-f9413a79-0c29-4308-9872-d708f8350982.png)

resolves #1120