### PR TITLE
feat: add Wide Article Preview component #1132

### DIFF
--- a/py/examples/tour.conf
+++ b/py/examples/tour.conf
@@ -11,6 +11,7 @@ postcard.py
 preview.py
 stat_wide_pie.py
 tall_article_preview.py
+wide_article_preview.py
 profile.py
 stat_small.py
 stat_large.py

--- a/py/examples/wide_article_preview.py
+++ b/py/examples/wide_article_preview.py
@@ -6,36 +6,45 @@ from h2o_wave import main, app, Q, ui
 
 @app('/demo')
 async def serve(q: Q):
-    persona_pic = 'https://images.pexels.com/photos/415829/pexels-photo-415829.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=100&w=100'
-    q.page['example'] = ui.wide_article_preview_card(
-        box='1 1 6 5',
-        persona=ui.persona(title='Jasmine Grand', subtitle='Marketing Executive',
-                           image=persona_pic, caption='caption'),
-        commands=[
-            ui.command(name='new', label='New', icon='Add', items=[
-                ui.command(name='email', label='Email Message', icon='Mail'),
-                ui.command(name='calendar', label='Calendar Event', icon='Calendar'),
-            ]),
-            ui.command(name='upload', label='Upload', icon='Upload'),
-            ui.command(name='share', label='Share', icon='Share'),
-            ui.command(name='download', label='Download', icon='Download'),
-        ],
-        aux_value='2h ago',
-        image='https://images.pexels.com/photos/1269968/pexels-photo-1269968.jpeg?auto=compress',
-        title='Jasmine Grand',
-        caption='''
-            Lorem ipsum dolor sit amet consectetur adipisicing elit. Ipsum sed odio porro veniam dolorum velit doloremque neque aliquam quisquam rem officiis, eius facilis iste quam, minus repellat magni iure eaque!
-            Veniam pariatur itaque nisi, a nam consequuntur. Aliquam nulla sequi, nihil soluta quaerat vitae inventore magni vero voluptates officiis dolorem alias incidunt iure in sapiente doloribus, quos distinctio? Illo, ullam?
-        ''',
-        items=[
-            ui.inline(justify='end', items=[
-                ui.mini_buttons([
-                    ui.mini_button(name='like', label='4', icon='Heart'),
-                    ui.mini_button(name='comment', label='2', icon='Comment'),
-                    ui.mini_button(name='share', label='1', icon='Share'),
+    if q.args.wide_article_preview:
+        q.page['example'] = ui.form_card(box='1 1 4 6', items=[
+            ui.button(name='back', label='Go back', primary=True),
+        ])
+    else:
+        q.page['meta'] = ui.meta_card(box='', theme='neon')
+        persona_pic = 'https://images.pexels.com/photos/415829/pexels-photo-415829.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=100&w=100'
+        q.page['example'] = ui.wide_article_preview_card(
+            box='1 1 6 5',
+            name='wide_article_preview',
+            persona=ui.persona(title='Jasmine Grand', subtitle='Marketing Executive',
+                               image=persona_pic, caption='caption'),
+            commands=[
+                ui.command(name='new', label='New', icon='Add', items=[
+                    ui.command(name='email', label='Email Message', icon='Mail'),
+                    ui.command(name='calendar', label='Calendar Event', icon='Calendar'),
                 ]),
-            ])
-        ],
-    )
+                ui.command(name='upload', label='Upload', icon='Upload'),
+                ui.command(name='share', label='Share', icon='Share'),
+                ui.command(name='download', label='Download', icon='Download'),
+            ],
+            aux_value='2h ago',
+            image='https://images.pexels.com/photos/1269968/pexels-photo-1269968.jpeg?auto=compress',
+            title='Jasmine Grand',
+            caption='''
+                Lorem ipsum dolor sit amet consectetur adipisicing elit. Ipsum sed odio porro veniam dolorum velit doloremque neque aliquam quisquam rem officiis, eius facilis iste quam, minus repellat magni iure eaque!
+                Veniam pariatur itaque nisi, a nam consequuntur. Aliquam nulla sequi, nihil soluta quaerat vitae inventore magni vero voluptates officiis dolorem alias incidunt iure in sapiente doloribus, quos distinctio? Illo, ullam?
+                Veniam pariatur itaque nisi, a nam consequuntur. Aliquam nulla sequi, nihil soluta quaerat vitae inventore magni vero voluptates officiis dolorem alias incidunt iure in sapiente doloribus, quos distinctio? Illo, ullam?
+                Veniam pariatur itaque nisi, a nam consequuntur. Aliquam nulla sequi, nihil soluta quaerat vitae inventore magni vero voluptates officiis dolorem alias incidunt iure in sapiente doloribus, quos distinctio? Illo, ullam?
+            ''',
+            items=[
+                ui.inline(justify='end', items=[
+                    ui.mini_buttons([
+                        ui.mini_button(name='like', label='4', icon='Heart'),
+                        ui.mini_button(name='comment', label='2', icon='Comment'),
+                        ui.mini_button(name='share', label='1', icon='Share'),
+                    ]),
+                ])
+            ],
+        )
 
     await q.page.save()

--- a/py/examples/wide_article_preview.py
+++ b/py/examples/wide_article_preview.py
@@ -11,7 +11,6 @@ async def serve(q: Q):
             ui.button(name='back', label='Go back', primary=True),
         ])
     else:
