### PR TITLE
feat: Notification bar.

### DIFF
--- a/py/examples/message_bar.py
+++ b/py/examples/message_bar.py
@@ -7,16 +7,21 @@ from h2o_wave import site, ui
 page = site['/demo']
 
 page['example'] = ui.form_card(
-    box='1 1 4 10',
+    box='1 1 3 10',
     items=[
         ui.message_bar(type='blocked', text='This action is blocked.'),
         ui.message_bar(type='error', text='This is an error message'),
         ui.message_bar(type='warning', text='This is a warning message.'),
         ui.message_bar(type='info', text='This is an information message.'),
-        ui.message_bar(type='success', text='This is an success message.'),
+        ui.message_bar(type='success', text='This is a success message.'),
         ui.message_bar(type='danger', text='This is a danger message.'),
         ui.message_bar(type='success', text='This is a **MARKDOWN** _message_.'),
         ui.message_bar(type='success', text='This is an <b>HTML</b> <i>message</i>.'),
+        ui.message_bar(type='info', text='With a button.', buttons=[ui.button(name='btn', label='Button')]),
+        ui.message_bar(type='info', text='With a button as link.',
+                       buttons=[ui.button(name='btn', label='Button', link=True)]),
+        ui.message_bar(type='info', text='With multiline text that should hopefully span at least 2 rows',
+                       buttons=[ui.button(name='btn', label='Button')]),
     ]
 )
 page.save()

--- a/py/examples/meta_notification_bar.py
+++ b/py/examples/meta_notification_bar.py
@@ -1,0 +1,61 @@
+# Meta / Notification bar
+# Display a notification bar #notification_bar. #meta
+# Use this kind of notification when an immediate user feedback is needed. For cases when
+# the feedback is not immediate (long-running jobs), use ui.notification as it will
+# be visible even when the user is not currently focusing browser tab with your Wave app.
+# ---
+from h2o_wave import main, app, Q, ui
+
+
+@app('/demo')
+async def serve(q: Q):
+    if not q.client.initialized:
+        q.page['form'] = ui.form_card(box='1 1 2 4', items=[
+            ui.button(name='top_right', label='Success top-right'),
+            ui.button(name='top_center', label='Error top-center'),
+            ui.button(name='top_left', label='Warning top-left'),
+            ui.button(name='bottom_right', label='Info bottom-right'),
+            ui.button(name='bottom_center', label='Info bottom-center'),
+            ui.button(name='bottom_left', label='Info bottom-left'),
+        ])
+        q.client.initialized = True
+    if q.args.top_right:
+        q.page['meta'] = ui.meta_card(box='', notification_bar=ui.notification_bar(
+            text='Success notification',
+            type='success',
+            position='top-right',
+            buttons=[ui.button(name='btn1', label='Button 1', link=True)]
+        ))
+    if q.args.top_center:
+        q.page['meta'] = ui.meta_card(box='', notification_bar=ui.notification_bar(
+            text='Error notification that should hopefully span at least two lines',
+            type='error',
+            position='top-center',
+            buttons=[
+                ui.button(name='btn1', label='Button 1'),
+                ui.button(name='btn2', label='Button 2')
+            ]
+        ))
+    if q.args.top_left:
+        q.page['meta'] = ui.meta_card(box='', notification_bar=ui.notification_bar(
+            text='Warning notification',
+            type='warning',
+            position='top-left',
+        ))
+    if q.args.bottom_right:
+        q.page['meta'] = ui.meta_card(box='', notification_bar=ui.notification_bar(
+            text='Info notification',
+            type='info',
+            position='bottom-right',
+        ))
+    if q.args.bottom_center:
+        q.page['meta'] = ui.meta_card(box='', notification_bar=ui.notification_bar(
+            text='Info notification',
+            position='bottom-center',
+        ))
+    if q.args.bottom_left:
+        q.page['meta'] = ui.meta_card(box='', notification_bar=ui.notification_bar(
+            text='Default notification',
+            position='bottom-left',
+        ))
+    await q.page.save()

--- a/py/examples/tour.conf
+++ b/py/examples/tour.conf
@@ -194,6 +194,7 @@ meta_side_panel.py
 meta_title.py
 meta_icon.py
 meta_notification.py
+meta_notification_bar.py
 meta_refresh.py
 meta_redirect.py
 meta_theme.py

--- a/py/h2o_wave/types.py
+++ b/py/h2o_wave/types.py
@@ -890,44 +890,44 @@ class MessageBar:
             type: Optional[str] = None,
             text: Optional[str] = None,
             name: Optional[str] = None,
-            buttons: Optional[List['Component']] = None,
             width: Optional[str] = None,
             visible: Optional[bool] = None,
+            buttons: Optional[List['Component']] = None,
     ):
         _guard_enum('MessageBar.type', type, _MessageBarType, True)
         _guard_scalar('MessageBar.text', text, (str,), False, True, False)
         _guard_scalar('MessageBar.name', name, (str,), False, True, False)
-        _guard_vector('MessageBar.buttons', buttons, (Component,), False, True, False)
         _guard_scalar('MessageBar.width', width, (str,), False, True, False)
         _guard_scalar('MessageBar.visible', visible, (bool,), False, True, False)
+        _guard_vector('MessageBar.buttons', buttons, (Component,), False, True, False)
         self.type = type
         """The icon and color of the message bar. One of 'info', 'error', 'warning', 'success', 'danger', 'blocked'. See enum h2o_wave.ui.MessageBarType."""
         self.text = text
         """The text displayed on the message bar."""
         self.name = name
         """An identifying name for this component."""
-        self.buttons = buttons
-        """Specify one or more action buttons."""
         self.width = width
         """The width of the message bar, e.g. '100px'. Defaults to '100%'."""
         self.visible = visible
         """True if the component should be visible. Defaults to True."""
+        self.buttons = buttons
+        """Specify one or more action buttons."""
 
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""
         _guard_enum('MessageBar.type', self.type, _MessageBarType, True)
         _guard_scalar('MessageBar.text', self.text, (str,), False, True, False)
         _guard_scalar('MessageBar.name', self.name, (str,), False, True, False)
-        _guard_vector('MessageBar.buttons', self.buttons, (Component,), False, True, False)
         _guard_scalar('MessageBar.width', self.width, (str,), False, True, False)
         _guard_scalar('MessageBar.visible', self.visible, (bool,), False, True, False)
+        _guard_vector('MessageBar.buttons', self.buttons, (Component,), False, True, False)
         return _dump(
             type=self.type,
             text=self.text,
             name=self.name,
-            buttons=None if self.buttons is None else [__e.dump() for __e in self.buttons],
             width=self.width,
             visible=self.visible,
+            buttons=None if self.buttons is None else [__e.dump() for __e in self.buttons],
         )
 
     @staticmethod
@@ -939,25 +939,25 @@ class MessageBar:
         _guard_scalar('MessageBar.text', __d_text, (str,), False, True, False)
         __d_name: Any = __d.get('name')
         _guard_scalar('MessageBar.name', __d_name, (str,), False, True, False)
-        __d_buttons: Any = __d.get('buttons')
-        _guard_vector('MessageBar.buttons', __d_buttons, (dict,), False, True, False)
         __d_width: Any = __d.get('width')
         _guard_scalar('MessageBar.width', __d_width, (str,), False, True, False)
         __d_visible: Any = __d.get('visible')
         _guard_scalar('MessageBar.visible', __d_visible, (bool,), False, True, False)
+        __d_buttons: Any = __d.get('buttons')
+        _guard_vector('MessageBar.buttons', __d_buttons, (dict,), False, True, False)
         type: Optional[str] = __d_type
         text: Optional[str] = __d_text
         name: Optional[str] = __d_name
