### PR TITLE
Allow side panel to be blocking

### DIFF
--- a/py/h2o_wave/types.py
+++ b/py/h2o_wave/types.py
@@ -8569,7 +8569,7 @@ class Dialog:
         self.closable = closable
         """True if the dialog should have a closing 'X' button at the top right corner."""
         self.blocking = blocking
-        """True to disable all actions and commands behind the dialog. Blocking dialogs should be used very sparingly, only when it is critical that the user makes a choice or provides information before they can proceed. Blocking dialogs are generally used for irreversible or potentially destructive tasks. Defaults to False."""
+        """True to disable close by clicking or tapping the area outside the dialog. A blocking Dialog also disables all other actions and commands on the page behind it. They should be used very sparingly, only when it is critical that the user makes a choice or provides information before they can proceed. Blocking Dialogs are generally used for irreversible or potentially destructive tasks. Defaults to False."""
         self.primary = primary
         """Dialog with large header banner, mutually exclusive with `closable` prop. Defaults to False."""
         self.name = name
@@ -8668,7 +8668,7 @@ class SidePanel:
         self.events = events
         """The events to capture on this side panel."""
         self.blocking = blocking
-        """True to disable all actions and commands behind the side panel and to disable dismiss when clicking outside of side panel. Defaults to False."""
+        """True to disable close by clicking or tapping the area outside the panel. Defaults to False."""
 
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""

--- a/py/h2o_wave/types.py
+++ b/py/h2o_wave/types.py
@@ -8649,12 +8649,14 @@ class SidePanel:
             width: Optional[str] = None,
             name: Optional[str] = None,
             events: Optional[List[str]] = None,
+            blocking: Optional[bool] = None,
     ):
         _guard_scalar('SidePanel.title', title, (str,), False, False, False)
         _guard_vector('SidePanel.items', items, (Component,), False, False, False)
         _guard_scalar('SidePanel.width', width, (str,), False, True, False)
         _guard_scalar('SidePanel.name', name, (str,), True, True, False)
         _guard_vector('SidePanel.events', events, (str,), False, True, False)
+        _guard_scalar('SidePanel.blocking', blocking, (bool,), False, True, False)
         self.title = title
         """The side panel's title."""
         self.items = items
@@ -8665,6 +8667,8 @@ class SidePanel:
         """An identifying name for this component."""
         self.events = events
         """The events to capture on this side panel."""
+        self.blocking = blocking
+        """True to disable all actions and commands behind the side panel and to disable dismiss when clicking outside of side panel. Defaults to False."""
 
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""
@@ -8673,12 +8677,14 @@ class SidePanel:
         _guard_scalar('SidePanel.width', self.width, (str,), False, True, False)
         _guard_scalar('SidePanel.name', self.name, (str,), True, True, False)
         _guard_vector('SidePanel.events', self.events, (str,), False, True, False)
+        _guard_scalar('SidePanel.blocking', self.blocking, (bool,), False, True, False)
         return _dump(
             title=self.title,
             items=[__e.dump() for __e in self.items],
             width=self.width,
             name=self.name,
             events=self.events,
+            blocking=self.blocking,
         )
 
     @staticmethod
@@ -8694,17 +8700,21 @@ class SidePanel:
         _guard_scalar('SidePanel.name', __d_name, (str,), True, True, False)
         __d_events: Any = __d.get('events')
         _guard_vector('SidePanel.events', __d_events, (str,), False, True, False)
+        __d_blocking: Any = __d.get('blocking')
+        _guard_scalar('SidePanel.blocking', __d_blocking, (bool,), False, True, False)
         title: str = __d_title
         items: List[Component] = [Component.load(__e) for __e in __d_items]
         width: Optional[str] = __d_width
         name: Optional[str] = __d_name
         events: Optional[List[str]] = __d_events
+        blocking: Optional[bool] = __d_blocking
         return SidePanel(
             title,
             items,
             width,
             name,
             events,
+            blocking,
         )
 
 

