### PR TITLE
docs: Fix missing keyword in run command

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -75,7 +75,7 @@ make run
 Try running the Wave tour to verify if your setup is functional:
 
 ``` bash
-cd py && ./venv/bin/wave examples.tour
+cd py && ./venv/bin/wave run examples.tour
 ```
 
 You should now see the Wave Tour at http://localhost:10101/tour, and examples running at http://localhost:10101/demo.


### PR DESCRIPTION
In Getting started section of Development setup in CONTRIBUTING.md there is a missing `run` keyword in a command running example tour. 

🔴**Wrong:** `cd py && ./venv/bin/wave examples.tour`

🟢**Correct:** `cd py && ./venv/bin/wave run examples.tour`