-        buttons: Optional[List['Component']] = None if __d_buttons is None else [Component.load(__e) for __e in __d_buttons]
         width: Optional[str] = __d_width
         visible: Optional[bool] = __d_visible
+        buttons: Optional[List['Component']] = None if __d_buttons is None else [Component.load(__e) for __e in __d_buttons]
         return MessageBar(
             type,
             text,
             name,
-            buttons,
             width,
             visible,
+            buttons,
         )
 
 
@@ -8406,7 +8406,7 @@ class NotificationBar:
         self.type = type
         """The icon and color of the notification bar. Defaults to 'info'. One of 'info', 'error', 'warning', 'success', 'danger', 'blocked'. See enum h2o_wave.ui.NotificationBarType."""
         self.timeout = timeout
-        """When should the notification bar disappear in seconds. Defaults to 5."""
+        """How long the notification stays visible, in seconds. Defaults to 5."""
         self.buttons = buttons
         """Specify one or more action buttons."""
         self.position = position

--- a/py/h2o_wave/types.py
+++ b/py/h2o_wave/types.py
@@ -890,12 +890,14 @@ class MessageBar:
             type: Optional[str] = None,
             text: Optional[str] = None,
             name: Optional[str] = None,
+            buttons: Optional[List['Component']] = None,
             width: Optional[str] = None,
             visible: Optional[bool] = None,
     ):
         _guard_enum('MessageBar.type', type, _MessageBarType, True)
         _guard_scalar('MessageBar.text', text, (str,), False, True, False)
         _guard_scalar('MessageBar.name', name, (str,), False, True, False)
+        _guard_vector('MessageBar.buttons', buttons, (Component,), False, True, False)
         _guard_scalar('MessageBar.width', width, (str,), False, True, False)
         _guard_scalar('MessageBar.visible', visible, (bool,), False, True, False)
         self.type = type
@@ -904,6 +906,8 @@ class MessageBar:
         """The text displayed on the message bar."""
         self.name = name
         """An identifying name for this component."""
+        self.buttons = buttons
+        """Specify one or more action buttons."""
         self.width = width
         """The width of the message bar, e.g. '100px'. Defaults to '100%'."""
         self.visible = visible
@@ -914,12 +918,14 @@ class MessageBar:
         _guard_enum('MessageBar.type', self.type, _MessageBarType, True)
         _guard_scalar('MessageBar.text', self.text, (str,), False, True, False)
         _guard_scalar('MessageBar.name', self.name, (str,), False, True, False)
+        _guard_vector('MessageBar.buttons', self.buttons, (Component,), False, True, False)
         _guard_scalar('MessageBar.width', self.width, (str,), False, True, False)
         _guard_scalar('MessageBar.visible', self.visible, (bool,), False, True, False)
         return _dump(
             type=self.type,
             text=self.text,
             name=self.name,
+            buttons=None if self.buttons is None else [__e.dump() for __e in self.buttons],
             width=self.width,
             visible=self.visible,
         )
@@ -933,6 +939,8 @@ class MessageBar:
         _guard_scalar('MessageBar.text', __d_text, (str,), False, True, False)
         __d_name: Any = __d.get('name')
         _guard_scalar('MessageBar.name', __d_name, (str,), False, True, False)
+        __d_buttons: Any = __d.get('buttons')
+        _guard_vector('MessageBar.buttons', __d_buttons, (dict,), False, True, False)
         __d_width: Any = __d.get('width')
         _guard_scalar('MessageBar.width', __d_width, (str,), False, True, False)
         __d_visible: Any = __d.get('visible')
@@ -940,12 +948,14 @@ class MessageBar:
         type: Optional[str] = __d_type
         text: Optional[str] = __d_text
         name: Optional[str] = __d_name
+        buttons: Optional[List['Component']] = None if __d_buttons is None else [Component.load(__e) for __e in __d_buttons]
         width: Optional[str] = __d_width
         visible: Optional[bool] = __d_visible
         return MessageBar(
             type,
             text,
             name,
+            buttons,
             width,
             visible,
         )
@@ -8346,6 +8356,112 @@ class MarkupCard:
         )
 
 
+_NotificationBarType = ['info', 'error', 'warning', 'success', 'danger', 'blocked']
+
+
+class NotificationBarType:
+    INFO = 'info'
+    ERROR = 'error'
+    WARNING = 'warning'
+    SUCCESS = 'success'
+    DANGER = 'danger'
+    BLOCKED = 'blocked'
+
+
+_NotificationBarPosition = ['top-right', 'bottom-right', 'bottom-center', 'bottom-left', 'top-left', 'top-center']
+
+
+class NotificationBarPosition:
+    TOP_RIGHT = 'top-right'
+    BOTTOM_RIGHT = 'bottom-right'
+    BOTTOM_CENTER = 'bottom-center'
+    BOTTOM_LEFT = 'bottom-left'
+    TOP_LEFT = 'top-left'
+    TOP_CENTER = 'top-center'
+
+
+class NotificationBar:
+    """Create a notification bar.
+
+    A notification bar is an area at the edge of a primary view that displays relevant status information.
+    You can use a notification bar to tell the user about a result of an action, e.g. "Data has been successfully saved".
+    """
+    def __init__(
+            self,
+            text: str,
+            type: Optional[str] = None,
+            timeout: Optional[int] = None,
+            buttons: Optional[List[Component]] = None,
+            position: Optional[str] = None,
+            events: Optional[List[str]] = None,
+    ):
+        _guard_scalar('NotificationBar.text', text, (str,), False, False, False)
+        _guard_enum('NotificationBar.type', type, _NotificationBarType, True)
+        _guard_scalar('NotificationBar.timeout', timeout, (int,), False, True, False)
+        _guard_vector('NotificationBar.buttons', buttons, (Component,), False, True, False)
+        _guard_enum('NotificationBar.position', position, _NotificationBarPosition, True)
+        _guard_vector('NotificationBar.events', events, (str,), False, True, False)
+        self.text = text
+        """The text displayed on the notification bar."""
+        self.type = type
+        """The icon and color of the notification bar. Defaults to 'info'. One of 'info', 'error', 'warning', 'success', 'danger', 'blocked'. See enum h2o_wave.ui.NotificationBarType."""
+        self.timeout = timeout
+        """When should the notification bar disappear in seconds. Defaults to 5."""
+        self.buttons = buttons
+        """Specify one or more action buttons."""
+        self.position = position
+        """Specify the location of notification. Defaults to 'top-right'. One of 'top-right', 'bottom-right', 'bottom-center', 'bottom-left', 'top-left', 'top-center'. See enum h2o_wave.ui.NotificationBarPosition."""
+        self.events = events
+        """The events to capture on this notification bar."""
+
+    def dump(self) -> Dict:
+        """Returns the contents of this object as a dict."""
+        _guard_scalar('NotificationBar.text', self.text, (str,), False, False, False)
+        _guard_enum('NotificationBar.type', self.type, _NotificationBarType, True)
+        _guard_scalar('NotificationBar.timeout', self.timeout, (int,), False, True, False)
+        _guard_vector('NotificationBar.buttons', self.buttons, (Component,), False, True, False)
+        _guard_enum('NotificationBar.position', self.position, _NotificationBarPosition, True)
+        _guard_vector('NotificationBar.events', self.events, (str,), False, True, False)
+        return _dump(
+            text=self.text,
+            type=self.type,
+            timeout=self.timeout,
+            buttons=None if self.buttons is None else [__e.dump() for __e in self.buttons],
+            position=self.position,
+            events=self.events,
+        )
+
+    @staticmethod
+    def load(__d: Dict) -> 'NotificationBar':
+        """Creates an instance of this class using the contents of a dict."""
+        __d_text: Any = __d.get('text')
+        _guard_scalar('NotificationBar.text', __d_text, (str,), False, False, False)
+        __d_type: Any = __d.get('type')
+        _guard_enum('NotificationBar.type', __d_type, _NotificationBarType, True)
+        __d_timeout: Any = __d.get('timeout')
+        _guard_scalar('NotificationBar.timeout', __d_timeout, (int,), False, True, False)
+        __d_buttons: Any = __d.get('buttons')
+        _guard_vector('NotificationBar.buttons', __d_buttons, (dict,), False, True, False)
+        __d_position: Any = __d.get('position')
+        _guard_enum('NotificationBar.position', __d_position, _NotificationBarPosition, True)
+        __d_events: Any = __d.get('events')
+        _guard_vector('NotificationBar.events', __d_events, (str,), False, True, False)
+        text: str = __d_text
+        type: Optional[str] = __d_type
+        timeout: Optional[int] = __d_timeout
+        buttons: Optional[List[Component]] = None if __d_buttons is None else [Component.load(__e) for __e in __d_buttons]
+        position: Optional[str] = __d_position
+        events: Optional[List[str]] = __d_events
+        return NotificationBar(
+            text,
+            type,
+            timeout,
+            buttons,
+            position,
+            events,
+        )
+
+
 _ZoneDirection = ['row', 'column']
 
 
