### PR TITLE
feat: Add dialog prop to dropdown #1116

### DIFF
--- a/py/examples/dropdown.py
+++ b/py/examples/dropdown.py
@@ -33,7 +33,7 @@ async def serve(q: Q):
                         disabled=True),
             ui.dropdown(name='dropdown_dialog', label='Pick multiple in dialog (>100 choices)', values=['1'],
                         required=True, choices=choices_dialog),
-            ui.dropdown(name='dropdown_dialog_always', label='Always show dialog even when choices < 100', value='A',
+            ui.dropdown(name='dropdown_popup_always', label='Always show popup even when choices < 100', value='A',
                         required=True, choices=choices, popup='always'),
             ui.dropdown(name='dropdown_dialog_never', label='Never show dialog even when choices > 100', value='1',
                         required=True, choices=choices_dialog, popup='never'),

--- a/py/examples/dropdown.py
+++ b/py/examples/dropdown.py
@@ -33,6 +33,10 @@ async def serve(q: Q):
                         disabled=True),
             ui.dropdown(name='dropdown_dialog', label='Pick multiple in dialog (>100 choices)', values=['1'],
                         required=True, choices=choices_dialog),
+            ui.dropdown(name='dropdown_dialog_always', label='Always show dialog even when choices < 100', value='A',
+                        required=True, choices=choices, popup='always'),
+            ui.dropdown(name='dropdown_dialog_never', label='Never show dialog even when choices > 100', value='1',
+                        required=True, choices=choices_dialog, popup='never'),
             ui.button(name='show_inputs', label='Submit', primary=True),
         ])
     await q.page.save()

--- a/py/examples/dropdown.py
+++ b/py/examples/dropdown.py
@@ -22,6 +22,8 @@ async def serve(q: Q):
             ui.text(f'dropdown_multi={q.args.dropdown_multi}'),
             ui.text(f'dropdown_disabled={q.args.dropdown_disabled}'),
             ui.text(f'dropdown_dialog={q.args.dropdown_dialog}'),
+            ui.text(f'dropdown_popup_always={q.args.dropdown_popup_always}'),
+            ui.text(f'dropdown_popup_never={q.args.dropdown_popup_never}'),
             ui.button(name='show_form', label='Back', primary=True),
         ]
     else:

--- a/py/examples/dropdown.py
+++ b/py/examples/dropdown.py
@@ -35,7 +35,7 @@ async def serve(q: Q):
                         required=True, choices=choices_dialog),
             ui.dropdown(name='dropdown_popup_always', label='Always show popup even when choices < 100', value='A',
                         required=True, choices=choices, popup='always'),
-            ui.dropdown(name='dropdown_dialog_never', label='Never show dialog even when choices > 100', value='1',
+            ui.dropdown(name='dropdown_popup_never', label='Never show popup even when choices > 100', value='1',
                         required=True, choices=choices_dialog, popup='never'),
             ui.button(name='show_inputs', label='Submit', primary=True),
         ])

--- a/py/h2o_wave/types.py
+++ b/py/h2o_wave/types.py
@@ -1670,6 +1670,15 @@ class Checklist:
         )
 
 