--- a/py/h2o_wave/types.py
+++ b/py/h2o_wave/types.py
@@ -8569,7 +8569,7 @@ class Dialog:
         self.closable = closable
         """True if the dialog should have a closing 'X' button at the top right corner."""
         self.blocking = blocking
-        """True to disable close by clicking or tapping the area outside the dialog. A blocking Dialog also disables all other actions and commands on the page behind it. They should be used very sparingly, only when it is critical that the user makes a choice or provides information before they can proceed. Blocking Dialogs are generally used for irreversible or potentially destructive tasks. Defaults to False."""
+        """True to prevent closing when clicking or tapping outside the dialog. Prevents interacting with the page behind the dialog. Defaults to False."""
         self.primary = primary
         """Dialog with large header banner, mutually exclusive with `closable` prop. Defaults to False."""
         self.name = name
@@ -8668,7 +8668,7 @@ class SidePanel:
         self.events = events
         """The events to capture on this side panel."""
         self.blocking = blocking
-        """True to disable close by clicking or tapping the area outside the panel. Defaults to False."""
+        """True to prevent closing when clicking or tapping outside the side panel. Prevents interacting with the page behind the side panel. Defaults to False."""
 
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""

--- a/py/h2o_wave/ui.py
+++ b/py/h2o_wave/ui.py
@@ -3031,7 +3031,7 @@ def dialog(
         items: The components displayed in this dialog.
         width: The width of the dialog, e.g. '400px'. Defaults to '600px'.
         closable: True if the dialog should have a closing 'X' button at the top right corner.
-        blocking: True to disable all actions and commands behind the dialog. Blocking dialogs should be used very sparingly, only when it is critical that the user makes a choice or provides information before they can proceed. Blocking dialogs are generally used for irreversible or potentially destructive tasks. Defaults to False.
+        blocking: True to disable close by clicking or tapping the area outside the dialog. A blocking Dialog also disables all other actions and commands on the page behind it. They should be used very sparingly, only when it is critical that the user makes a choice or provides information before they can proceed. Blocking Dialogs are generally used for irreversible or potentially destructive tasks. Defaults to False.
         primary: Dialog with large header banner, mutually exclusive with `closable` prop. Defaults to False.
         name: An identifying name for this component.
         events: The events to capture on this dialog.
@@ -3068,7 +3068,7 @@ def side_panel(
         width: The width of the dialog, e.g. '400px'. Defaults to '600px'.
         name: An identifying name for this component.
         events: The events to capture on this side panel.
-        blocking: True to disable all actions and commands behind the side panel and to disable dismiss when clicking outside of side panel. Defaults to False.
+        blocking: True to disable close by clicking or tapping the area outside the panel. Defaults to False.
     Returns:
         A `h2o_wave.types.SidePanel` instance.
     """

--- a/py/h2o_wave/ui.py
+++ b/py/h2o_wave/ui.py
@@ -3031,7 +3031,7 @@ def dialog(
         items: The components displayed in this dialog.
         width: The width of the dialog, e.g. '400px'. Defaults to '600px'.
         closable: True if the dialog should have a closing 'X' button at the top right corner.
-        blocking: True to disable close by clicking or tapping the area outside the dialog. A blocking Dialog also disables all other actions and commands on the page behind it. They should be used very sparingly, only when it is critical that the user makes a choice or provides information before they can proceed. Blocking Dialogs are generally used for irreversible or potentially destructive tasks. Defaults to False.
+        blocking: True to prevent closing when clicking or tapping outside the dialog. Prevents interacting with the page behind the dialog. Defaults to False.
         primary: Dialog with large header banner, mutually exclusive with `closable` prop. Defaults to False.
         name: An identifying name for this component.
         events: The events to capture on this dialog.
@@ -3068,7 +3068,7 @@ def side_panel(
         width: The width of the dialog, e.g. '400px'. Defaults to '600px'.
         name: An identifying name for this component.
         events: The events to capture on this side panel.
-        blocking: True to disable close by clicking or tapping the area outside the panel. Defaults to False.
+        blocking: True to prevent closing when clicking or tapping outside the side panel. Prevents interacting with the page behind the side panel. Defaults to False.
     Returns:
         A `h2o_wave.types.SidePanel` instance.
     """

--- a/py/h2o_wave/ui.py
+++ b/py/h2o_wave/ui.py
@@ -3056,6 +3056,7 @@ def side_panel(
         width: Optional[str] = None,
         name: Optional[str] = None,
         events: Optional[List[str]] = None,
+        blocking: Optional[bool] = None,
 ) -> SidePanel:
     """A dialog box (Dialog) is a temporary pop-up that takes focus from the page or app
     and requires people to interact with it. It’s primarily used for confirming actions,
@@ -3067,6 +3068,7 @@ def side_panel(
         width: The width of the dialog, e.g. '400px'. Defaults to '600px'.
         name: An identifying name for this component.
         events: The events to capture on this side panel.
+        blocking: True to disable all actions and commands behind the side panel and to disable dismiss when clicking outside of side panel. Defaults to False.
     Returns:
         A `h2o_wave.types.SidePanel` instance.
     """
@@ -3076,6 +3078,7 @@ def side_panel(
         width,
         name,
         events,
+        blocking,
     )
 
 

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -3512,7 +3512,7 @@ ui_layout <- function(
 #' @param items The components displayed in this dialog.
 #' @param width The width of the dialog, e.g. '400px'. Defaults to '600px'.
 #' @param closable True if the dialog should have a closing 'X' button at the top right corner.
-#' @param blocking True to disable close by clicking or tapping the area outside the dialog. A blocking Dialog also disables all other actions and commands on the page behind it. They should be used very sparingly, only when it is critical that the user makes a choice or provides information before they can proceed. Blocking Dialogs are generally used for irreversible or potentially destructive tasks. Defaults to False.
+#' @param blocking True to prevent closing when clicking or tapping outside the dialog. Prevents interacting with the page behind the dialog. Defaults to False.
 #' @param primary Dialog with large header banner, mutually exclusive with `closable` prop. Defaults to False.
 #' @param name An identifying name for this component.
 #' @param events The events to capture on this dialog.
@@ -3557,7 +3557,7 @@ ui_dialog <- function(
 #' @param width The width of the dialog, e.g. '400px'. Defaults to '600px'.
 #' @param name An identifying name for this component.
 #' @param events The events to capture on this side panel.
-#' @param blocking True to disable close by clicking or tapping the area outside the panel. Defaults to False.
+#' @param blocking True to prevent closing when clicking or tapping outside the side panel. Prevents interacting with the page behind the side panel. Defaults to False.
 #' @return A SidePanel instance.
 #' @export
 ui_side_panel <- function(

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -3557,6 +3557,7 @@ ui_dialog <- function(
 #' @param width The width of the dialog, e.g. '400px'. Defaults to '600px'.
 #' @param name An identifying name for this component.
 #' @param events The events to capture on this side panel.
+#' @param blocking True to disable all actions and commands behind the side panel and to disable dismiss when clicking outside of side panel. Defaults to False.
 #' @return A SidePanel instance.
 #' @export
 ui_side_panel <- function(
@@ -3564,18 +3565,21 @@ ui_side_panel <- function(
   items,
   width = NULL,
   name = NULL,
-  events = NULL) {
+  events = NULL,
+  blocking = NULL) {
   .guard_scalar("title", "character", title)
   .guard_vector("items", "WaveComponent", items)
   .guard_scalar("width", "character", width)
   .guard_scalar("name", "character", name)
   .guard_vector("events", "character", events)
+  .guard_scalar("blocking", "logical", blocking)
   .o <- list(
     title=title,
     items=items,
     width=width,
     name=name,
-    events=events)
+    events=events,
+    blocking=blocking)
   class(.o) <- append(class(.o), c(.wave_obj, "WaveSidePanel"))
   return(.o)
 }

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -3512,7 +3512,7 @@ ui_layout <- function(
 #' @param items The components displayed in this dialog.
 #' @param width The width of the dialog, e.g. '400px'. Defaults to '600px'.
 #' @param closable True if the dialog should have a closing 'X' button at the top right corner.
-#' @param blocking True to disable all actions and commands behind the dialog. Blocking dialogs should be used very sparingly, only when it is critical that the user makes a choice or provides information before they can proceed. Blocking dialogs are generally used for irreversible or potentially destructive tasks. Defaults to False.
+#' @param blocking True to disable close by clicking or tapping the area outside the dialog. A blocking Dialog also disables all other actions and commands on the page behind it. They should be used very sparingly, only when it is critical that the user makes a choice or provides information before they can proceed. Blocking Dialogs are generally used for irreversible or potentially destructive tasks. Defaults to False.
 #' @param primary Dialog with large header banner, mutually exclusive with `closable` prop. Defaults to False.
 #' @param name An identifying name for this component.
 #' @param events The events to capture on this dialog.
@@ -3557,7 +3557,7 @@ ui_dialog <- function(
 #' @param width The width of the dialog, e.g. '400px'. Defaults to '600px'.
 #' @param name An identifying name for this component.
 #' @param events The events to capture on this side panel.
-#' @param blocking True to disable all actions and commands behind the side panel and to disable dismiss when clicking outside of side panel. Defaults to False.
+#' @param blocking True to disable close by clicking or tapping the area outside the panel. Defaults to False.
 #' @return A SidePanel instance.
 #' @export
 ui_side_panel <- function(

--- a/tools/intellij-plugin/src/main/resources/templates/wave-components.xml
+++ b/tools/intellij-plugin/src/main/resources/templates/wave-components.xml
@@ -1843,10 +1843,11 @@
       <option name="Python" value="true"/>
     </context>
   </template>
-  <template name="w_full_side_panel" value="ui.side_panel(title='$title$',width='$width$',name='$name$',items=[&#10;	$items$	&#10;],events=[&#10;	$events$	&#10;]),$END$" description="Create Wave SidePanel with full attributes." toReformat="true" toShortenFQNames="true">
+  <template name="w_full_side_panel" value="ui.side_panel(title='$title$',width='$width$',name='$name$',blocking=$blocking$,items=[&#10;	$items$	&#10;],events=[&#10;	$events$	&#10;]),$END$" description="Create Wave SidePanel with full attributes." toReformat="true" toShortenFQNames="true">
     <variable name="title" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="width" expression="" defaultValue="&quot;600px&quot;" alwaysStopAt="true"/>
     <variable name="name" expression="" defaultValue="" alwaysStopAt="true"/>
+    <variable name="blocking" expression="" defaultValue="&quot;False&quot;" alwaysStopAt="true"/>
     <variable name="items" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="events" expression="" defaultValue="" alwaysStopAt="true"/>
     <context>

--- a/tools/wavegen/wave-components.json
+++ b/tools/wavegen/wave-components.json
@@ -1381,7 +1381,7 @@
   "Wave Full SidePanel": {
     "prefix": "w_full_side_panel",
     "body": [
-      "ui.side_panel(title='$1', width='${2:600px'}', name='$3', items=[\n\t\t$4\t\t\n], events=[\n\t\t$5\t\t\n]),$0"
+      "ui.side_panel(title='$1', width='${2:600px'}', name='$3', blocking=${4:False}, items=[\n\t\t$5\t\t\n], events=[\n\t\t$6\t\t\n]),$0"
     ],
     "description": "Create a full Wave SidePanel."
   },

--- a/ui/src/dialog.tsx
+++ b/ui/src/dialog.tsx
@@ -34,7 +34,7 @@ export interface Dialog {
   width?: S
   /** True if the dialog should have a closing 'X' button at the top right corner. */
   closable?: B
-  /** True to disable all actions and commands behind the dialog. Blocking dialogs should be used very sparingly, only when it is critical that the user makes a choice or provides information before they can proceed. Blocking dialogs are generally used for irreversible or potentially destructive tasks. Defaults to False. */
+  /** True to disable close by clicking or tapping the area outside the dialog. A blocking Dialog also disables all other actions and commands on the page behind it. They should be used very sparingly, only when it is critical that the user makes a choice or provides information before they can proceed. Blocking Dialogs are generally used for irreversible or potentially destructive tasks. Defaults to False. */
   blocking?: B
   /** Dialog with large header banner, mutually exclusive with `closable` prop. Defaults to False. */
   primary?: B
@@ -47,8 +47,8 @@ export interface Dialog {
 export default bond(() => {
   const
     onDismiss = () => {
-      const { closable, name, events } = dialogB() || {}
-      if (closable && name) {
+      const { closable, blocking, name, events } = dialogB() || {}
+      if ((closable || !blocking) && name) {
         events?.forEach(e => {
           if (e === 'dismissed') wave.emit(name, e, true)
         })
@@ -57,10 +57,11 @@ export default bond(() => {
     },
     render = () => {
       const
-        { title, width = '600px', items = [], closable, primary, blocking } = dialogB() || {},
+        { title, width = '600px', items = [], closable, primary, blocking = false } = dialogB() || {},
         dialogContentProps: Fluent.IDialogContentProps = {
           title,
           onDismiss,
+          showCloseButton: closable,
           type: closable
             ? Fluent.DialogType.close
             : primary
@@ -69,7 +70,13 @@ export default bond(() => {
         }
 
       return (
-        <Fluent.Dialog hidden={!dialogB()} dialogContentProps={dialogContentProps} modalProps={{ isBlocking: blocking }} minWidth={width} maxWidth={width}>
+        <Fluent.Dialog
+          hidden={!dialogB()}
+          onDismiss={onDismiss}
+          dialogContentProps={dialogContentProps}
+          modalProps={{ isBlocking: blocking }}
+          minWidth={width}
+          maxWidth={width}>
           <XComponents items={items} />
         </Fluent.Dialog>
       )

--- a/ui/src/dialog.tsx
+++ b/ui/src/dialog.tsx
@@ -34,7 +34,7 @@ export interface Dialog {
   width?: S
   /** True if the dialog should have a closing 'X' button at the top right corner. */
   closable?: B
-  /** True to disable close by clicking or tapping the area outside the dialog. A blocking Dialog also disables all other actions and commands on the page behind it. They should be used very sparingly, only when it is critical that the user makes a choice or provides information before they can proceed. Blocking Dialogs are generally used for irreversible or potentially destructive tasks. Defaults to False. */
+  /** True to prevent closing when clicking or tapping outside the dialog. Prevents interacting with the page behind the dialog. Defaults to False. */
   blocking?: B
   /** Dialog with large header banner, mutually exclusive with `closable` prop. Defaults to False. */
   primary?: B

--- a/ui/src/side_panel.test.tsx
+++ b/ui/src/side_panel.test.tsx
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { fireEvent, render, wait } from '@testing-library/react'
+import { fireEvent, render, wait, waitForElementToBeRemoved } from '@testing-library/react'
 import React from 'react'
 import SidePanel, { sidePanelB } from './side_panel'
 import { wave } from './ui'
@@ -20,16 +20,12 @@ import { wave } from './ui'
 const
   name = 'sidePanel',
   sidePanelProps = { name, items: [], title: 'Title' },
-  mouseEvent = { clientX: 0, clientY: 0 },
-  simulateClick = (el: Element) => {
-    fireEvent.mouseDown(el, mouseEvent)
-    fireEvent.mouseUp(el, mouseEvent)
-  },
   emitMock = jest.fn()
 
 describe('SidePanel.tsx', () => {
+  beforeAll(() => wave.emit = emitMock)
+
   beforeEach(() => {
-    jest.clearAllMocks()
     emitMock.mockReset()
     sidePanelB(sidePanelProps)
   })
@@ -53,45 +49,45 @@ describe('SidePanel.tsx', () => {
 
   it('should close side panel when clicking on X', async () => {
     const { container, queryByRole } = render(<SidePanel />)
-    fireEvent.click(container.parentElement?.querySelector('.ms-Panel-closeButton') as any)
+    fireEvent.click(container.parentElement?.querySelector('.ms-Panel-closeButton') as HTMLDivElement)
     await wait(() => expect(queryByRole('dialog')).not.toBeInTheDocument())
   })
 
   it('should fire event if specified when clicking on X', () => {
     sidePanelB({ ...sidePanelProps, events: ['dismissed'] })
     const { container } = render(<SidePanel />)
-    wave.emit = emitMock
-    fireEvent.click(container.parentElement?.querySelector('.ms-Panel-closeButton') as any)
-    expect(emitMock).toHaveBeenCalled()
-  })
-
-  it('should fire event if specified when clicking outside of side panel', () => {
-    sidePanelB({ ...sidePanelProps, events: ['dismissed'] })
-    const { container } = render(<SidePanel />)
-    wave.emit = emitMock
-    fireEvent.click(container.parentElement?.querySelector('.ms-Overlay') as any)
+    fireEvent.click(container.parentElement?.querySelector('.ms-Panel-closeButton') as HTMLDivElement)
     expect(emitMock).toHaveBeenCalled()
   })
 
   it('should not fire event if specified when clicking outside of side panel if blocking is specified', () => {
     sidePanelB({ ...sidePanelProps, blocking: true, events: ['dismissed'] })
     const { container } = render(<SidePanel />)
-    wave.emit = emitMock
-    fireEvent.click(container.parentElement?.querySelector('.ms-Overlay') as any)
+    fireEvent.click(container.parentElement?.querySelector('.ms-Overlay') as HTMLDivElement)
     expect(emitMock).not.toHaveBeenCalled()
   })
 
+  it('should fire event if specified when clicking outside of side panel', () => {
+    sidePanelB({ ...sidePanelProps, events: ['dismissed'] })
+    const { container } = render(<SidePanel />)
+    fireEvent.click(container.parentElement?.querySelector('.ms-Overlay') as HTMLDivElement)
+    expect(emitMock).toHaveBeenCalled()
+  })
+
   it('should close side panel when clicking outside of side panel', async () => {
-    const { queryByRole } = render(<SidePanel />)
-    simulateClick(document.body);
-    await wait(() => expect(queryByRole('dialog')).not.toBeInTheDocument())
+    const { container, queryByRole } = render(<SidePanel />)
+    fireEvent.click(container.parentElement?.querySelector('.ms-Overlay') as HTMLDivElement)
+    await waitForElementToBeRemoved(() => queryByRole('dialog'))
+    expect(queryByRole('dialog')).not.toBeInTheDocument()
   })
 
   it('should not close side panel when clicking outside of side panel if blocking is specified', async () => {
     sidePanelB({ ...sidePanelProps, blocking: true })
-    const { queryByRole } = render(<SidePanel />)
-    simulateClick(document.body);
-    await wait(() => expect(queryByRole('dialog')).toBeInTheDocument())
+    const { container, queryByRole } = render(<SidePanel />)
+    fireEvent.click(container.parentElement?.querySelector('.ms-Overlay') as HTMLDivElement)
+    // wait for side panel to be closed in case blocking side panel fails
+    await new Promise((res) => setTimeout(() => res('resolved'), 1000))
+    expect(queryByRole('dialog')).toBeInTheDocument()
   })
 
 })

--- a/ui/src/side_panel.tsx
+++ b/ui/src/side_panel.tsx
@@ -36,7 +36,7 @@ export interface SidePanel {
   name?: Id
   /** The events to capture on this side panel. */
   events?: S[]
-  /** True to disable all actions and commands behind the side panel and to disable dismiss when clicking outside of side panel. Defaults to False. */
+  /** True to disable close by clicking or tapping the area outside the panel. Defaults to False. */
   blocking?: B
 }
 
@@ -44,14 +44,14 @@ export default bond(() => {
   const
     onDismiss = () => {
       const
-        { name, events } = sidePanelB() || {},
+        { blocking, name, events } = sidePanelB() || {},
         ev = events?.find(e => e === 'dismissed')
 
-      if (ev && name) wave.emit(name, ev, true)
+      if (!blocking && ev && name) wave.emit(name, ev, true)
       sidePanelB(null)
     },
     render = () => {
-      const { title, width = '600px', items = [], blocking } = sidePanelB() || {}
+      const { title, width = '600px', items = [], blocking = false } = sidePanelB() || {}
       return (
         <Fluent.Panel
           isOpen={!!sidePanelB()}
@@ -59,6 +59,7 @@ export default bond(() => {
           type={Fluent.PanelType.custom}
           customWidth={width}
           onDismiss={onDismiss}
+          overlayProps={blocking ? { style: { cursor: 'default' } } : undefined}
           isBlocking={true}
           isLightDismiss={!blocking}>
           <XComponents items={items} />

--- a/ui/src/side_panel.tsx
+++ b/ui/src/side_panel.tsx
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import * as Fluent from '@fluentui/react'
-import { Box, box, Id, S } from 'h2o-wave'
+import { B, Box, box, Id, S } from 'h2o-wave'
 import React from 'react'
 import { Component, XComponents } from './form'
 import { bond, wave } from './ui'
@@ -36,6 +36,8 @@ export interface SidePanel {
   name?: Id
   /** The events to capture on this side panel. */
   events?: S[]
+  /** True to disable all actions and commands behind the side panel and to disable dismiss when clicking outside of side panel. Defaults to False. */
+  blocking?: B
 }
 
 export default bond(() => {
@@ -49,9 +51,16 @@ export default bond(() => {
       sidePanelB(null)
     },
     render = () => {
-      const { title, width = '600px', items = [] } = sidePanelB() || {}
+      const { title, width = '600px', items = [], blocking } = sidePanelB() || {}
       return (
-        <Fluent.Panel isOpen={!!sidePanelB()} headerText={title} type={Fluent.PanelType.custom} customWidth={width} onDismiss={onDismiss}>
+        <Fluent.Panel
+          isOpen={!!sidePanelB()}
+          headerText={title}
+          type={Fluent.PanelType.custom}
+          customWidth={width}
+          onDismiss={onDismiss}
+          isBlocking={true}
+          isLightDismiss={!blocking}>
           <XComponents items={items} />
         </Fluent.Panel >
       )

--- a/ui/src/side_panel.tsx
+++ b/ui/src/side_panel.tsx
@@ -36,7 +36,7 @@ export interface SidePanel {
   name?: Id
   /** The events to capture on this side panel. */
   events?: S[]
-  /** True to disable close by clicking or tapping the area outside the panel. Defaults to False. */
+  /** True to prevent closing when clicking or tapping outside the side panel. Prevents interacting with the page behind the side panel. Defaults to False. */
   blocking?: B
 }
 
@@ -60,7 +60,7 @@ export default bond(() => {
           customWidth={width}
           onDismiss={onDismiss}
           overlayProps={blocking ? { style: { cursor: 'default' } } : undefined}
-          isBlocking={true}
+          isBlocking
           isLightDismiss={!blocking}>
           <XComponents items={items} />
         </Fluent.Panel >


### PR DESCRIPTION
This PR addresses issue #1093  that user cannot allow side panel to be blocking.

The issue is resolved by adding `blocking` property to side panel (see examples).

**Examples:**

- `blocking=False` (default)

   https://user-images.githubusercontent.com/23740173/149329423-6e639d94-c908-4ee5-b8c8-fed3d47ae230.mov

- `blocking=True`

   https://user-images.githubusercontent.com/23740173/149329460-6728331e-8d20-4265-96ea-9533d0499f25.mov


The changes were made also to [dialog](https://github.com/h2oai/wave/blob/master/ui/src/dialog.tsx) where already existing `blocking` property now matches the same behaviour as on side panel examples above.

Closes issue #1093 