@@ -9101,6 +9217,7 @@ class MetaCard:
             title: Optional[str] = None,
             refresh: Optional[int] = None,
             notification: Optional[str] = None,
+            notification_bar: Optional[NotificationBar] = None,
             redirect: Optional[str] = None,
             icon: Optional[str] = None,
             layouts: Optional[List[Layout]] = None,
@@ -9119,6 +9236,7 @@ class MetaCard:
         _guard_scalar('MetaCard.title', title, (str,), False, True, False)
         _guard_scalar('MetaCard.refresh', refresh, (int,), False, True, False)
         _guard_scalar('MetaCard.notification', notification, (str,), False, True, False)
+        _guard_scalar('MetaCard.notification_bar', notification_bar, (NotificationBar,), False, True, False)
         _guard_scalar('MetaCard.redirect', redirect, (str,), False, True, False)
         _guard_scalar('MetaCard.icon', icon, (str,), False, True, False)
         _guard_vector('MetaCard.layouts', layouts, (Layout,), False, True, False)
@@ -9140,6 +9258,8 @@ class MetaCard:
         """Refresh rate in seconds. A value of 0 turns off live-updates. Values != 0 are currently ignored (reserved for future use)."""
         self.notification = notification
         """Display a desktop notification."""
+        self.notification_bar = notification_bar
+        """Display an in-app notification bar."""
         self.redirect = redirect
         """Redirect the page to a new URL."""
         self.icon = icon
@@ -9173,6 +9293,7 @@ class MetaCard:
         _guard_scalar('MetaCard.title', self.title, (str,), False, True, False)
         _guard_scalar('MetaCard.refresh', self.refresh, (int,), False, True, False)
         _guard_scalar('MetaCard.notification', self.notification, (str,), False, True, False)
+        _guard_scalar('MetaCard.notification_bar', self.notification_bar, (NotificationBar,), False, True, False)
         _guard_scalar('MetaCard.redirect', self.redirect, (str,), False, True, False)
         _guard_scalar('MetaCard.icon', self.icon, (str,), False, True, False)
         _guard_vector('MetaCard.layouts', self.layouts, (Layout,), False, True, False)
@@ -9192,6 +9313,7 @@ class MetaCard:
             title=self.title,
             refresh=self.refresh,
             notification=self.notification,
+            notification_bar=None if self.notification_bar is None else self.notification_bar.dump(),
             redirect=self.redirect,
             icon=self.icon,
             layouts=None if self.layouts is None else [__e.dump() for __e in self.layouts],
@@ -9218,6 +9340,8 @@ class MetaCard:
         _guard_scalar('MetaCard.refresh', __d_refresh, (int,), False, True, False)
         __d_notification: Any = __d.get('notification')
         _guard_scalar('MetaCard.notification', __d_notification, (str,), False, True, False)
+        __d_notification_bar: Any = __d.get('notification_bar')
+        _guard_scalar('MetaCard.notification_bar', __d_notification_bar, (dict,), False, True, False)
         __d_redirect: Any = __d.get('redirect')
         _guard_scalar('MetaCard.redirect', __d_redirect, (str,), False, True, False)
         __d_icon: Any = __d.get('icon')
@@ -9248,6 +9372,7 @@ class MetaCard:
         title: Optional[str] = __d_title
         refresh: Optional[int] = __d_refresh
         notification: Optional[str] = __d_notification
+        notification_bar: Optional[NotificationBar] = None if __d_notification_bar is None else NotificationBar.load(__d_notification_bar)
         redirect: Optional[str] = __d_redirect
         icon: Optional[str] = __d_icon
         layouts: Optional[List[Layout]] = None if __d_layouts is None else [Layout.load(__e) for __e in __d_layouts]
@@ -9266,6 +9391,7 @@ class MetaCard:
             title,
             refresh,
             notification,
+            notification_bar,
             redirect,
             icon,
             layouts,

--- a/py/h2o_wave/ui.py
+++ b/py/h2o_wave/ui.py
@@ -349,6 +349,7 @@ def message_bar(
         type: Optional[str] = None,
         text: Optional[str] = None,
         name: Optional[str] = None,
+        buttons: Optional[List[Component]] = None,
         width: Optional[str] = None,
         visible: Optional[bool] = None,
 ) -> Component:
@@ -362,6 +363,7 @@ def message_bar(
         type: The icon and color of the message bar. One of 'info', 'error', 'warning', 'success', 'danger', 'blocked'. See enum h2o_wave.ui.MessageBarType.
         text: The text displayed on the message bar.
         name: An identifying name for this component.
+        buttons: Specify one or more action buttons.
         width: The width of the message bar, e.g. '100px'. Defaults to '100%'.
         visible: True if the component should be visible. Defaults to True.
     Returns:
@@ -371,6 +373,7 @@ def message_bar(
         type,
         text,
         name,
+        buttons,
         width,
         visible,
     ))
@@ -2958,6 +2961,39 @@ def markup_card(
     )
 
 