+_DropdownPopup = ['auto', 'always', 'never']
+
+
+class DropdownPopup:
+    AUTO = 'auto'
+    ALWAYS = 'always'
+    NEVER = 'never'
+
+
 class Dropdown:
     """Create a dropdown.
 
@@ -1697,6 +1706,7 @@ class Dropdown:
             width: Optional[str] = None,
             visible: Optional[bool] = None,
             tooltip: Optional[str] = None,
+            popup: Optional[str] = None,
     ):
         _guard_scalar('Dropdown.name', name, (str,), True, False, False)
         _guard_scalar('Dropdown.label', label, (str,), False, True, False)
@@ -1710,6 +1720,7 @@ class Dropdown:
         _guard_scalar('Dropdown.width', width, (str,), False, True, False)
         _guard_scalar('Dropdown.visible', visible, (bool,), False, True, False)
         _guard_scalar('Dropdown.tooltip', tooltip, (str,), False, True, False)
+        _guard_enum('Dropdown.popup', popup, _DropdownPopup, True)
         self.name = name
         """An identifying name for this component."""
         self.label = label
@@ -1734,6 +1745,8 @@ class Dropdown:
         """True if the component should be visible. Defaults to True."""
         self.tooltip = tooltip
         """An optional tooltip message displayed when a user clicks the help icon to the right of the component."""
+        self.popup = popup
+        """Whether to present the choices using a pop-up dialog. Defaults to `auto`, which pops up a dialog only when there are more than 100 choices. One of 'auto', 'always', 'never'. See enum h2o_wave.ui.DropdownPopup."""
 
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""
@@ -1749,6 +1762,7 @@ class Dropdown:
         _guard_scalar('Dropdown.width', self.width, (str,), False, True, False)
         _guard_scalar('Dropdown.visible', self.visible, (bool,), False, True, False)
         _guard_scalar('Dropdown.tooltip', self.tooltip, (str,), False, True, False)
+        _guard_enum('Dropdown.popup', self.popup, _DropdownPopup, True)
         return _dump(
             name=self.name,
             label=self.label,
@@ -1762,6 +1776,7 @@ class Dropdown:
             width=self.width,
             visible=self.visible,
             tooltip=self.tooltip,
+            popup=self.popup,
         )
 
     @staticmethod
@@ -1791,6 +1806,8 @@ class Dropdown:
         _guard_scalar('Dropdown.visible', __d_visible, (bool,), False, True, False)
         __d_tooltip: Any = __d.get('tooltip')
         _guard_scalar('Dropdown.tooltip', __d_tooltip, (str,), False, True, False)
+        __d_popup: Any = __d.get('popup')
+        _guard_enum('Dropdown.popup', __d_popup, _DropdownPopup, True)
         name: str = __d_name
         label: Optional[str] = __d_label
         placeholder: Optional[str] = __d_placeholder
@@ -1803,6 +1820,7 @@ class Dropdown:
         width: Optional[str] = __d_width
         visible: Optional[bool] = __d_visible
         tooltip: Optional[str] = __d_tooltip
+        popup: Optional[str] = __d_popup
         return Dropdown(
             name,
             label,
@@ -1816,6 +1834,7 @@ class Dropdown:
             width,
             visible,
             tooltip,
+            popup,
         )
 
 

--- a/py/h2o_wave/ui.py
+++ b/py/h2o_wave/ui.py
@@ -667,6 +667,7 @@ def dropdown(
         width: Optional[str] = None,
         visible: Optional[bool] = None,
         tooltip: Optional[str] = None,
+        popup: Optional[str] = None,
 ) -> Component:
     """Create a dropdown.
 
