### PR TITLE
feat: Add ability to turn off spellcheck for textbox #606

### DIFF
--- a/py/examples/textbox.py
+++ b/py/examples/textbox.py
@@ -21,6 +21,7 @@ async def serve(q: Q):
             ui.text(f'textbox_placeholder={q.args.textbox_placeholder}'),
             ui.text(f'textbox_disabled_placeholder={q.args.textbox_disabled_placeholder}'),
             ui.text(f'textbox_multiline={q.args.textbox_multiline}'),
+            ui.text(f'textbox_spellcheck_disabled={q.args.textbox_spellcheck_disabled}'),
             ui.button(name='show_form', label='Back', primary=True),
         ]
     else:
@@ -38,6 +39,7 @@ async def serve(q: Q):
             ui.textbox(name='textbox_disabled_placeholder', label='Disabled with placeholder', disabled=True,
                        placeholder='I am disabled'),
             ui.textbox(name='textbox_multiline', label='Multiline textarea', multiline=True),
+            ui.textbox(name='textbox_spellcheck_disabled', label='Spellcheck disabled', spellcheck=False),
             ui.button(name='show_inputs', label='Submit', primary=True),
         ])
     await q.page.save()

--- a/py/h2o_wave/types.py
+++ b/py/h2o_wave/types.py
@@ -979,6 +979,7 @@ class Textbox:
             width: Optional[str] = None,
             visible: Optional[bool] = None,
             tooltip: Optional[str] = None,
+            spellcheck: Optional[bool] = None,
     ):
         _guard_scalar('Textbox.name', name, (str,), True, False, False)
         _guard_scalar('Textbox.label', label, (str,), False, True, False)
@@ -999,6 +1000,7 @@ class Textbox:
         _guard_scalar('Textbox.width', width, (str,), False, True, False)
         _guard_scalar('Textbox.visible', visible, (bool,), False, True, False)
         _guard_scalar('Textbox.tooltip', tooltip, (str,), False, True, False)
+        _guard_scalar('Textbox.spellcheck', spellcheck, (bool,), False, True, False)
         self.name = name
         """An identifying name for this component."""
         self.label = label
@@ -1037,6 +1039,8 @@ class Textbox:
         """True if the component should be visible. Defaults to True."""
         self.tooltip = tooltip
         """An optional tooltip message displayed when a user clicks the help icon to the right of the component."""
+        self.spellcheck = spellcheck
+        """True if spellcheck is enabled."""
 
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""
@@ -1059,6 +1063,7 @@ class Textbox:
         _guard_scalar('Textbox.width', self.width, (str,), False, True, False)
         _guard_scalar('Textbox.visible', self.visible, (bool,), False, True, False)
         _guard_scalar('Textbox.tooltip', self.tooltip, (str,), False, True, False)
+        _guard_scalar('Textbox.spellcheck', self.spellcheck, (bool,), False, True, False)
         return _dump(
             name=self.name,
             label=self.label,
@@ -1079,6 +1084,7 @@ class Textbox:
             width=self.width,
             visible=self.visible,
             tooltip=self.tooltip,
+            spellcheck=self.spellcheck,
         )
 
     @staticmethod
@@ -1122,6 +1128,8 @@ class Textbox:
         _guard_scalar('Textbox.visible', __d_visible, (bool,), False, True, False)
         __d_tooltip: Any = __d.get('tooltip')
         _guard_scalar('Textbox.tooltip', __d_tooltip, (str,), False, True, False)
+        __d_spellcheck: Any = __d.get('spellcheck')
+        _guard_scalar('Textbox.spellcheck', __d_spellcheck, (bool,), False, True, False)
         name: str = __d_name
         label: Optional[str] = __d_label
         placeholder: Optional[str] = __d_placeholder
@@ -1141,6 +1149,7 @@ class Textbox:
         width: Optional[str] = __d_width
         visible: Optional[bool] = __d_visible
         tooltip: Optional[str] = __d_tooltip
+        spellcheck: Optional[bool] = __d_spellcheck
         return Textbox(
             name,
             label,
@@ -1161,6 +1170,7 @@ class Textbox:
             width,
             visible,
             tooltip,
+            spellcheck,
         )
 
 