+def notification_bar(
+        text: str,
+        type: Optional[str] = None,
+        timeout: Optional[int] = None,
+        buttons: Optional[List[Component]] = None,
+        position: Optional[str] = None,
+        events: Optional[List[str]] = None,
+) -> NotificationBar:
+    """Create a notification bar.
+
+    A notification bar is an area at the edge of a primary view that displays relevant status information.
+    You can use a notification bar to tell the user about a result of an action, e.g. "Data has been successfully saved".
+
+    Args:
+        text: The text displayed on the notification bar.
+        type: The icon and color of the notification bar. Defaults to 'info'. One of 'info', 'error', 'warning', 'success', 'danger', 'blocked'. See enum h2o_wave.ui.NotificationBarType.
+        timeout: When should the notification bar disappear in seconds. Defaults to 5.
+        buttons: Specify one or more action buttons.
+        position: Specify the location of notification. Defaults to 'top-right'. One of 'top-right', 'bottom-right', 'bottom-center', 'bottom-left', 'top-left', 'top-center'. See enum h2o_wave.ui.NotificationBarPosition.
+        events: The events to capture on this notification bar.
+    Returns:
+        A `h2o_wave.types.NotificationBar` instance.
+    """
+    return NotificationBar(
+        text,
+        type,
+        timeout,
+        buttons,
+        position,
+        events,
+    )
+
+
 def zone(
         name: str,
         size: Optional[str] = None,
@@ -3237,6 +3273,7 @@ def meta_card(
         title: Optional[str] = None,
         refresh: Optional[int] = None,
         notification: Optional[str] = None,
+        notification_bar: Optional[NotificationBar] = None,
         redirect: Optional[str] = None,
         icon: Optional[str] = None,
         layouts: Optional[List[Layout]] = None,
@@ -3261,6 +3298,7 @@ def meta_card(
         title: The title of the page.
         refresh: Refresh rate in seconds. A value of 0 turns off live-updates. Values != 0 are currently ignored (reserved for future use).
         notification: Display a desktop notification.
+        notification_bar: Display an in-app notification bar.
         redirect: Redirect the page to a new URL.
         icon: Shortcut icon path. Preferably a `.png` file (`.ico` files may not work in mobile browsers). Not supported in Safari.
         layouts: The layouts supported by this page.
@@ -3282,6 +3320,7 @@ def meta_card(
         title,
         refresh,
         notification,
+        notification_bar,
         redirect,
         icon,
         layouts,

--- a/py/h2o_wave/ui.py
+++ b/py/h2o_wave/ui.py
@@ -349,9 +349,9 @@ def message_bar(
         type: Optional[str] = None,
         text: Optional[str] = None,
         name: Optional[str] = None,
-        buttons: Optional[List[Component]] = None,
         width: Optional[str] = None,
         visible: Optional[bool] = None,
+        buttons: Optional[List[Component]] = None,
 ) -> Component:
     """Create a message bar.
 
@@ -363,9 +363,9 @@ def message_bar(
         type: The icon and color of the message bar. One of 'info', 'error', 'warning', 'success', 'danger', 'blocked'. See enum h2o_wave.ui.MessageBarType.
         text: The text displayed on the message bar.
         name: An identifying name for this component.
-        buttons: Specify one or more action buttons.
         width: The width of the message bar, e.g. '100px'. Defaults to '100%'.
         visible: True if the component should be visible. Defaults to True.
+        buttons: Specify one or more action buttons.
     Returns:
         A `h2o_wave.types.MessageBar` instance.
     """
@@ -373,9 +373,9 @@ def message_bar(
         type,
         text,
         name,
-        buttons,
         width,
         visible,
+        buttons,
     ))
 
 
@@ -2977,7 +2977,7 @@ def notification_bar(
     Args:
         text: The text displayed on the notification bar.
         type: The icon and color of the notification bar. Defaults to 'info'. One of 'info', 'error', 'warning', 'success', 'danger', 'blocked'. See enum h2o_wave.ui.NotificationBarType.
-        timeout: When should the notification bar disappear in seconds. Defaults to 5.
+        timeout: How long the notification stays visible, in seconds. Defaults to 5.
         buttons: Specify one or more action buttons.
         position: Specify the location of notification. Defaults to 'top-right'. One of 'top-right', 'bottom-right', 'bottom-center', 'bottom-left', 'top-left', 'top-center'. See enum h2o_wave.ui.NotificationBarPosition.
         events: The events to capture on this notification bar.

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -429,31 +429,31 @@ ui_progress <- function(
 #'   One of 'info', 'error', 'warning', 'success', 'danger', 'blocked'. See enum h2o_wave.ui.MessageBarType.
 #' @param text The text displayed on the message bar.
 #' @param name An identifying name for this component.
-#' @param buttons Specify one or more action buttons.
 #' @param width The width of the message bar, e.g. '100px'. Defaults to '100%'.
 #' @param visible True if the component should be visible. Defaults to True.
+#' @param buttons Specify one or more action buttons.
 #' @return A MessageBar instance.
 #' @export
 ui_message_bar <- function(
   type = NULL,
   text = NULL,
   name = NULL,
-  buttons = NULL,
   width = NULL,
-  visible = NULL) {
+  visible = NULL,
+  buttons = NULL) {
   # TODO Validate type
   .guard_scalar("text", "character", text)
   .guard_scalar("name", "character", name)
-  .guard_vector("buttons", "WaveComponent", buttons)
   .guard_scalar("width", "character", width)
   .guard_scalar("visible", "logical", visible)
+  .guard_vector("buttons", "WaveComponent", buttons)
   .o <- list(message_bar=list(
     type=type,
     text=text,
     name=name,
-    buttons=buttons,
     width=width,
-    visible=visible))
+    visible=visible,
+    buttons=buttons))
   class(.o) <- append(class(.o), c(.wave_obj, "WaveComponent"))
   return(.o)
 }
@@ -3437,7 +3437,7 @@ ui_markup_card <- function(
 #' @param text The text displayed on the notification bar.
 #' @param type The icon and color of the notification bar. Defaults to 'info'.
 #'   One of 'info', 'error', 'warning', 'success', 'danger', 'blocked'. See enum h2o_wave.ui.NotificationBarType.
-#' @param timeout When should the notification bar disappear in seconds. Defaults to 5.
+#' @param timeout How long the notification stays visible, in seconds. Defaults to 5.
 #' @param buttons Specify one or more action buttons.
 #' @param position Specify the location of notification. Defaults to 'top-right'.
 #'   One of 'top-right', 'bottom-right', 'bottom-center', 'bottom-left', 'top-left', 'top-center'. See enum h2o_wave.ui.NotificationBarPosition.

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -429,6 +429,7 @@ ui_progress <- function(
 #'   One of 'info', 'error', 'warning', 'success', 'danger', 'blocked'. See enum h2o_wave.ui.MessageBarType.
 #' @param text The text displayed on the message bar.
 #' @param name An identifying name for this component.
+#' @param buttons Specify one or more action buttons.
 #' @param width The width of the message bar, e.g. '100px'. Defaults to '100%'.
 #' @param visible True if the component should be visible. Defaults to True.
 #' @return A MessageBar instance.
@@ -437,17 +438,20 @@ ui_message_bar <- function(
   type = NULL,
   text = NULL,
   name = NULL,
+  buttons = NULL,
   width = NULL,
   visible = NULL) {
   # TODO Validate type
   .guard_scalar("text", "character", text)
   .guard_scalar("name", "character", name)
+  .guard_vector("buttons", "WaveComponent", buttons)
   .guard_scalar("width", "character", width)
   .guard_scalar("visible", "logical", visible)
   .o <- list(message_bar=list(
     type=type,
     text=text,
     name=name,
+    buttons=buttons,
     width=width,
     visible=visible))
   class(.o) <- append(class(.o), c(.wave_obj, "WaveComponent"))
@@ -3425,6 +3429,45 @@ ui_markup_card <- function(
   return(.o)
 }
 
+#' Create a notification bar.
+#' 
+#' A notification bar is an area at the edge of a primary view that displays relevant status information.
+#' You can use a notification bar to tell the user about a result of an action, e.g. "Data has been successfully saved".
+#'
+#' @param text The text displayed on the notification bar.
+#' @param type The icon and color of the notification bar. Defaults to 'info'.
+#'   One of 'info', 'error', 'warning', 'success', 'danger', 'blocked'. See enum h2o_wave.ui.NotificationBarType.
+#' @param timeout When should the notification bar disappear in seconds. Defaults to 5.
+#' @param buttons Specify one or more action buttons.
+#' @param position Specify the location of notification. Defaults to 'top-right'.
+#'   One of 'top-right', 'bottom-right', 'bottom-center', 'bottom-left', 'top-left', 'top-center'. See enum h2o_wave.ui.NotificationBarPosition.
+#' @param events The events to capture on this notification bar.
+#' @return A NotificationBar instance.
+#' @export
+ui_notification_bar <- function(
+  text,
+  type = NULL,
+  timeout = NULL,
+  buttons = NULL,
+  position = NULL,
+  events = NULL) {
+  .guard_scalar("text", "character", text)
+  # TODO Validate type
+  .guard_scalar("timeout", "numeric", timeout)
+  .guard_vector("buttons", "WaveComponent", buttons)
+  # TODO Validate position
+  .guard_vector("events", "character", events)
+  .o <- list(
+    text=text,
+    type=type,
+    timeout=timeout,
+    buttons=buttons,
+    position=position,
+    events=events)
+  class(.o) <- append(class(.o), c(.wave_obj, "WaveNotificationBar"))
+  return(.o)
+}
+
 #' Represents an zone within a page layout.
 #'
 #' @param name An identifying name for this zone.
@@ -3752,6 +3795,7 @@ ui_stylesheet <- function(
 #' @param title The title of the page.
 #' @param refresh Refresh rate in seconds. A value of 0 turns off live-updates. Values != 0 are currently ignored (reserved for future use).
 #' @param notification Display a desktop notification.
+#' @param notification_bar Display an in-app notification bar.
 #' @param redirect Redirect the page to a new URL.
 #' @param icon Shortcut icon path. Preferably a `.png` file (`.ico` files may not work in mobile browsers).
 #'   Not supported in Safari.
@@ -3773,6 +3817,7 @@ ui_meta_card <- function(
   title = NULL,
   refresh = NULL,
   notification = NULL,
+  notification_bar = NULL,
   redirect = NULL,
   icon = NULL,
   layouts = NULL,
@@ -3790,6 +3835,7 @@ ui_meta_card <- function(
   .guard_scalar("title", "character", title)
   .guard_scalar("refresh", "numeric", refresh)
   .guard_scalar("notification", "character", notification)
+  .guard_scalar("notification_bar", "WaveNotificationBar", notification_bar)
   .guard_scalar("redirect", "character", redirect)
   .guard_scalar("icon", "character", icon)
   .guard_vector("layouts", "WaveLayout", layouts)
@@ -3808,6 +3854,7 @@ ui_meta_card <- function(
     title=title,
     refresh=refresh,
     notification=notification,
+    notification_bar=notification_bar,
     redirect=redirect,
     icon=icon,
     layouts=layouts,

--- a/tools/intellij-plugin/src/main/resources/templates/wave-components.xml
+++ b/tools/intellij-plugin/src/main/resources/templates/wave-components.xml
@@ -369,6 +369,12 @@
       <option name="Python" value="true"/>
     </context>
   </template>
+  <template name="w_notification_bar" value="ui.notification_bar(text='$text$'),$END$" description="Create a minimal Wave NotificationBar." toReformat="true" toShortenFQNames="true">
+    <variable name="text" expression="" defaultValue="" alwaysStopAt="true"/>
+    <context>
+      <option name="Python" value="true"/>
+    </context>
+  </template>
   <template name="w_persona" value="ui.persona(title='$title$'),$END$" description="Create a minimal Wave Persona." toReformat="true" toShortenFQNames="true">
     <variable name="title" expression="" defaultValue="" alwaysStopAt="true"/>
     <context>
@@ -1450,12 +1456,13 @@
       <option name="Python" value="true"/>
     </context>
   </template>
-  <template name="w_full_message_bar" value="ui.message_bar(type='$type$',text='$text$',name='$name$',width='$width$',visible=$visible$),$END$" description="Create Wave MessageBar with full attributes." toReformat="true" toShortenFQNames="true">
+  <template name="w_full_message_bar" value="ui.message_bar(type='$type$',text='$text$',name='$name$',width='$width$',visible=$visible$,buttons=[&#10;	$buttons$	&#10;]),$END$" description="Create Wave MessageBar with full attributes." toReformat="true" toShortenFQNames="true">
     <variable name="type" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="text" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="name" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="width" expression="" defaultValue="&quot;100%&quot;" alwaysStopAt="true"/>
     <variable name="visible" expression="" defaultValue="&quot;True&quot;" alwaysStopAt="true"/>
+    <variable name="buttons" expression="" defaultValue="" alwaysStopAt="true"/>
     <context>
       <option name="Python" value="true"/>
     </context>
@@ -1511,11 +1518,12 @@
       <option name="Python" value="true"/>
     </context>
   </template>
-  <template name="w_full_meta_card" value="ui.meta_card(box='$box$',title='$title$',refresh=$refresh$,notification='$notification$',redirect='$redirect$',icon='$icon$',dialog=$dialog$,side_panel=$side_panel$,theme='$theme$',tracker=$tracker$,script=$script$,stylesheet=$stylesheet$,layouts=[&#10;	$layouts$	&#10;],themes=[&#10;	$themes$	&#10;],scripts=[&#10;	$scripts$	&#10;],stylesheets=[&#10;	$stylesheets$	&#10;],commands=[&#10;	$commands$	&#10;])$END$" description="Create Wave MetaCard with full attributes." toReformat="true" toShortenFQNames="true">
+  <template name="w_full_meta_card" value="ui.meta_card(box='$box$',title='$title$',refresh=$refresh$,notification='$notification$',notification_bar=$notification_bar$,redirect='$redirect$',icon='$icon$',dialog=$dialog$,side_panel=$side_panel$,theme='$theme$',tracker=$tracker$,script=$script$,stylesheet=$stylesheet$,layouts=[&#10;	$layouts$	&#10;],themes=[&#10;	$themes$	&#10;],scripts=[&#10;	$scripts$	&#10;],stylesheets=[&#10;	$stylesheets$	&#10;],commands=[&#10;	$commands$	&#10;])$END$" description="Create Wave MetaCard with full attributes." toReformat="true" toShortenFQNames="true">
     <variable name="box" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="title" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="refresh" expression="" defaultValue="&quot;None&quot;" alwaysStopAt="true"/>
     <variable name="notification" expression="" defaultValue="" alwaysStopAt="true"/>
+    <variable name="notification_bar" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="redirect" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="icon" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="dialog" expression="" defaultValue="" alwaysStopAt="true"/>
@@ -1564,6 +1572,17 @@
     <variable name="items" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="secondary_items" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="commands" expression="" defaultValue="" alwaysStopAt="true"/>
+    <context>
+      <option name="Python" value="true"/>
+    </context>
+  </template>
+  <template name="w_full_notification_bar" value="ui.notification_bar(text='$text$',type='$type$',timeout=$timeout$,position='$position$',buttons=[&#10;	$buttons$	&#10;],events=[&#10;	$events$	&#10;]),$END$" description="Create Wave NotificationBar with full attributes." toReformat="true" toShortenFQNames="true">
+    <variable name="text" expression="" defaultValue="" alwaysStopAt="true"/>
+    <variable name="type" expression="" defaultValue="&quot;info&quot;" alwaysStopAt="true"/>
+    <variable name="timeout" expression="" defaultValue="&quot;5&quot;" alwaysStopAt="true"/>
+    <variable name="position" expression="" defaultValue="&quot;top-right&quot;" alwaysStopAt="true"/>
+    <variable name="buttons" expression="" defaultValue="" alwaysStopAt="true"/>
+    <variable name="events" expression="" defaultValue="" alwaysStopAt="true"/>
     <context>
       <option name="Python" value="true"/>
     </context>

--- a/tools/vscode-extension/component-snippets.json
+++ b/tools/vscode-extension/component-snippets.json
@@ -363,6 +363,13 @@
     ],
     "description": "Create a minimal Wave NavCard."
   },
+  "Wave NotificationBar": {
+    "prefix": "w_notification_bar",
+    "body": [
+      "ui.notification_bar(text='$1'),$0"
+    ],
+    "description": "Create a minimal Wave NotificationBar."
+  },
   "Wave Persona": {
     "prefix": "w_persona",
     "body": [
@@ -1178,7 +1185,7 @@
   "Wave Full MessageBar": {
     "prefix": "w_full_message_bar",
     "body": [
-      "ui.message_bar(type='$1', text='$2', name='$3', width='${4:100%'}', visible=${5:True}),$0"
+      "ui.message_bar(type='$1', text='$2', name='$3', width='${4:100%'}', visible=${5:True}, buttons=[\n\t\t$6\t\t\n]),$0"
     ],
     "description": "Create a full Wave MessageBar."
   },
@@ -1220,7 +1227,7 @@
   "Wave Full MetaCard": {
     "prefix": "w_full_meta_card",
     "body": [
-      "ui.meta_card(box='$1', title='$2', refresh=${3:None}, notification='$4', redirect='$5', icon='$6', dialog=$7, side_panel=$8, theme='$9', tracker=$10, script=$11, stylesheet=$12, layouts=[\n\t\t$13\t\t\n], themes=[\n\t\t$14\t\t\n], scripts=[\n\t\t$15\t\t\n], stylesheets=[\n\t\t$16\t\t\n], commands=[\n\t\t$17\t\t\n])$0"
+      "ui.meta_card(box='$1', title='$2', refresh=${3:None}, notification='$4', notification_bar=$5, redirect='$6', icon='$7', dialog=$8, side_panel=$9, theme='$10', tracker=$11, script=$12, stylesheet=$13, layouts=[\n\t\t$14\t\t\n], themes=[\n\t\t$15\t\t\n], scripts=[\n\t\t$16\t\t\n], stylesheets=[\n\t\t$17\t\t\n], commands=[\n\t\t$18\t\t\n])$0"
     ],
     "description": "Create a full Wave MetaCard."
   },
@@ -1244,6 +1251,13 @@
       "ui.nav_card(box='$1', value='$2', title='$3', subtitle='$4', icon='$5', icon_color='$6', image='$7', persona=$8, color='${9:card'}', items=[\n\t\t$10\t\t\n], secondary_items=[\n\t\t$11\t\t\n], commands=[\n\t\t$12\t\t\n])$0"
     ],
     "description": "Create a full Wave NavCard."
+  },
+  "Wave Full NotificationBar": {
+    "prefix": "w_full_notification_bar",
+    "body": [
+      "ui.notification_bar(text='$1', type='${2:info'}', timeout=${3:5}, position='${4:top-right'}', buttons=[\n\t\t$5\t\t\n], events=[\n\t\t$6\t\t\n]),$0"
+    ],
+    "description": "Create a full Wave NotificationBar."
   },
   "Wave Full Persona": {
     "prefix": "w_full_persona",

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -19,6 +19,7 @@ import { stylesheet } from 'typestyle'
 import Dialog from './dialog'
 import { LayoutPicker } from './editor'
 import { Logo } from './logo'
+import { NotificationBar } from './notification_bar'
 import { PageLayout } from './page'
 import SidePanel from './side_panel'
 import { clas, cssVar, pc } from './theme'
@@ -119,6 +120,7 @@ const
                       <BusyOverlay />
                       <Dialog />
                       <SidePanel />
+                      <NotificationBar />
                     </div>
                   </Fluent.Fabric>
                 )

--- a/ui/src/message_bar.tsx
+++ b/ui/src/message_bar.tsx
@@ -16,7 +16,9 @@ import * as Fluent from '@fluentui/react'
 import { B, S } from 'h2o-wave'
 import React from 'react'
 import { stylesheet } from 'typestyle'
+import { Component, XComponents } from './form'
 import { Markdown } from './markdown'
+import { important, margin, pc, px } from './theme'
 
 /**
  * Create a message bar.
@@ -32,6 +34,8 @@ export interface MessageBar {
   text?: S
   /** An identifying name for this component. */
   name?: S
+  /** Specify one or more action buttons. */
+  buttons?: Component[]
   /** The width of the message bar, e.g. '100px'. Defaults to '100%'. */
   width?: S
   /** True if the component should be visible. Defaults to True. */
@@ -45,9 +49,60 @@ const
         // Adjust spacing to align with Fluent Messagebar icon.
         '.wave-markdown > *:first-child': { marginTop: 0 },
         '.wave-markdown > *:only-child': { marginBottom: 0 },
+        '.wave-markdown p': { fontSize: 14, lineHeight: px(20), letterSpacing: '-0.006em' },
+        '.ms-MessageBar-dismissal .ms-Button-icon': { fontSize: 16 },
       }
     }
-  }),
+  })
+
+type NotificationType = 'info' | 'error' | 'warning' | 'success' | 'danger' | 'blocked'
+type NotificationStyle = {
+  iconName: S
+  background: S
+  color: S
+}
+type MessagebarProps = {
+  type?: NotificationType
+  text?: S
+  buttons?: Component[]
+  name?: S
+  extraStyles?: Fluent.IRawStyle
+  onDismiss?: () => void
+}
+
+const
+  notificationTypes: { [K in NotificationType]: NotificationStyle } = {
+    'info': {
+      iconName: 'InfoSolid',
+      background: '#DBEEFD',
+      color: '#165589'
+    },
+    'error': {
+      iconName: 'StatusErrorFull',
+      background: '#F1CBCB',
+      color: '#5E0000'
+    },
+    'warning': {
+      iconName: 'IncidentTriangle',
+      background: '#FFF6DC',
+      color: '#8F7015'
+    },
+    'success': {
+      iconName: 'CompletedSolid',
+      background: '#CAEACA',
+      color: '#094609'
+    },
+    'danger': {
+      iconName: 'IncidentTriangle',
+      background: '#F1CBCB',
+      color: '#5E0000'
+    },
+    'blocked': {
+      iconName: 'Blocked2Solid',
+      background: '#F1CBCB',
+      color: '#5E0000'
+    },
+  },
   toMessageBarType = (t?: S): Fluent.MessageBarType => {
     switch (t) {
       case 'error': return Fluent.MessageBarType.error
@@ -57,15 +112,54 @@ const
       case 'blocked': return Fluent.MessageBarType.blocked
       default: return Fluent.MessageBarType.info
     }
+  },
+  isMessagebarMultiline = (text?: S, buttons?: Component[]) => {
+    const textLength = text?.length || 0
+    const buttonTextLength = buttons?.filter(({ button }) => button).reduce((prev, curr) => prev + (curr.button?.label?.length || 0) + 15, 0) || 0
+    return textLength + buttonTextLength > 54
   }
 
 export const
-  XMessageBar = ({ model: m }: { model: MessageBar }) => (
-    m.text?.length
-      ? (
-        <Fluent.MessageBar data-test={m.name} messageBarType={toMessageBarType(m.type)} className={css.messageBar}>
-          <Markdown source={m.text} />
-        </Fluent.MessageBar>
-      )
-      : <div />
-  )
+  MessageBar = ({ type, text, buttons, name, extraStyles = {}, onDismiss }: MessagebarProps) => {
+    const { iconName, color, background } = notificationTypes[type || 'info']
+    const isMultiline = isMessagebarMultiline(text, buttons)
+    return (
+      text?.length
+        ? (
+          <Fluent.MessageBar
+            data-test={name}
+            styles={{
+              root: {
+                background,
+                color,
+                borderRadius: 4,
+                maxWidth: 500,
+                width: pc(100),
+                animationFillMode: 'forwards',
+                '.ms-Link': { color, fontWeight: 600 },
+                '.ms-Link:hover': { textDecoration: 'none', color },
+                ...extraStyles
+              },
+              content: { alignItems: isMultiline ? 'start' : 'center' },
+              icon: { fontSize: 24, color },
+              iconContainer: { margin: margin(16, 16, 16, 24), display: 'flex', alignItems: 'center' },
+              text: { margin: margin(16, 0) },
+              innerText: { whiteSpace: important('initial') },
+              dismissal: { fontSize: 16, height: 'auto', margin: margin(16, 16, 16, 0), padding: 0, '.ms-Button-flexContainer': { display: 'block' } },
+              dismissSingleLine: { display: 'flex' },
+              actions: { margin: 16, marginTop: isMultiline ? 0 : undefined }
+            }}
+            messageBarType={toMessageBarType(type)}
+            onDismiss={onDismiss}
+            className={css.messageBar}
+            isMultiline={isMultiline}
+            actions={buttons ? <XComponents items={buttons || []} alignment='end' /> : undefined}
+            messageBarIconProps={{ iconName }}
+          >
+            <Markdown source={text} />
+          </Fluent.MessageBar>
+        )
+        : null
+    )
+  },
+  XMessageBar = ({ model: m }: { model: MessageBar }) => <MessageBar name={m.name} text={m.text} type={m.type} buttons={m.buttons} />

--- a/ui/src/message_bar.tsx
+++ b/ui/src/message_bar.tsx
@@ -34,12 +34,12 @@ export interface MessageBar {
   text?: S
   /** An identifying name for this component. */
   name?: S
-  /** Specify one or more action buttons. */
-  buttons?: Component[]
   /** The width of the message bar, e.g. '100px'. Defaults to '100%'. */
   width?: S
   /** True if the component should be visible. Defaults to True. */
   visible?: B
+  /** Specify one or more action buttons. */
+  buttons?: Component[]
 }
 
 const
@@ -115,14 +115,15 @@ const
   },
   isMessagebarMultiline = (text?: S, buttons?: Component[]) => {
     const textLength = text?.length || 0
-    const buttonTextLength = buttons?.filter(({ button }) => button).reduce((prev, curr) => prev + (curr.button?.label?.length || 0) + 15, 0) || 0
+    const buttonTextLength = buttons?.reduce((prev, curr) => prev + (curr.button?.label?.length || 0) + 15, 0) || 0
     return textLength + buttonTextLength > 54
   }
 
 export const
   MessageBar = ({ type, text, buttons, name, extraStyles = {}, onDismiss }: MessagebarProps) => {
     const { iconName, color, background } = notificationTypes[type || 'info']
-    const isMultiline = isMessagebarMultiline(text, buttons)
+    const btns = buttons?.filter(({ button }) => button)
+    const isMultiline = isMessagebarMultiline(text, btns)
     return (
       text?.length
         ? (
@@ -153,7 +154,7 @@ export const
             onDismiss={onDismiss}
             className={css.messageBar}
             isMultiline={isMultiline}
-            actions={buttons ? <XComponents items={buttons || []} alignment='end' /> : undefined}
+            actions={btns?.length ? <XComponents items={btns || []} alignment='end' /> : undefined}
             messageBarIconProps={{ iconName }}
           >
             <Markdown source={text} />

--- a/ui/src/meta.tsx
+++ b/ui/src/meta.tsx
@@ -14,6 +14,7 @@
 
 import { box, disconnect, Id, Model, on, S, U } from 'h2o-wave'
 import React from 'react'
+import { NotificationBar, notificationBarB } from './notification_bar'
 import { Dialog, dialogB } from './dialog'
 import { cards } from './layout'
 import { showNotification } from './notification'
@@ -132,6 +133,8 @@ interface State {
   refresh?: U
   /** Display a desktop notification. */
   notification?: S
+  /** Display an in-app notification bar. */
+  notification_bar?: NotificationBar
   /** Redirect the page to a new URL. */
   redirect?: S
   /** 
@@ -183,6 +186,7 @@ export const
       icon,
       refresh,
       notification,
+      notification_bar,
       redirect,
       layouts,
       dialog,
@@ -214,6 +218,9 @@ export const
 
     dialogB(dialog ? { ...dialog } : null)
     sidePanelB(side_panel ? { ...side_panel } : null)
+    // HACK: Since meta cards are processed within render, wait for React to finish the original render before proceeding.
+    setTimeout(() => notificationBarB(notification_bar ? { ...notification_bar } : null), 0)
+
 
     if (title) windowTitleB(title)
     if (icon) windowIconB(icon)

--- a/ui/src/notification_bar.test.tsx
+++ b/ui/src/notification_bar.test.tsx
@@ -1,0 +1,49 @@
+// Copyright 2020 H2O.ai, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { fireEvent, render } from '@testing-library/react'
+import React from 'react'
+import { NotificationBar, notificationBarB } from './notification_bar'
+
+const notificationbarProps: NotificationBar = { text: 'notification_bar' }
+
+describe('NotificationBar.tsx', () => {
+
+  beforeAll(() => jest.useFakeTimers())
+  beforeEach(() => notificationBarB(notificationbarProps))
+
+  it('should open notification bar when global wave.notificationBarB is set', () => {
+    const { queryByRole } = render(<NotificationBar />)
+    expect(queryByRole('region')).toBeInTheDocument()
+  })
+
+  it('should not close the notifification bar after timeout if buttons specified', () => {
+    notificationBarB({ ...notificationbarProps, buttons: [] })
+    render(<NotificationBar />)
+    jest.runOnlyPendingTimers()
+    expect(notificationBarB()).not.toBeNull()
+  })
+
+  it('should close the notifification bar after timeout if no buttons specified', () => {
+    render(<NotificationBar />)
+    jest.runOnlyPendingTimers()
+    expect(notificationBarB()).toBeNull()
+  })
+
+  it('should close the notifification bar after clicking dismiss', () => {
+    const { container } = render(<NotificationBar />)
+    fireEvent.click(container.querySelector('.ms-MessageBar-dismissal') as HTMLButtonElement)
+    expect(notificationBarB()).toBeNull()
+  })
+})

--- a/ui/src/notification_bar.test.tsx
+++ b/ui/src/notification_bar.test.tsx
@@ -29,10 +29,17 @@ describe('NotificationBar.tsx', () => {
   })
 
   it('should not close the notifification bar after timeout if buttons specified', () => {
-    notificationBarB({ ...notificationbarProps, buttons: [] })
+    notificationBarB({ ...notificationbarProps, buttons: [{ button: { name: 'btn' } }] })
     render(<NotificationBar />)
     jest.runOnlyPendingTimers()
     expect(notificationBarB()).not.toBeNull()
+  })
+
+  it('should close the notifification bar after timeout if other components than buttons specified', () => {
+    notificationBarB({ ...notificationbarProps, buttons: [{ text: { content: 'btn' } }] })
+    render(<NotificationBar />)
+    jest.runOnlyPendingTimers()
+    expect(notificationBarB()).toBeNull()
   })
 
   it('should close the notifification bar after timeout if no buttons specified', () => {

--- a/ui/src/notification_bar.tsx
+++ b/ui/src/notification_bar.tsx
@@ -1,0 +1,93 @@
+// Copyright 2020 H2O.ai, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as Fluent from '@fluentui/react'
+import { B, Box, box, S, U } from 'h2o-wave'
+import React from 'react'
+import { Component } from './form'
+import { MessageBar } from "./message_bar"
+import { bond } from './ui'
+
+/**
+ * Create a notification bar.
+ *
+ * A notification bar is an area at the edge of a primary view that displays relevant status information.
+ * You can use a notification bar to tell the user about a result of an action, e.g. "Data has been successfully saved".
+ */
+export interface NotificationBar {
+  /** The text displayed on the notification bar. */
+  text: S
+  /** The icon and color of the notification bar. Defaults to 'info'. */
+  type?: 'info' | 'error' | 'warning' | 'success' | 'danger' | 'blocked'
+  /** When should the notification bar disappear in seconds. Defaults to 5. */
+  timeout?: U
+  /** Specify one or more action buttons. */
+  buttons?: Component[]
+  /** Specify the location of notification. Defaults to 'top-right'. */
+  position?: 'top-right' | 'bottom-right' | 'bottom-center' | 'bottom-left' | 'top-left' | 'top-center'
+  /** The events to capture on this notification bar. */
+  events?: S[]
+}
+
+const gap = 15
+
+export const
+  notificationBarB: Box<NotificationBar | null> = box(null),
+  NotificationBar = bond(() => {
+    let
+      timeout: U | undefined,
+      lastModel: NotificationBar | null = null
+    const
+      getAnimation = (shouldBeOpen: B, transform: S) => shouldBeOpen
+        ? Fluent.keyframes({ from: { transform }, to: { transform: 'none' }, })
+        : Fluent.keyframes({ from: { transform: 'none' }, to: { transform }, }),
+      getPosition = (position = 'top-right', shouldBeOpen: B) => {
+        if (window.innerWidth < 500 + gap) return position.includes('top')
+          ? { top: 0, right: 0, left: 0, margin: '0 auto', animationName: getAnimation(shouldBeOpen, 'translateY(-100%)') }
+          : { bottom: 0, right: 0, left: 0, margin: '0 auto', animationName: getAnimation(shouldBeOpen, 'translateY(100%)') }
+
+        switch (position) {
+          case 'top-right': return { top: gap, right: gap, animationName: getAnimation(shouldBeOpen, `translateX(calc(100% + ${gap}px))`) }
+          case 'top-center': return { top: gap, right: 0, left: 0, margin: '0 auto', animationName: getAnimation(shouldBeOpen, `translateY(calc(-100% - ${gap}px))`) }
+          case 'top-left': return { top: gap, left: gap, animationName: getAnimation(shouldBeOpen, `translateX(calc(-100% - ${gap}px))`) }
+          case 'bottom-right': return { bottom: gap, right: gap, animationName: getAnimation(shouldBeOpen, `translateX(calc(100% + ${gap}px))`) }
+          case 'bottom-center': return { bottom: gap, right: 0, left: 0, margin: '0 auto', animationName: getAnimation(shouldBeOpen, `translateY(calc(100% + ${gap}px))`) }
+          case 'bottom-left': return { bottom: gap, left: gap, animationName: getAnimation(shouldBeOpen, `translateX(calc(-100% - ${gap}px))`) }
+        }
+      },
+      onDismiss = () => {
+        window.clearTimeout(timeout)
+        lastModel = notificationBarB()
+        notificationBarB(null)
+      },
+      render = () => {
+        const
+          model = notificationBarB(),
+          shouldBeOpen = !!model,
+          currentModel = model || lastModel,
+          extraStyles: Fluent.IRawStyle = {
+            position: 'fixed',
+            animationDuration: '0.5s',
+            animationFillMode: 'forwards',
+            ...getPosition(currentModel?.position, shouldBeOpen)
+          }
+
+        if (!model?.buttons && shouldBeOpen) timeout = window.setTimeout(onDismiss, model?.timeout || 5000)
+
+        return <MessageBar type={currentModel?.type} text={currentModel?.text} buttons={currentModel?.buttons} extraStyles={extraStyles} onDismiss={onDismiss} />
+      },
+      dispose = () => window.clearTimeout(timeout)
+
+    return { render, notificationBarB, dispose }
+  }) 

--- a/ui/src/notification_bar.tsx
+++ b/ui/src/notification_bar.tsx
@@ -16,6 +16,7 @@ import * as Fluent from '@fluentui/react'
 import { B, Box, box, S, U } from 'h2o-wave'
 import React from 'react'
 import { Component } from './form'
+import { grid } from './layout'
 import { MessageBar } from "./message_bar"
 import { bond } from './ui'
 
@@ -40,7 +41,7 @@ export interface NotificationBar {
   events?: S[]
 }
 
-const gap = 15
+const gap = grid.gap
 
 export const
   notificationBarB: Box<NotificationBar | null> = box(null),

--- a/ui/src/notification_bar.tsx
+++ b/ui/src/notification_bar.tsx
@@ -82,11 +82,12 @@ export const
             animationDuration: '0.5s',
             animationFillMode: 'forwards',
             ...getPosition(currentModel?.position, shouldBeOpen)
-          }
+          },
+          buttons = currentModel?.buttons?.filter(({ button }) => button)
 
-        if (!model?.buttons && shouldBeOpen) timeout = window.setTimeout(onDismiss, model?.timeout || 5000)
+        if (!buttons?.length && shouldBeOpen) timeout = window.setTimeout(onDismiss, model?.timeout || 5000)
 
-        return <MessageBar type={currentModel?.type} text={currentModel?.text} buttons={currentModel?.buttons} extraStyles={extraStyles} onDismiss={onDismiss} />
+        return <MessageBar type={currentModel?.type} text={currentModel?.text} buttons={buttons} extraStyles={extraStyles} onDismiss={onDismiss} />
       },
       dispose = () => window.clearTimeout(timeout)
 

--- a/ui/src/notification_bar.tsx
+++ b/ui/src/notification_bar.tsx
@@ -31,7 +31,7 @@ export interface NotificationBar {
   text: S
   /** The icon and color of the notification bar. Defaults to 'info'. */
   type?: 'info' | 'error' | 'warning' | 'success' | 'danger' | 'blocked'
-  /** When should the notification bar disappear in seconds. Defaults to 5. */
+  /** How long the notification stays visible, in seconds. Defaults to 5. */
   timeout?: U
   /** Specify one or more action buttons. */
   buttons?: Component[]

--- a/website/widgets/form/message_bar.md
+++ b/website/widgets/form/message_bar.md
@@ -26,3 +26,17 @@ q.page['form'] = ui.form_card(
     ]
 )
 ```
+
+## With buttons
+
+```py
+q.page['form'] = ui.form_card(
+    box='1 1 4 2',
+    items=[
+        ui.message_bar(type='success', text='This is a success message.', buttons=[
+            ui.button(name='cancel', label='Cancel'),
+            ui.button(name='agree', label='Agree', primary=True),
+        ]),
+    ]
+)
+```


### PR DESCRIPTION
## Demo

https://github.com/h2oai/wave/issues/1007#issuecomment-929074383

Working in Chrome / Safari / FF.

Unified `ui.message_bar` styling to match the `notification_bar` + added support for buttons to keep consistency

![image](https://user-images.githubusercontent.com/64769322/150142681-5e3b0b05-d54d-4be8-a83c-fd4bf16b0e42.png)

## API review

```ts
/**
 * Create a notification bar.
 *
 * A notification bar is an area at the edge of a primary view that displays relevant status information.
 * You can use a notification bar to tell the user about a result of an action, e.g. "Data has been successfully saved".
 */
export interface NotificationBar {
  /** The text displayed on the notification bar. */
  text: S
  /** The icon and color of the notification bar. Defaults to 'info'. */
  type?: 'info' | 'error' | 'warning' | 'success' | 'danger' | 'blocked'
  /** When should the notification bar disappear in seconds. Defaults to 5. */
  timeout?: U
  /** Specify one or more action buttons. */
  buttons?: Component[]
  /** Specify the location of notification. Defaults to 'top-right'. */
  position?: 'top-right' | 'bottom-right' | 'bottom-center' | 'bottom-left' | 'top-left' | 'top-center'
  /** The events to capture on this notification bar. */
  events?: S[]
}
```

```ts
/**
 * Create a message bar.
 *
 * A message bar is an area at the top of a primary view that displays relevant status information.
 * You can use a message bar to tell the user about a situation that does not require their immediate attention and
 * therefore does not need to block other activities.
 */
export interface MessageBar {
  /** The icon and color of the message bar. */
  type?: 'info' | 'error' | 'warning' | 'success' | 'danger' | 'blocked'
  /** The text displayed on the message bar. */
  text?: S
  /** An identifying name for this component. */
  name?: S
  /** Specify one or more action buttons. */
  buttons?: Component[]
  /** The width of the message bar, e.g. '100px'. Defaults to '100%'. */
  width?: S
  /** True if the component should be visible. Defaults to True. */
  visible?: B
}
```

Closes #1007