@@ -693,6 +694,7 @@ def dropdown(
         width: The width of the dropdown, e.g. '100px'. Defaults to '100%'.
         visible: True if the component should be visible. Defaults to True.
         tooltip: An optional tooltip message displayed when a user clicks the help icon to the right of the component.
+        popup: Whether to present the choices using a pop-up dialog. Defaults to `auto`, which pops up a dialog only when there are more than 100 choices. One of 'auto', 'always', 'never'. See enum h2o_wave.ui.DropdownPopup.
     Returns:
         A `h2o_wave.types.Dropdown` instance.
     """
@@ -709,6 +711,7 @@ def dropdown(
         width,
         visible,
         tooltip,
+        popup,
     ))
 
 

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -801,6 +801,8 @@ ui_checklist <- function(
 #' @param width The width of the dropdown, e.g. '100px'. Defaults to '100%'.
 #' @param visible True if the component should be visible. Defaults to True.
 #' @param tooltip An optional tooltip message displayed when a user clicks the help icon to the right of the component.
+#' @param popup Whether to present the choices using a pop-up dialog. Defaults to `auto`, which pops up a dialog only when there are more than 100 choices.
+#'   One of 'auto', 'always', 'never'. See enum h2o_wave.ui.DropdownPopup.
 #' @return A Dropdown instance.
 #' @export
 ui_dropdown <- function(
@@ -815,7 +817,8 @@ ui_dropdown <- function(
   trigger = NULL,
   width = NULL,
   visible = NULL,
-  tooltip = NULL) {
+  tooltip = NULL,
+  popup = NULL) {
   .guard_scalar("name", "character", name)
   .guard_scalar("label", "character", label)
   .guard_scalar("placeholder", "character", placeholder)
@@ -828,6 +831,7 @@ ui_dropdown <- function(
   .guard_scalar("width", "character", width)
   .guard_scalar("visible", "logical", visible)
   .guard_scalar("tooltip", "character", tooltip)
+  # TODO Validate popup
   .o <- list(dropdown=list(
     name=name,
     label=label,
@@ -840,7 +844,8 @@ ui_dropdown <- function(
     trigger=trigger,
     width=width,
     visible=visible,
-    tooltip=tooltip))
+    tooltip=tooltip,
+    popup=popup))
   class(.o) <- append(class(.o), c(.wave_obj, "WaveComponent"))
   return(.o)
 }

--- a/ui/src/dropdown.test.tsx
+++ b/ui/src/dropdown.test.tsx
@@ -377,38 +377,38 @@ describe('Dropdown.tsx', () => {
     })
 
     it(`Displays dialog when choices > 100 and 'popup' prop is not provided`, () => {
-      const { getByTestId, getAllByRole  } = render(<XDropdown model={dialogProps} />)
+      const { getByTestId, getByRole  } = render(<XDropdown model={dialogProps} />)
 
       fireEvent.click(getByTestId(name))
 
-      expect(getAllByRole('dialog')).toBeDefined()
+      expect(getByRole('dialog')).toBeInTheDocument()
     })
 
     it(`Displays dialog when choices > 100 and 'popup' prop is set as 'auto'`, () => {
-      const { getByTestId, getAllByRole  } = render(<XDropdown model={dialogProps} />)
+      const { getByTestId, getByRole  } = render(<XDropdown model={dialogProps} />)
 
       fireEvent.click(getByTestId(name))
 
-      expect(getAllByRole('dialog')).toBeDefined()
+      expect(getByRole('dialog')).toBeInTheDocument()
     })
 
     it(`Displays dialog when choices < 100 and 'popup' prop is set as 'always'`, () => {
       dialogProps.popup = 'always'
       dialogProps.choices = [{ name: 'A' }]
-      const { getByTestId, getAllByRole  } = render(<XDropdown model={dialogProps} />)
+      const { getByTestId, getByRole  } = render(<XDropdown model={dialogProps} />)
 
       fireEvent.click(getByTestId(name))
 
-      expect(getAllByRole('dialog')).toBeDefined()
+      expect(getByRole('dialog')).toBeInTheDocument()
     })
 
     it(`Displays dialog when choices > 100 and 'popup' prop is set as 'never'`, () => {
       dialogProps.popup = 'never'
-      const { getByTestId, getAllByRole  } = render(<XDropdown model={dialogProps} />)
+      const { getByTestId, getByRole  } = render(<XDropdown model={dialogProps} />)
 
       fireEvent.click(getByTestId(name))
 
-      expect(getAllByRole('listbox')).toBeDefined()
+      expect(getByRole('listbox')).toBeInTheDocument()
     })
   })
 })

--- a/ui/src/dropdown.test.tsx
+++ b/ui/src/dropdown.test.tsx
@@ -375,5 +375,40 @@ describe('Dropdown.tsx', () => {
       fireEvent.click(getByTestId(name))
       expect(getAllByRole('listitem')).toHaveLength(40) // Fluent Detaillist uses virtualization, so only first 40 listitems are rendered.
     })
+
+    it(`Displays dialog when choices > 100 and 'popup' prop is not provided`, () => {
+      const { getByTestId, getAllByRole  } = render(<XDropdown model={dialogProps} />)
+
+      fireEvent.click(getByTestId(name))
+
+      expect(getAllByRole('dialog')).toBeDefined()
+    })
+
+    it(`Displays dialog when choices > 100 and 'popup' prop is set as 'auto'`, () => {
+      const { getByTestId, getAllByRole  } = render(<XDropdown model={dialogProps} />)
+
+      fireEvent.click(getByTestId(name))
+
+      expect(getAllByRole('dialog')).toBeDefined()
+    })
+
+    it(`Displays dialog when choices < 100 and 'popup' prop is set as 'always'`, () => {
+      dialogProps.popup = 'always'
+      dialogProps.choices = [{ name: 'A' }]
+      const { getByTestId, getAllByRole  } = render(<XDropdown model={dialogProps} />)
+
+      fireEvent.click(getByTestId(name))
+
+      expect(getAllByRole('dialog')).toBeDefined()
+    })
+
+    it(`Displays dialog when choices > 100 and 'popup' prop is set as 'never'`, () => {
+      dialogProps.popup = 'never'
+      const { getByTestId, getAllByRole  } = render(<XDropdown model={dialogProps} />)
+
+      fireEvent.click(getByTestId(name))
+
+      expect(getAllByRole('listbox')).toBeDefined()
+    })
   })
 })

--- a/ui/src/dropdown.test.tsx
+++ b/ui/src/dropdown.test.tsx
@@ -377,38 +377,38 @@ describe('Dropdown.tsx', () => {
     })
 
     it(`Displays dialog when choices > 100 and 'popup' prop is not provided`, () => {
-      const { getByTestId, getByRole  } = render(<XDropdown model={dialogProps} />)
+      const { getByTestId, queryByRole } = render(<XDropdown model={dialogProps} />)
 
+      expect(queryByRole('dialog')).not.toBeInTheDocument()
       fireEvent.click(getByTestId(name))
-
-      expect(getByRole('dialog')).toBeInTheDocument()
+      expect(queryByRole('dialog')).toBeInTheDocument()
     })
 
     it(`Displays dialog when choices > 100 and 'popup' prop is set as 'auto'`, () => {
-      const { getByTestId, getByRole  } = render(<XDropdown model={dialogProps} />)
+      const { getByTestId, queryByRole } = render(<XDropdown model={dialogProps} />)
 
+      expect(queryByRole('dialog')).not.toBeInTheDocument()
       fireEvent.click(getByTestId(name))
-
-      expect(getByRole('dialog')).toBeInTheDocument()
+      expect(queryByRole('dialog')).toBeInTheDocument()
     })
 
     it(`Displays dialog when choices < 100 and 'popup' prop is set as 'always'`, () => {
       dialogProps.popup = 'always'
       dialogProps.choices = [{ name: 'A' }]
-      const { getByTestId, getByRole  } = render(<XDropdown model={dialogProps} />)
+      const { getByTestId, queryByRole } = render(<XDropdown model={dialogProps} />)
 
+      expect(queryByRole('dialog')).not.toBeInTheDocument()
       fireEvent.click(getByTestId(name))
-
-      expect(getByRole('dialog')).toBeInTheDocument()
+      expect(queryByRole('dialog')).toBeInTheDocument()
     })
 
     it(`Does not displays dialog when choices > 100 and 'popup' prop is set as 'never'`, () => {
       dialogProps.popup = 'never'
-      const { getByTestId, getByRole  } = render(<XDropdown model={dialogProps} />)
+      const { getByTestId, queryByRole } = render(<XDropdown model={dialogProps} />)
 
       fireEvent.click(getByTestId(name))
 
-      expect(getByRole('listbox')).toBeInTheDocument()
+      expect(queryByRole('dialog')).not.toBeInTheDocument()
     })
   })
 })

--- a/ui/src/dropdown.test.tsx
+++ b/ui/src/dropdown.test.tsx
@@ -402,7 +402,7 @@ describe('Dropdown.tsx', () => {
       expect(getByRole('dialog')).toBeInTheDocument()
     })
 
-    it(`Displays dialog when choices > 100 and 'popup' prop is set as 'never'`, () => {
+    it(`Does not displays dialog when choices > 100 and 'popup' prop is set as 'never'`, () => {
       dialogProps.popup = 'never'
       const { getByTestId, getByRole  } = render(<XDropdown model={dialogProps} />)
 

--- a/ui/src/dropdown.tsx
+++ b/ui/src/dropdown.tsx
@@ -59,6 +59,8 @@ export interface Dropdown {
   visible?: B
   /** An optional tooltip message displayed when a user clicks the help icon to the right of the component. */
   tooltip?: S
+  /** Whether to present the choices using a pop-up dialog. Defaults to `auto`, which pops up a dialog only when there are more than 100 choices. */
+  popup?: 'auto' | 'always' | 'never'
 }
 
 type DropdownItem = {
@@ -251,6 +253,12 @@ const
 export const XDropdown = ({ model: m }: { model: Dropdown }) => {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   React.useEffect(() => { wave.args[m.name] = m.values ? (m.values || []) : (m.value || null) }, [])
-
-  return (m.choices?.length || 0) > 100 ? <DialogDropdown {...m} /> : <BaseDropdown {...m} />
+  
+  return m.popup === 'always'
+      ? <DialogDropdown {...m} />
+      : m.popup === 'never'
+          ? <BaseDropdown {...m} />
+          : (m.choices?.length || 0) > 100
+              ? <DialogDropdown {...m} />
+              : <BaseDropdown {...m} />
 }

--- a/website/components/form/dropdown.md
+++ b/website/components/form/dropdown.md
@@ -88,3 +88,22 @@ q.page['example'] = ui.form_card(box='1 1 2 2', items=[
     ])
 ])
 ```
+
+## Popup
+
+The popup attribute should be used to specify the dialog behavior.
+You can use one of these values: `'always', 'never', 'auto'`
+
+* `'always'`: display dialog even when number of choices < 100.
+* `'never'`: does not display dialog even when number of choices > 100.
+* `'auto'`: only display dialog when number of choices > 100 (default).
+
+```py
+q.page['example'] = ui.form_card(box='1 1 2 2', items=[
+    ui.dropdown(name='dropdown', popup='always', label='Dropdown', choices=[
+        ui.choice(name='choice1', label='Choice 1'),
+        ui.choice(name='choice2', label='Choice 2'),
+        ui.choice(name='choice3', label='Choice 3'),
+    ])
+])
+```


### PR DESCRIPTION
* Define when dialog should be displayed. If not provided, display only when choices > 100

API: `dialog?: 'auto' <- (default) | 'always' | 'never'`

![2021-12-02 13 54 41](https://user-images.githubusercontent.com/15820796/144426049-4f791f0e-f1cb-41d0-8d57-ba1e15d6aa41.gif)

resolves #1116