-        q.page['meta'] = ui.meta_card(box='', theme='neon')
         persona_pic = 'https://images.pexels.com/photos/415829/pexels-photo-415829.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=100&w=100'
         q.page['example'] = ui.wide_article_preview_card(
             box='1 1 6 5',

--- a/py/examples/wide_article_preview.py
+++ b/py/examples/wide_article_preview.py
@@ -1,0 +1,41 @@
+# Wide Article Preview
+# Create a Wide Article Preview card displaying a persona, image, title, caption, and buttons.
+# ---
+from h2o_wave import main, app, Q, ui
+
+
+@app('/demo')
+async def serve(q: Q):
+    persona_pic = 'https://images.pexels.com/photos/415829/pexels-photo-415829.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=100&w=100'
+    q.page['example'] = ui.wide_article_preview_card(
+        box='1 1 6 5',
+        persona=ui.persona(title='Jasmine Grand', subtitle='Marketing Executive',
+                           image=persona_pic, caption='caption'),
+        commands=[
+            ui.command(name='new', label='New', icon='Add', items=[
+                ui.command(name='email', label='Email Message', icon='Mail'),
+                ui.command(name='calendar', label='Calendar Event', icon='Calendar'),
+            ]),
+            ui.command(name='upload', label='Upload', icon='Upload'),
+            ui.command(name='share', label='Share', icon='Share'),
+            ui.command(name='download', label='Download', icon='Download'),
+        ],
+        aux_value='2h ago',
+        image='https://images.pexels.com/photos/1269968/pexels-photo-1269968.jpeg?auto=compress',
+        title='Jasmine Grand',
+        caption='''
+            Lorem ipsum dolor sit amet consectetur adipisicing elit. Ipsum sed odio porro veniam dolorum velit doloremque neque aliquam quisquam rem officiis, eius facilis iste quam, minus repellat magni iure eaque!
+            Veniam pariatur itaque nisi, a nam consequuntur. Aliquam nulla sequi, nihil soluta quaerat vitae inventore magni vero voluptates officiis dolorem alias incidunt iure in sapiente doloribus, quos distinctio? Illo, ullam?
+        ''',
+        items=[
+            ui.inline(justify='end', items=[
+                ui.mini_buttons([
+                    ui.mini_button(name='like', label='4', icon='Heart'),
+                    ui.mini_button(name='comment', label='2', icon='Comment'),
+                    ui.mini_button(name='share', label='1', icon='Share'),
+                ]),
+            ])
+        ],
+    )
+
+    await q.page.save()

--- a/py/examples/wide_article_preview.py
+++ b/py/examples/wide_article_preview.py
@@ -33,8 +33,6 @@ async def serve(q: Q):
             caption='''
                 Lorem ipsum dolor sit amet consectetur adipisicing elit. Ipsum sed odio porro veniam dolorum velit doloremque neque aliquam quisquam rem officiis, eius facilis iste quam, minus repellat magni iure eaque!
                 Veniam pariatur itaque nisi, a nam consequuntur. Aliquam nulla sequi, nihil soluta quaerat vitae inventore magni vero voluptates officiis dolorem alias incidunt iure in sapiente doloribus, quos distinctio? Illo, ullam?
-                Veniam pariatur itaque nisi, a nam consequuntur. Aliquam nulla sequi, nihil soluta quaerat vitae inventore magni vero voluptates officiis dolorem alias incidunt iure in sapiente doloribus, quos distinctio? Illo, ullam?
-                Veniam pariatur itaque nisi, a nam consequuntur. Aliquam nulla sequi, nihil soluta quaerat vitae inventore magni vero voluptates officiis dolorem alias incidunt iure in sapiente doloribus, quos distinctio? Illo, ullam?
             ''',
             items=[
                 ui.inline(justify='end', items=[

--- a/py/h2o_wave/types.py
+++ b/py/h2o_wave/types.py
@@ -11296,6 +11296,116 @@ class VegaCard:
         )
 
 
+class WideArticlePreviewCard:
+    """Create a wide article preview card displaying a persona, image, title, caption, and optional buttons.
+    """
+    def __init__(
+            self,
+            box: str,
+            persona: Component,
+            image: str,
+            title: str,
+            name: Optional[str] = None,
+            aux_value: Optional[str] = None,
+            caption: Optional[str] = None,
+            items: Optional[List[Component]] = None,
+            commands: Optional[List[Command]] = None,
+    ):
+        _guard_scalar('WideArticlePreviewCard.box', box, (str,), False, False, False)
+        _guard_scalar('WideArticlePreviewCard.persona', persona, (Component,), False, False, False)
+        _guard_scalar('WideArticlePreviewCard.image', image, (str,), False, False, False)
+        _guard_scalar('WideArticlePreviewCard.title', title, (str,), False, False, False)
+        _guard_scalar('WideArticlePreviewCard.name', name, (str,), False, True, False)
+        _guard_scalar('WideArticlePreviewCard.aux_value', aux_value, (str,), False, True, False)
+        _guard_scalar('WideArticlePreviewCard.caption', caption, (str,), False, True, False)
+        _guard_vector('WideArticlePreviewCard.items', items, (Component,), False, True, False)
+        _guard_vector('WideArticlePreviewCard.commands', commands, (Command,), False, True, False)
+        self.box = box
+        """A string indicating how to place this component on the page."""
+        self.persona = persona
+        """The card's user avatar, 'size' prop is restricted to 'xs'."""
+        self.image = image
+        """The card’s image displayed on the left-hand side."""
+        self.title = title
+        """The card's title on the righ-hand side"""
+        self.name = name
+        """An identifying name for this card. Makes the card clickable, similar to a button."""
+        self.aux_value = aux_value
+        """The card's auxiliary text, displayed on the right-hand side of the header."""
+        self.caption = caption
+        """The card's caption, displayed bellow the title on the right-hand side."""
+        self.items = items
+        """The card's buttons, displayed at the bottom-right corner."""
+        self.commands = commands
+        """Contextual menu commands for this component."""
+
+    def dump(self) -> Dict:
+        """Returns the contents of this object as a dict."""
+        _guard_scalar('WideArticlePreviewCard.box', self.box, (str,), False, False, False)
+        _guard_scalar('WideArticlePreviewCard.persona', self.persona, (Component,), False, False, False)
+        _guard_scalar('WideArticlePreviewCard.image', self.image, (str,), False, False, False)
+        _guard_scalar('WideArticlePreviewCard.title', self.title, (str,), False, False, False)
+        _guard_scalar('WideArticlePreviewCard.name', self.name, (str,), False, True, False)
+        _guard_scalar('WideArticlePreviewCard.aux_value', self.aux_value, (str,), False, True, False)
+        _guard_scalar('WideArticlePreviewCard.caption', self.caption, (str,), False, True, False)
+        _guard_vector('WideArticlePreviewCard.items', self.items, (Component,), False, True, False)
+        _guard_vector('WideArticlePreviewCard.commands', self.commands, (Command,), False, True, False)
+        return _dump(
+            view='wide_article_preview',
+            box=self.box,
+            persona=self.persona.dump(),
+            image=self.image,
+            title=self.title,
+            name=self.name,
+            aux_value=self.aux_value,
+            caption=self.caption,
+            items=None if self.items is None else [__e.dump() for __e in self.items],
+            commands=None if self.commands is None else [__e.dump() for __e in self.commands],
+        )
+
+    @staticmethod
+    def load(__d: Dict) -> 'WideArticlePreviewCard':
+        """Creates an instance of this class using the contents of a dict."""
+        __d_box: Any = __d.get('box')
+        _guard_scalar('WideArticlePreviewCard.box', __d_box, (str,), False, False, False)
+        __d_persona: Any = __d.get('persona')
+        _guard_scalar('WideArticlePreviewCard.persona', __d_persona, (dict,), False, False, False)
+        __d_image: Any = __d.get('image')
+        _guard_scalar('WideArticlePreviewCard.image', __d_image, (str,), False, False, False)
+        __d_title: Any = __d.get('title')
+        _guard_scalar('WideArticlePreviewCard.title', __d_title, (str,), False, False, False)
+        __d_name: Any = __d.get('name')
+        _guard_scalar('WideArticlePreviewCard.name', __d_name, (str,), False, True, False)
+        __d_aux_value: Any = __d.get('aux_value')
+        _guard_scalar('WideArticlePreviewCard.aux_value', __d_aux_value, (str,), False, True, False)
+        __d_caption: Any = __d.get('caption')
+        _guard_scalar('WideArticlePreviewCard.caption', __d_caption, (str,), False, True, False)
+        __d_items: Any = __d.get('items')
+        _guard_vector('WideArticlePreviewCard.items', __d_items, (dict,), False, True, False)
+        __d_commands: Any = __d.get('commands')
+        _guard_vector('WideArticlePreviewCard.commands', __d_commands, (dict,), False, True, False)
+        box: str = __d_box
+        persona: Component = Component.load(__d_persona)
+        image: str = __d_image
+        title: str = __d_title
+        name: Optional[str] = __d_name
+        aux_value: Optional[str] = __d_aux_value
+        caption: Optional[str] = __d_caption
+        items: Optional[List[Component]] = None if __d_items is None else [Component.load(__e) for __e in __d_items]
+        commands: Optional[List[Command]] = None if __d_commands is None else [Command.load(__e) for __e in __d_commands]
+        return WideArticlePreviewCard(
+            box,
+            persona,
+            image,
+            title,
+            name,
+            aux_value,
+            caption,
+            items,
+            commands,
+        )
+
+
 class WideBarStatCard:
     """Create a wide stat card displaying a primary value, an auxiliary value and a progress bar.
     """

--- a/py/h2o_wave/ui.py
+++ b/py/h2o_wave/ui.py
@@ -4038,6 +4038,45 @@ def vega_card(
     )
 
 
+def wide_article_preview_card(
+        box: str,
+        persona: Component,
+        image: str,
+        title: str,
+        name: Optional[str] = None,
+        aux_value: Optional[str] = None,
+        caption: Optional[str] = None,
+        items: Optional[List[Component]] = None,
+        commands: Optional[List[Command]] = None,
+) -> WideArticlePreviewCard:
+    """Create a wide article preview card displaying a persona, image, title, caption, and optional buttons.
+
+    Args:
+        box: A string indicating how to place this component on the page.
+        persona: The card's user avatar, 'size' prop is restricted to 'xs'.
+        image: The card’s image displayed on the left-hand side.
+        title: The card's title on the righ-hand side
+        name: An identifying name for this card. Makes the card clickable, similar to a button.
+        aux_value: The card's auxiliary text, displayed on the right-hand side of the header.
+        caption: The card's caption, displayed bellow the title on the right-hand side.
+        items: The card's buttons, displayed at the bottom-right corner.
+        commands: Contextual menu commands for this component.
+    Returns:
+        A `h2o_wave.types.WideArticlePreviewCard` instance.
+    """
+    return WideArticlePreviewCard(
+        box,
+        persona,
+        image,
+        title,
+        name,
+        aux_value,
+        caption,
+        items,
+        commands,
+    )
+
+
 def wide_bar_stat_card(
         box: str,
         title: str,

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -4687,6 +4687,52 @@ ui_vega_card <- function(
   return(.o)
 }
 
+#' Create a wide article preview card displaying a persona, image, title, caption, and optional buttons.
+#'
+#' @param box A string indicating how to place this component on the page.
+#' @param persona The card's user avatar, 'size' prop is restricted to 'xs'.
+#' @param image The card’s image displayed on the left-hand side.
+#' @param title The card's title on the righ-hand side
+#' @param name An identifying name for this card. Makes the card clickable, similar to a button.
+#' @param aux_value The card's auxiliary text, displayed on the right-hand side of the header.
+#' @param caption The card's caption, displayed bellow the title on the right-hand side.
+#' @param items The card's buttons, displayed at the bottom-right corner.
+#' @param commands Contextual menu commands for this component.
+#' @return A WideArticlePreviewCard instance.
+#' @export
+ui_wide_article_preview_card <- function(
+  box,
+  persona,
+  image,
+  title,
+  name = NULL,
+  aux_value = NULL,
+  caption = NULL,
+  items = NULL,
+  commands = NULL) {
+  .guard_scalar("box", "character", box)
+  .guard_scalar("persona", "WaveComponent", persona)
+  .guard_scalar("image", "character", image)
+  .guard_scalar("title", "character", title)
+  .guard_scalar("name", "character", name)
+  .guard_scalar("aux_value", "character", aux_value)
+  .guard_scalar("caption", "character", caption)
+  .guard_vector("items", "WaveComponent", items)
+  .guard_vector("commands", "WaveCommand", commands)
+  .o <- list(
+    box=box,
+    persona=persona,
+    image=image,
+    title=title,
+    name=name,
+    aux_value=aux_value,
+    caption=caption,
+    items=items,
+    commands=commands)
+  class(.o) <- append(class(.o), c(.wave_obj, "WaveWideArticlePreviewCard"))
+  return(.o)
+}
+
 #' Create a wide stat card displaying a primary value, an auxiliary value and a progress bar.
 #'
 #' @param box A string indicating how to place this component on the page.

--- a/tools/intellij-plugin/src/main/resources/templates/wave-components.xml
+++ b/tools/intellij-plugin/src/main/resources/templates/wave-components.xml
@@ -793,6 +793,15 @@
       <option name="Python" value="true"/>
     </context>
   </template>
+  <template name="w_wide_article_preview_card" value="ui.wide_article_preview_card(box='$box$',persona=$persona$,image='$image$',title='$title$')$END$" description="Create a minimal Wave WideArticlePreviewCard." toReformat="true" toShortenFQNames="true">
+    <variable name="box" expression="" defaultValue="" alwaysStopAt="true"/>
+    <variable name="persona" expression="" defaultValue="" alwaysStopAt="true"/>
+    <variable name="image" expression="" defaultValue="" alwaysStopAt="true"/>
+    <variable name="title" expression="" defaultValue="" alwaysStopAt="true"/>
+    <context>
+      <option name="Python" value="true"/>
+    </context>
+  </template>
   <template name="w_wide_bar_stat_card" value="ui.wide_bar_stat_card(box='$box$',title='$title$',value='$value$',aux_value='$aux_value$',progress=$progress$)$END$" description="Create a minimal Wave WideBarStatCard." toReformat="true" toShortenFQNames="true">
     <variable name="box" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="title" expression="" defaultValue="" alwaysStopAt="true"/>
@@ -1067,7 +1076,7 @@
       <option name="Python" value="true"/>
     </context>
   </template>
-  <template name="w_full_dropdown" value="ui.dropdown(name='$name$',label='$label$',placeholder='$placeholder$',value='$value$',required=$required$,disabled=$disabled$,trigger=$trigger$,width='$width$',visible=$visible$,tooltip='$tooltip$',values=[&#10;	$values$	&#10;],choices=[&#10;	$choices$	&#10;]),$END$" description="Create Wave Dropdown with full attributes." toReformat="true" toShortenFQNames="true">
+  <template name="w_full_dropdown" value="ui.dropdown(name='$name$',label='$label$',placeholder='$placeholder$',value='$value$',required=$required$,disabled=$disabled$,trigger=$trigger$,width='$width$',visible=$visible$,tooltip='$tooltip$',popup='$popup$',values=[&#10;	$values$	&#10;],choices=[&#10;	$choices$	&#10;]),$END$" description="Create Wave Dropdown with full attributes." toReformat="true" toShortenFQNames="true">
     <variable name="name" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="label" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="placeholder" expression="" defaultValue="" alwaysStopAt="true"/>
@@ -1078,6 +1087,7 @@
     <variable name="width" expression="" defaultValue="&quot;100%&quot;" alwaysStopAt="true"/>
     <variable name="visible" expression="" defaultValue="&quot;True&quot;" alwaysStopAt="true"/>
     <variable name="tooltip" expression="" defaultValue="" alwaysStopAt="true"/>
+    <variable name="popup" expression="" defaultValue="&quot;auto`, which pops up a dialog only when there are more than 100 choices&quot;" alwaysStopAt="true"/>
     <variable name="values" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="choices" expression="" defaultValue="" alwaysStopAt="true"/>
     <context>
@@ -2338,6 +2348,20 @@
     <variable name="title" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="specification" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="data" expression="" defaultValue="" alwaysStopAt="true"/>
+    <variable name="commands" expression="" defaultValue="" alwaysStopAt="true"/>
+    <context>
+      <option name="Python" value="true"/>
+    </context>
+  </template>
+  <template name="w_full_wide_article_preview_card" value="ui.wide_article_preview_card(box='$box$',persona=$persona$,image='$image$',title='$title$',name='$name$',aux_value='$aux_value$',caption='$caption$',items=[&#10;	$items$	&#10;],commands=[&#10;	$commands$	&#10;])$END$" description="Create Wave WideArticlePreviewCard with full attributes." toReformat="true" toShortenFQNames="true">
+    <variable name="box" expression="" defaultValue="" alwaysStopAt="true"/>
+    <variable name="persona" expression="" defaultValue="" alwaysStopAt="true"/>
+    <variable name="image" expression="" defaultValue="" alwaysStopAt="true"/>
+    <variable name="title" expression="" defaultValue="" alwaysStopAt="true"/>
+    <variable name="name" expression="" defaultValue="" alwaysStopAt="true"/>
+    <variable name="aux_value" expression="" defaultValue="" alwaysStopAt="true"/>
+    <variable name="caption" expression="" defaultValue="" alwaysStopAt="true"/>
+    <variable name="items" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="commands" expression="" defaultValue="" alwaysStopAt="true"/>
     <context>
       <option name="Python" value="true"/>

--- a/tools/wavegen/wave-components.json
+++ b/tools/wavegen/wave-components.json
@@ -783,6 +783,13 @@
     ],
     "description": "Create a minimal Wave VegaCard."
   },
+  "Wave WideArticlePreviewCard": {
+    "prefix": "w_wide_article_preview_card",
+    "body": [
+      "ui.wide_article_preview_card(box='$1', persona=$2, image='$3', title='$4')$0"
+    ],
+    "description": "Create a minimal Wave WideArticlePreviewCard."
+  },
   "Wave WideBarStatCard": {
     "prefix": "w_wide_bar_stat_card",
     "body": [
@@ -961,7 +968,7 @@
   "Wave Full Dropdown": {
     "prefix": "w_full_dropdown",
     "body": [
-      "ui.dropdown(name='$1', label='$2', placeholder='$3', value='$4', required=${5:False}, disabled=${6:False}, trigger=${7:False}, width='${8:100%'}', visible=${9:True}, tooltip='$10', values=[\n\t\t$11\t\t\n], choices=[\n\t\t$12\t\t\n]),$0"
+      "ui.dropdown(name='$1', label='$2', placeholder='$3', value='$4', required=${5:False}, disabled=${6:False}, trigger=${7:False}, width='${8:100%'}', visible=${9:True}, tooltip='$10', popup='${11:auto`, which pops up a dialog only when there are more than 100 choices}', values=[\n\t\t$12\t\t\n], choices=[\n\t\t$13\t\t\n]),$0"
     ],
     "description": "Create a full Wave Dropdown."
   },
@@ -1685,6 +1692,13 @@
       "ui.vega_card(box='$1', title='$2', specification='$3', data=$4, commands=[\n\t\t$5\t\t\n])$0"
     ],
     "description": "Create a full Wave VegaCard."
+  },
+  "Wave Full WideArticlePreviewCard": {
+    "prefix": "w_full_wide_article_preview_card",
+    "body": [
+      "ui.wide_article_preview_card(box='$1', persona=$2, image='$3', title='$4', name='$5', aux_value='$6', caption='$7', items=[\n\t\t$8\t\t\n], commands=[\n\t\t$9\t\t\n])$0"
+    ],
+    "description": "Create a full Wave WideArticlePreviewCard."
   },
   "Wave Full WideBarStatCard": {
     "prefix": "w_full_wide_bar_stat_card",

--- a/ui/src/cards.tsx
+++ b/ui/src/cards.tsx
@@ -60,4 +60,5 @@ import './wide_info'
 import './wide_pie_stat'
 import './wide_plot'
 import './wide_series_stat'
+import './wide_article_preview'
 

--- a/ui/src/wide_article_preview.test.tsx
+++ b/ui/src/wide_article_preview.test.tsx
@@ -1,0 +1,57 @@
+// Copyright 2020 H2O.ai, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { fireEvent, render } from '@testing-library/react'
+import { box, Model } from 'h2o-wave'
+import React from 'react'
+import { wave } from './ui'
+import { View } from './wide_article_preview'
+
+const
+  name = 'wide_article_preview',
+  pushMock = jest.fn()
+let wideArticlePreviewProps: Model<any>
+
+describe('WideArticlePreview.tsx', () => {
+  beforeAll(() => wave.push = pushMock)
+  beforeEach(() => {
+    pushMock.mockReset()
+    wave.args = [] as any
+    wideArticlePreviewProps = {
+      name,
+      state: { persona: { persona: {} }, image: '', name, title: '' },
+      changed: box(false)
+    }
+  })
+
+  it('Renders data-test attr', () => {
+    const { queryByTestId } = render(<View {...wideArticlePreviewProps} />)
+    expect(queryByTestId(name)).toBeInTheDocument()
+  })
+
+  it('Makes card clickable if name was specified', () => {
+    const { getByTestId } = render(<View {...wideArticlePreviewProps} />)
+    fireEvent.click(getByTestId(name))
+    expect(pushMock).toHaveBeenCalled()
+    expect(wave.args[name]).toBe(name)
+  })
+
+  it('Makes card unclickable if name is empty', () => {
+    wideArticlePreviewProps.state.name = ''
+    const { getByTestId } = render(<View {...wideArticlePreviewProps} />)
+    fireEvent.click(getByTestId(name))
+    expect(pushMock).not.toHaveBeenCalled()
+    expect(wave.args[name]).not.toBe(name)
+  })
+})

--- a/ui/src/wide_article_preview.test.tsx
+++ b/ui/src/wide_article_preview.test.tsx
@@ -54,4 +54,12 @@ describe('WideArticlePreview.tsx', () => {
     expect(pushMock).not.toHaveBeenCalled()
     expect(wave.args[name]).not.toBe(name)
   })
+
+  it('Does not submit data to server if name starts with #', () => {
+    wideArticlePreviewProps.state.name = `#${name}`
+    const { getByTestId } = render(<View {...wideArticlePreviewProps} />)
+    fireEvent.click(getByTestId(name))
+    expect(pushMock).not.toHaveBeenCalled()
+    expect(wave.args[name]).toBeUndefined()
+  })
 })

--- a/ui/src/wide_article_preview.tsx
+++ b/ui/src/wide_article_preview.tsx
@@ -86,6 +86,7 @@ const css = stylesheet({
   },
   title: {
     marginBottom: 8,
+    lineHeight: 0.6,
   },
   caption: {
     marginBottom: 24,

--- a/ui/src/wide_article_preview.tsx
+++ b/ui/src/wide_article_preview.tsx
@@ -97,7 +97,7 @@ export interface State {
   aux_value?: S
   /** The card's caption, displayed bellow the title on the right-hand side. */
   caption?: S
-  /** The card's buttons, displayed at the bottom-right corner. */
+  /** The card's buttons, displayed under the caption. */
   items?: Component[]
 }
 

--- a/ui/src/wide_article_preview.tsx
+++ b/ui/src/wide_article_preview.tsx
@@ -17,7 +17,7 @@ import React from 'react'
 import { stylesheet } from 'typestyle'
 import { Component, XComponents } from './form'
 import { cards } from './layout'
-import { clas, cssVar, px } from './theme'
+import { clas, cssVar, important, px } from './theme'
 import { bond, wave } from './ui'
 import { XPersona } from './persona'
 
@@ -47,7 +47,7 @@ const css = stylesheet({
         color: cssVar('$text7')
       },
       '.ms-Persona-image': {
-        height: '40px !important',
+        height: important('40px'),
         width: '40px !important',
       },
       '.ms-Persona-imageArea': {

--- a/ui/src/wide_article_preview.tsx
+++ b/ui/src/wide_article_preview.tsx
@@ -1,0 +1,144 @@
+// Copyright 2020 H2O.ai, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Model, S } from 'h2o-wave'
+import React from 'react'
+import { stylesheet } from 'typestyle'
+import { Component, XComponents } from './form'
+import { cards } from './layout'
+import { clas, cssVar, px } from './theme'
+import { bond, wave } from './ui'
+import { XPersona } from './persona'
+
+const css = stylesheet({
+  card: {
+    display: 'flex',
+    flexDirection: 'column',
+    padding: 24,
+  },
+  clickable: {
+    cursor: 'pointer'
+  },
+  header: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'flex-end',
+    marginBottom: 24,
+    $nest: {
+      '.ms-Persona-primaryText': {
+        fontSize: 16,
+        lineHeight: px(22),
+        fontWeight: 500,
+      },
+      '.ms-Persona-secondaryText': {
+        fontSize: 14,
+        lineHeight: px(20),
+        color: cssVar('$text7')
+      },
+      '.ms-Persona-image': {
+        height: '40px !important',
+        width: '40px !important',
+      },
+      '.ms-Persona-imageArea': {
+        height: '40px !important',
+        width: '40px !important',
+      }
+    }
+  },
+  content: {
+    flex: 1,
+    display: 'flex',
+  },
+  img: {
+    marginRight: 24,
+    flex: 1,
+    backgroundSize: 'cover',
+    backgroundRepeat: 'no-repeat',
+    backgroundPosition: 'center',
+  },
+  rhs: {
+    flex: 1,
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'space-between',
+  },
+  items: {
+    $nest: {
+      // Target mini button's icons and labels
+      '& .ms-Icon, & .ms-Button-label': {
+        color: cssVar('$text'),
+      }
+    }
+  },
+})
+
+/** Create a wide article preview card displaying a persona, image, title, caption, and optional buttons. */
+export interface State {
+  /** The card's user avatar, 'size' prop is restricted to 'xs'. */
+  persona: Component
+  /** The card’s image displayed on the left-hand side. */
+  image: S
+  /** The card's title on the righ-hand side */
+  title: S
+  /** An identifying name for this card. Makes the card clickable, similar to a button. */
+  name?: S
+  /** The card's auxiliary text, displayed on the right-hand side of the header. */
+  aux_value?: S
+  /** The card's caption, displayed bellow the title on the right-hand side. */
+  caption?: S
+  /** The card's buttons, displayed at the bottom-right corner. */
+  items?: Component[]
+}
+
+export const View = bond(({ name, state, changed }: Model<State>) => {
+  const render = () => {
+    const { persona, aux_value, name: stateName, image, title, caption, items } = state,
+    onClick = () => {
+      if (!stateName) return
+      if (stateName.startsWith('#')) {
+        window.location.hash = stateName.substr(1)
+        return
+      }
+      wave.args[stateName] = stateName
+      wave.push()
+    }
+    if (persona.persona) persona.persona.size = 'xs'
+    return (
+      <div
+        data-test={name}
+        onClick={onClick}
+        className={clas(css.card, stateName ? css.clickable : '')}
+      >
+        <div className={css.header}>
+          {persona.persona && <XPersona model={persona.persona} />}
+          {aux_value && <div className='wave-s12 wave-t7'>{aux_value}</div>}
+        </div>
+        <div className={css.content}>
+          <div className={css.img} style={{ backgroundImage: `url('${image}')` }}></div>
+          <div className={css.rhs}>
+            <div>
+              {title && <div className='wave-s16 wave-w6'>{title}</div>}
+              {caption && <div className='wave-s14 wave-w4 wave-t7'>{caption}</div>}
+            </div>
+            {items && <div className={css.items}><XComponents items={items} /></div>}
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  return { render, changed }
+})
+
+cards.register('wide_article_preview', View)

--- a/ui/src/wide_article_preview.tsx
+++ b/ui/src/wide_article_preview.tsx
@@ -95,7 +95,7 @@ export interface State {
   name?: S
   /** The card's auxiliary text, displayed on the right-hand side of the header. */
   aux_value?: S
-  /** The card's caption, displayed bellow the title on the right-hand side. */
+  /** The card's caption, displayed below the title on the right-hand side. */
   caption?: S
   /** The card's buttons, displayed under the caption. */
   items?: Component[]

--- a/ui/src/wide_article_preview.tsx
+++ b/ui/src/wide_article_preview.tsx
@@ -88,9 +88,6 @@ const css = stylesheet({
     marginBottom: 8,
     lineHeight: 0.6,
   },
-  caption: {
-    marginBottom: 24,
-  }
 })
 
 /** Create a wide article preview card displaying a persona, image, title, caption, and optional buttons. */
@@ -139,7 +136,7 @@ export const View = bond(({ name, state, changed }: Model<State>) => {
           <div className={css.rhs}>
             <div>
               {title && <div className={clas('wave-s16 wave-w6', css.title)}>{title}</div>}
-              {caption && <div className={clas('wave-s14 wave-w4 wave-t7', css.caption)}>{caption}</div>}
+              {caption && <div style={{ marginBottom: items ? 24 : 0 }} className='wave-s14 wave-w4 wave-t7'>{caption}</div>}
             </div>
             {items && <div className={css.items}><XComponents items={items} /></div>}
           </div>

--- a/ui/src/wide_article_preview.tsx
+++ b/ui/src/wide_article_preview.tsx
@@ -48,11 +48,11 @@ const css = stylesheet({
       },
       '.ms-Persona-image': {
         height: important('40px'),
-        width: '40px !important',
+        width: important('40px'),
       },
       '.ms-Persona-imageArea': {
-        height: '40px !important',
-        width: '40px !important',
+        height: important('40px'),
+        width: important('40px'),
       }
     }
   },

--- a/ui/src/wide_article_preview.tsx
+++ b/ui/src/wide_article_preview.tsx
@@ -81,6 +81,12 @@ const css = stylesheet({
       }
     }
   },
+  title: {
+    marginBottom: 8,
+  },
+  caption: {
+    marginBottom: 24,
+  }
 })
 
 /** Create a wide article preview card displaying a persona, image, title, caption, and optional buttons. */
@@ -128,8 +134,8 @@ export const View = bond(({ name, state, changed }: Model<State>) => {
           <div className={css.img} style={{ backgroundImage: `url('${image}')` }}></div>
           <div className={css.rhs}>
             <div>
-              {title && <div className='wave-s16 wave-w6'>{title}</div>}
-              {caption && <div className='wave-s14 wave-w4 wave-t7'>{caption}</div>}
+              {title && <div className={clas('wave-s16 wave-w6', css.title)}>{title}</div>}
+              {caption && <div className={clas('wave-s14 wave-w4 wave-t7', css.caption)}>{caption}</div>}
             </div>
             {items && <div className={css.items}><XComponents items={items} /></div>}
           </div>

--- a/ui/src/wide_article_preview.tsx
+++ b/ui/src/wide_article_preview.tsx
@@ -89,7 +89,7 @@ export interface State {
   persona: Component
   /** The card’s image displayed on the left-hand side. */
   image: S
-  /** The card's title on the righ-hand side */
+  /** The card's title on the right-hand side */
   title: S
   /** An identifying name for this card. Makes the card clickable, similar to a button. */
   name?: S

--- a/ui/src/wide_article_preview.tsx
+++ b/ui/src/wide_article_preview.tsx
@@ -56,6 +56,9 @@ const css = stylesheet({
       }
     }
   },
+  aux_value: {
+    marginBottom: 4,
+  },
   content: {
     flex: 1,
     display: 'flex',
@@ -128,7 +131,7 @@ export const View = bond(({ name, state, changed }: Model<State>) => {
       >
         <div className={css.header}>
           {persona.persona && <XPersona model={persona.persona} />}
-          {aux_value && <div className='wave-s12 wave-t7'>{aux_value}</div>}
+          {aux_value && <div className={clas('wave-s12 wave-t7', css.aux_value)}>{aux_value}</div>}
         </div>
         <div className={css.content}>
           <div className={css.img} style={{ backgroundImage: `url('${image}')` }}></div>

--- a/website/components/content/article.md
+++ b/website/components/content/article.md
@@ -78,35 +78,35 @@ Horizontal variant.
 Check the full API at [ui.wide_article_preview_card](/docs/api/ui#wide_article_preview_card).
 
 ```py
-    persona_pic = 'https://images.pexels.com/photos/415829/pexels-photo-415829.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=100&w=100'
-    q.page['example'] = ui.wide_article_preview_card(
-        box='1 1 6 5',
-        persona=ui.persona(title='Jasmine Grand', subtitle='Marketing Executive',
-                           image=persona_pic, caption='caption'),
-        commands=[
-            ui.command(name='new', label='New', icon='Add', items=[
-                ui.command(name='email', label='Email Message', icon='Mail'),
-                ui.command(name='calendar', label='Calendar Event', icon='Calendar'),
+persona_pic = 'https://images.pexels.com/photos/415829/pexels-photo-415829.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=100&w=100'
+q.page['example'] = ui.wide_article_preview_card(
+    box='1 1 6 5',
+    persona=ui.persona(title='Jasmine Grand', subtitle='Marketing Executive',
+                        image=persona_pic, caption='caption'),
+    commands=[
+        ui.command(name='new', label='New', icon='Add', items=[
+            ui.command(name='email', label='Email Message', icon='Mail'),
+            ui.command(name='calendar', label='Calendar Event', icon='Calendar'),
+        ]),
+        ui.command(name='upload', label='Upload', icon='Upload'),
+        ui.command(name='share', label='Share', icon='Share'),
+        ui.command(name='download', label='Download', icon='Download'),
+    ],
+    aux_value='2h ago',
+    image='https://images.pexels.com/photos/1269968/pexels-photo-1269968.jpeg?auto=compress',
+    title='Jasmine Grand',
+    caption='''
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Ipsum sed odio porro veniam dolorum velit doloremque neque aliquam quisquam rem officiis, eius facilis iste quam, minus repellat magni iure eaque!
+        Veniam pariatur itaque nisi, a nam consequuntur. Aliquam nulla sequi, nihil soluta quaerat vitae inventore magni vero voluptates officiis dolorem alias incidunt iure in sapiente doloribus, quos distinctio? Illo, ullam?
+    ''',
+    items=[
+        ui.inline(justify='end', items=[
+            ui.mini_buttons([   
+                ui.mini_button(name='like', label='4', icon='Heart'),
+                ui.mini_button(name='comment', label='2', icon='Comment'),
+                ui.mini_button(name='share', label='1', icon='Share'),
             ]),
-            ui.command(name='upload', label='Upload', icon='Upload'),
-            ui.command(name='share', label='Share', icon='Share'),
-            ui.command(name='download', label='Download', icon='Download'),
-        ],
-        aux_value='2h ago',
-        image='https://images.pexels.com/photos/1269968/pexels-photo-1269968.jpeg?auto=compress',
-        title='Jasmine Grand',
-        caption='''
-            Lorem ipsum dolor sit amet consectetur adipisicing elit. Ipsum sed odio porro veniam dolorum velit doloremque neque aliquam quisquam rem officiis, eius facilis iste quam, minus repellat magni iure eaque!
-            Veniam pariatur itaque nisi, a nam consequuntur. Aliquam nulla sequi, nihil soluta quaerat vitae inventore magni vero voluptates officiis dolorem alias incidunt iure in sapiente doloribus, quos distinctio? Illo, ullam?
-        ''',
-        items=[
-            ui.inline(justify='end', items=[
-                ui.mini_buttons([   
-                    ui.mini_button(name='like', label='4', icon='Heart'),
-                    ui.mini_button(name='comment', label='2', icon='Comment'),
-                    ui.mini_button(name='share', label='1', icon='Share'),
-                ]),
-            ])
-        ],
-    )
+        ])
+    ],
+)
 ```

--- a/website/components/content/article.md
+++ b/website/components/content/article.md
@@ -78,7 +78,7 @@ Horizontal variant.
 Check the full API at [ui.wide_article_preview_card](/docs/api/ui#wide_article_preview_card).
 
 ```py
-persona_pic = 'https://images.pexels.com/photos/415829/pexels-photo-415829.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=100&w=100'
+    persona_pic = 'https://images.pexels.com/photos/415829/pexels-photo-415829.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=100&w=100'
     q.page['example'] = ui.wide_article_preview_card(
         box='1 1 6 5',
         persona=ui.persona(title='Jasmine Grand', subtitle='Marketing Executive',
@@ -101,7 +101,7 @@ persona_pic = 'https://images.pexels.com/photos/415829/pexels-photo-415829.jpeg?
         ''',
         items=[
             ui.inline(justify='end', items=[
-                ui.mini_buttons([
+                ui.mini_buttons([   
                     ui.mini_button(name='like', label='4', icon='Heart'),
                     ui.mini_button(name='comment', label='2', icon='Comment'),
                     ui.mini_button(name='share', label='1', icon='Share'),

--- a/website/components/content/article.md
+++ b/website/components/content/article.md
@@ -96,8 +96,10 @@ q.page['example'] = ui.wide_article_preview_card(
     image='https://images.pexels.com/photos/1269968/pexels-photo-1269968.jpeg?auto=compress',
     title='Jasmine Grand',
     caption='''
-        Lorem ipsum dolor sit amet consectetur adipisicing elit. Ipsum sed odio porro veniam dolorum velit doloremque neque aliquam quisquam rem officiis, eius facilis iste quam, minus repellat magni iure eaque!
-        Veniam pariatur itaque nisi, a nam consequuntur. Aliquam nulla sequi, nihil soluta quaerat vitae inventore magni vero voluptates officiis dolorem alias incidunt iure in sapiente doloribus, quos distinctio? Illo, ullam?
+Duis porttitor tincidunt justo ac semper. Vestibulum et molestie lectus. Proin vel eros a ex condimentum aliquam.
+Sed accumsan tellus sit amet nulla ullamcorper. Suspendisse bibendum tristique sem, quis lacinia ex pulvinar quis.
+Nam elementum accumsan porta. Sed eget aliquam elit, sed luctus lorem. Nulla gravida malesuada purus eu eleifend.
+Maecenas in ante interdum, hendrerit velit at, tempus eros. Nullam convallis tempor libero at viverra.
     ''',
     items=[
         ui.inline(justify='end', items=[
@@ -105,8 +107,8 @@ q.page['example'] = ui.wide_article_preview_card(
                 ui.mini_button(name='like', label='4', icon='Heart'),
                 ui.mini_button(name='comment', label='2', icon='Comment'),
                 ui.mini_button(name='share', label='1', icon='Share'),
-            ]),
+            ])
         ])
-    ],
+    ]
 )
 ```

--- a/website/components/content/article.md
+++ b/website/components/content/article.md
@@ -70,3 +70,43 @@ q.page['example'] = ui.tall_article_preview_card(
 :::tip
 If you specify the `name` attribute, the whole card becomes clickable what can be used for leading into the detail view.
 :::
+
+## Wide article preview
+
+Horizontal variant.
+
+Check the full API at [ui.wide_article_preview_card](/docs/api/ui#wide_article_preview_card).
+
+```py
+persona_pic = 'https://images.pexels.com/photos/415829/pexels-photo-415829.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=100&w=100'
+    q.page['example'] = ui.wide_article_preview_card(
+        box='1 1 6 5',
+        persona=ui.persona(title='Jasmine Grand', subtitle='Marketing Executive',
+                           image=persona_pic, caption='caption'),
+        commands=[
+            ui.command(name='new', label='New', icon='Add', items=[
+                ui.command(name='email', label='Email Message', icon='Mail'),
+                ui.command(name='calendar', label='Calendar Event', icon='Calendar'),
+            ]),
+            ui.command(name='upload', label='Upload', icon='Upload'),
+            ui.command(name='share', label='Share', icon='Share'),
+            ui.command(name='download', label='Download', icon='Download'),
+        ],
+        aux_value='2h ago',
+        image='https://images.pexels.com/photos/1269968/pexels-photo-1269968.jpeg?auto=compress',
+        title='Jasmine Grand',
+        caption='''
+            Lorem ipsum dolor sit amet consectetur adipisicing elit. Ipsum sed odio porro veniam dolorum velit doloremque neque aliquam quisquam rem officiis, eius facilis iste quam, minus repellat magni iure eaque!
+            Veniam pariatur itaque nisi, a nam consequuntur. Aliquam nulla sequi, nihil soluta quaerat vitae inventore magni vero voluptates officiis dolorem alias incidunt iure in sapiente doloribus, quos distinctio? Illo, ullam?
+        ''',
+        items=[
+            ui.inline(justify='end', items=[
+                ui.mini_buttons([
+                    ui.mini_button(name='like', label='4', icon='Heart'),
+                    ui.mini_button(name='comment', label='2', icon='Comment'),
+                    ui.mini_button(name='share', label='1', icon='Share'),
+                ]),
+            ])
+        ],
+    )
+```


### PR DESCRIPTION
### Design
![image](https://user-images.githubusercontent.com/15820796/146166349-ccd372b8-1780-442f-8379-67dd765a6d2e.png)

### Themes
Default
![image](https://user-images.githubusercontent.com/15820796/146165680-1eb7c572-da67-4c26-abfc-dc676f370931.png)

H2O-dark
![image](https://user-images.githubusercontent.com/15820796/146165843-06ed0c05-da83-42a7-ac61-6d6564ac3f51.png)

Neon
![image](https://user-images.githubusercontent.com/15820796/146166208-2019f49f-7ffa-4bdc-aa88-baca984eea66.png)

Proposed API: 

```ts
/** Create a wide article preview card displaying a persona, image, title, caption, and optional buttons. */
export interface State {
  /** The card's user avatar, 'size' prop is restricted to 'xs'. */
  persona: Component
  /** The card’s image displayed on the left-hand side. */
  image: S
  /** The card's title on the righ-hand side */
  title: S
  /** An identifying name for this card. Makes the card clickable, similar to a button. */
  name?: S
  /** The card's auxiliary text, displayed on the right-hand side of the header. */
  aux_value?: S
  /** The card's caption, displayed bellow the title on the right-hand side. */
  caption?: S
  /** The card's buttons, displayed at the bottom-right corner. */
  items?: Component[]
}
```