@@ -11327,15 +11337,15 @@ class WideArticlePreviewCard:
         self.image = image
         """The card’s image displayed on the left-hand side."""
         self.title = title
-        """The card's title on the righ-hand side"""
+        """The card's title on the right-hand side"""
         self.name = name
         """An identifying name for this card. Makes the card clickable, similar to a button."""
         self.aux_value = aux_value
         """The card's auxiliary text, displayed on the right-hand side of the header."""
         self.caption = caption
-        """The card's caption, displayed bellow the title on the right-hand side."""
+        """The card's caption, displayed below the title on the right-hand side."""
         self.items = items
-        """The card's buttons, displayed at the bottom-right corner."""
+        """The card's buttons, displayed under the caption."""
         self.commands = commands
         """Contextual menu commands for this component."""
 

--- a/py/h2o_wave/types.py
+++ b/py/h2o_wave/types.py
@@ -1040,7 +1040,7 @@ class Textbox:
         self.tooltip = tooltip
         """An optional tooltip message displayed when a user clicks the help icon to the right of the component."""
         self.spellcheck = spellcheck
-        """True if spellcheck is enabled."""
+        """True if the text may be checked for spelling errors. Defaults to True."""
 
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""

--- a/py/h2o_wave/ui.py
+++ b/py/h2o_wave/ui.py
@@ -424,7 +424,7 @@ def textbox(
         width: The width of the text box, e.g. '100px'. Defaults to '100%'.
         visible: True if the component should be visible. Defaults to True.
         tooltip: An optional tooltip message displayed when a user clicks the help icon to the right of the component.
-        spellcheck: True if spellcheck is enabled.
+        spellcheck: True if the text may be checked for spelling errors. Defaults to True.
     Returns:
         A `h2o_wave.types.Textbox` instance.
     """

--- a/py/h2o_wave/ui.py
+++ b/py/h2o_wave/ui.py
@@ -396,6 +396,7 @@ def textbox(
         width: Optional[str] = None,
         visible: Optional[bool] = None,
         tooltip: Optional[str] = None,
+        spellcheck: Optional[bool] = None,
 ) -> Component:
     """Create a text box.
 
@@ -423,6 +424,7 @@ def textbox(
         width: The width of the text box, e.g. '100px'. Defaults to '100%'.
         visible: True if the component should be visible. Defaults to True.
         tooltip: An optional tooltip message displayed when a user clicks the help icon to the right of the component.
+        spellcheck: True if spellcheck is enabled.
     Returns:
         A `h2o_wave.types.Textbox` instance.
     """
@@ -446,6 +448,7 @@ def textbox(
         width,
         visible,
         tooltip,
+        spellcheck,
     ))
 
 
@@ -4055,11 +4058,11 @@ def wide_article_preview_card(
         box: A string indicating how to place this component on the page.
         persona: The card's user avatar, 'size' prop is restricted to 'xs'.
         image: The card’s image displayed on the left-hand side.
-        title: The card's title on the righ-hand side
+        title: The card's title on the right-hand side
         name: An identifying name for this card. Makes the card clickable, similar to a button.
         aux_value: The card's auxiliary text, displayed on the right-hand side of the header.
-        caption: The card's caption, displayed bellow the title on the right-hand side.
-        items: The card's buttons, displayed at the bottom-right corner.
+        caption: The card's caption, displayed below the title on the right-hand side.
+        items: The card's buttons, displayed under the caption.
         commands: Contextual menu commands for this component.
     Returns:
         A `h2o_wave.types.WideArticlePreviewCard` instance.

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -479,7 +479,7 @@ ui_message_bar <- function(
 #' @param width The width of the text box, e.g. '100px'. Defaults to '100%'.
 #' @param visible True if the component should be visible. Defaults to True.
 #' @param tooltip An optional tooltip message displayed when a user clicks the help icon to the right of the component.
-#' @param spellcheck True if spellcheck is enabled.
+#' @param spellcheck True if the text may be checked for spelling errors. Defaults to True.
 #' @return A Textbox instance.
 #' @export
 ui_textbox <- function(

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -479,6 +479,7 @@ ui_message_bar <- function(
 #' @param width The width of the text box, e.g. '100px'. Defaults to '100%'.
 #' @param visible True if the component should be visible. Defaults to True.
 #' @param tooltip An optional tooltip message displayed when a user clicks the help icon to the right of the component.
+#' @param spellcheck True if spellcheck is enabled.
 #' @return A Textbox instance.
 #' @export
 ui_textbox <- function(
@@ -500,7 +501,8 @@ ui_textbox <- function(
   height = NULL,
   width = NULL,
   visible = NULL,
-  tooltip = NULL) {
+  tooltip = NULL,
+  spellcheck = NULL) {
   .guard_scalar("name", "character", name)
   .guard_scalar("label", "character", label)
   .guard_scalar("placeholder", "character", placeholder)
@@ -520,6 +522,7 @@ ui_textbox <- function(
   .guard_scalar("width", "character", width)
   .guard_scalar("visible", "logical", visible)
   .guard_scalar("tooltip", "character", tooltip)
+  .guard_scalar("spellcheck", "logical", spellcheck)
   .o <- list(textbox=list(
     name=name,
     label=label,
@@ -539,7 +542,8 @@ ui_textbox <- function(
     height=height,
     width=width,
     visible=visible,
-    tooltip=tooltip))
+    tooltip=tooltip,
+    spellcheck=spellcheck))
   class(.o) <- append(class(.o), c(.wave_obj, "WaveComponent"))
   return(.o)
 }
@@ -4692,11 +4696,11 @@ ui_vega_card <- function(
 #' @param box A string indicating how to place this component on the page.
 #' @param persona The card's user avatar, 'size' prop is restricted to 'xs'.
 #' @param image The card’s image displayed on the left-hand side.
-#' @param title The card's title on the righ-hand side
+#' @param title The card's title on the right-hand side
 #' @param name An identifying name for this card. Makes the card clickable, similar to a button.
 #' @param aux_value The card's auxiliary text, displayed on the right-hand side of the header.
-#' @param caption The card's caption, displayed bellow the title on the right-hand side.
-#' @param items The card's buttons, displayed at the bottom-right corner.
+#' @param caption The card's caption, displayed below the title on the right-hand side.
+#' @param items The card's buttons, displayed under the caption.
 #' @param commands Contextual menu commands for this component.
 #' @return A WideArticlePreviewCard instance.
 #' @export

--- a/tools/intellij-plugin/src/main/resources/templates/wave-components.xml
+++ b/tools/intellij-plugin/src/main/resources/templates/wave-components.xml
@@ -2286,7 +2286,7 @@
     <variable name="width" expression="" defaultValue="&quot;100%&quot;" alwaysStopAt="true"/>
     <variable name="visible" expression="" defaultValue="&quot;True&quot;" alwaysStopAt="true"/>
     <variable name="tooltip" expression="" defaultValue="" alwaysStopAt="true"/>
-    <variable name="spellcheck" expression="" defaultValue="&quot;False&quot;" alwaysStopAt="true"/>
+    <variable name="spellcheck" expression="" defaultValue="&quot;True&quot;" alwaysStopAt="true"/>
     <context>
       <option name="Python" value="true"/>
     </context>

--- a/tools/intellij-plugin/src/main/resources/templates/wave-components.xml
+++ b/tools/intellij-plugin/src/main/resources/templates/wave-components.xml
@@ -2266,7 +2266,7 @@
       <option name="Python" value="true"/>
     </context>
   </template>
-  <template name="w_full_textbox" value="ui.textbox(name='$name$',label='$label$',placeholder='$placeholder$',value='$value$',mask='$mask$',icon='$icon$',prefix='$prefix$',suffix='$suffix$',error='$error$',required=$required$,disabled=$disabled$,readonly=$readonly$,multiline=$multiline$,password=$password$,trigger=$trigger$,height='$height$',width='$width$',visible=$visible$,tooltip='$tooltip$'),$END$" description="Create Wave Textbox with full attributes." toReformat="true" toShortenFQNames="true">
+  <template name="w_full_textbox" value="ui.textbox(name='$name$',label='$label$',placeholder='$placeholder$',value='$value$',mask='$mask$',icon='$icon$',prefix='$prefix$',suffix='$suffix$',error='$error$',required=$required$,disabled=$disabled$,readonly=$readonly$,multiline=$multiline$,password=$password$,trigger=$trigger$,height='$height$',width='$width$',visible=$visible$,tooltip='$tooltip$',spellcheck=$spellcheck$),$END$" description="Create Wave Textbox with full attributes." toReformat="true" toShortenFQNames="true">
     <variable name="name" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="label" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="placeholder" expression="" defaultValue="" alwaysStopAt="true"/>
@@ -2286,6 +2286,7 @@
     <variable name="width" expression="" defaultValue="&quot;100%&quot;" alwaysStopAt="true"/>
     <variable name="visible" expression="" defaultValue="&quot;True&quot;" alwaysStopAt="true"/>
     <variable name="tooltip" expression="" defaultValue="" alwaysStopAt="true"/>
+    <variable name="spellcheck" expression="" defaultValue="&quot;False&quot;" alwaysStopAt="true"/>
     <context>
       <option name="Python" value="true"/>
     </context>

--- a/tools/showcase/showcase.py
+++ b/tools/showcase/showcase.py
@@ -196,6 +196,7 @@ def main():
     try:
         os.makedirs(example_file_path)
         wave_server = subprocess.Popen(['make', 'run'], cwd=os.path.join('..', '..'), stderr=subprocess.DEVNULL, preexec_fn=os.setsid) # noqa
+        time.sleep(1) # TODO: Fix race condition
         chunk_size = math.ceil(len(files) / os.cpu_count())
         file_chunks = [files[i:i + chunk_size] for i in range(0, len(files), chunk_size)]
         with Pool(len(file_chunks)) as pool:

--- a/tools/wavegen/wave-components.json
+++ b/tools/wavegen/wave-components.json
@@ -1647,7 +1647,7 @@
   "Wave Full Textbox": {
     "prefix": "w_full_textbox",
     "body": [
-      "ui.textbox(name='$1', label='$2', placeholder='$3', value='$4', mask='$5', icon='$6', prefix='$7', suffix='$8', error='$9', required=${10:False}, disabled=${11:False}, readonly=${12:False}, multiline=${13:False}, password=${14:False}, trigger=${15:False}, height='$16', width='${17:100%'}', visible=${18:True}, tooltip='$19', spellcheck=${20:False}),$0"
+      "ui.textbox(name='$1', label='$2', placeholder='$3', value='$4', mask='$5', icon='$6', prefix='$7', suffix='$8', error='$9', required=${10:False}, disabled=${11:False}, readonly=${12:False}, multiline=${13:False}, password=${14:False}, trigger=${15:False}, height='$16', width='${17:100%'}', visible=${18:True}, tooltip='$19', spellcheck=${20:True}),$0"
     ],
     "description": "Create a full Wave Textbox."
   },

--- a/tools/wavegen/wave-components.json
+++ b/tools/wavegen/wave-components.json
@@ -1647,7 +1647,7 @@
   "Wave Full Textbox": {
     "prefix": "w_full_textbox",
     "body": [
-      "ui.textbox(name='$1', label='$2', placeholder='$3', value='$4', mask='$5', icon='$6', prefix='$7', suffix='$8', error='$9', required=${10:False}, disabled=${11:False}, readonly=${12:False}, multiline=${13:False}, password=${14:False}, trigger=${15:False}, height='$16', width='${17:100%'}', visible=${18:True}, tooltip='$19'),$0"
+      "ui.textbox(name='$1', label='$2', placeholder='$3', value='$4', mask='$5', icon='$6', prefix='$7', suffix='$8', error='$9', required=${10:False}, disabled=${11:False}, readonly=${12:False}, multiline=${13:False}, password=${14:False}, trigger=${15:False}, height='$16', width='${17:100%'}', visible=${18:True}, tooltip='$19', spellcheck=${20:False}),$0"
     ],
     "description": "Create a full Wave Textbox."
   },

--- a/ui/src/textbox.tsx
+++ b/ui/src/textbox.tsx
@@ -63,7 +63,7 @@ export interface Textbox {
   visible?: B
   /** An optional tooltip message displayed when a user clicks the help icon to the right of the component. */
   tooltip?: S
-  /** True if spellcheck is enabled. */
+  /** True if the text may be checked for spelling errors. Defaults to True. */
   spellcheck?: B
 }
 

--- a/ui/src/textbox.tsx
+++ b/ui/src/textbox.tsx
@@ -63,6 +63,8 @@ export interface Textbox {
   visible?: B
   /** An optional tooltip message displayed when a user clicks the help icon to the right of the component. */
   tooltip?: S
+  /** True if spellcheck is enabled. */
+  spellcheck?: B
 }
 
 const DEBOUNCE_TIMEOUT = 500
@@ -107,6 +109,7 @@ export const
           disabled={m.disabled}
           readOnly={m.readonly}
           multiline={m.multiline}
+          spellCheck={m.spellcheck}
           type={m.password ? 'password' : undefined}
           onChange={m.trigger ? debounce(DEBOUNCE_TIMEOUT, onChange) : onChange}
         />

--- a/website/components/form/textbox.md
+++ b/website/components/form/textbox.md
@@ -122,3 +122,14 @@ q.page['example'] = ui.form_card(
     items=[ui.textbox(name='textbox_multiline', label='Multiline textarea', multiline=True)]
 )
 ```
+
+## Spellcheck
+
+Used for cases when the input should not check the word spelling (e.g. for inputing names or config parameters).
+
+```py
+q.page['example'] = ui.form_card(
+    box='1 1 2 2',
+    items=[ui.textbox(name='textbox_spellcheck_disabled', label='Spellcheck disabled', spellcheck=False)]
+)
+```

--- a/website/components/form/textbox.md
+++ b/website/components/form/textbox.md
@@ -32,7 +32,8 @@ Use `value` attribute when you want to prepopulate the textbox content.
 ```py
 q.page['example'] = ui.form_card(
     box='1 1 2 2',
-    items=[ui.textbox(name='textbox_default', label='Default value', value='Default value')]
+    items=[ui.textbox(name='textbox_default', label='Default value', 
+                      value='Default value')]
 )
 ```
 
@@ -92,7 +93,8 @@ to do is use `mask` attr with your desired format.
 ```py
 q.page['example'] = ui.form_card(
     box='1 1 2 2',
-    items=[ui.textbox(name='textbox_mask', label='With input mask', mask='(999) 999 - 9999')]
+    items=[ui.textbox(name='textbox_mask', label='With input mask', 
+                      mask='(999) 999 - 9999')]
 )
 ```
 
@@ -119,7 +121,8 @@ If you expect users to type in longer text that would hardly fit into a small te
 ```py
 q.page['example'] = ui.form_card(
     box='1 1 2 2',
-    items=[ui.textbox(name='textbox_multiline', label='Multiline textarea', multiline=True)]
+    items=[ui.textbox(name='textbox_multiline', label='Multiline textarea', 
+                      multiline=True)]
 )
 ```
 
@@ -130,6 +133,7 @@ Used for cases when the input should not check the word spelling (e.g. for input
 ```py
 q.page['example'] = ui.form_card(
     box='1 1 2 2',
-    items=[ui.textbox(name='textbox_spellcheck_disabled', label='Spellcheck disabled', spellcheck=False)]
+    items=[ui.textbox(name='textbox_spellcheck_disabled', label='Spellcheck disabled', 
+                      value="I have spellcheck disabld", spellcheck=False)]
 )
 ```


### PR DESCRIPTION
This PR introduces [requested feature](https://github.com/h2oai/wave/issues/606) to have option to disable spell checking in text input field.

See the screenshot below:
![image](https://user-images.githubusercontent.com/23740173/148210089-5c805769-8b22-498f-8ae0-a13369e0f617.png)

Closes #606 
