### PR TITLE
feat: Add title attribute to NavItem to show as a tooltip #692

### DIFF
--- a/py/examples/nav.py
+++ b/py/examples/nav.py
@@ -26,10 +26,10 @@ async def serve(q: Q):
             image='https://www.h2o.ai/wp-content/themes/h2o2018/templates/dist/images/h2o_logo.svg',
             items=[
                 ui.nav_group('Menu', items=[
-                    ui.nav_item(name='#menu/spam', label='Spam', tooltip='I contain unwanted messages.'),
-                    ui.nav_item(name='#menu/ham', label='Ham', tooltip='I am tasty!'),
+                    ui.nav_item(name='#menu/spam', label='Spam'),
+                    ui.nav_item(name='#menu/ham', label='Ham'),
                     ui.nav_item(name='#menu/eggs', label='Eggs', tooltip='Make me a scrambled egg.'),
-                    ui.nav_item(name='#menu/toast', label='Toast', tooltip='I love toasters!', disabled=True),
+                    ui.nav_item(name='#menu/toast', label='Toast', disabled=True),
                 ]),
                 ui.nav_group('Help', items=[
                     ui.nav_item(name='#about', label='About', icon='Info'),

--- a/py/examples/nav.py
+++ b/py/examples/nav.py
@@ -26,10 +26,10 @@ async def serve(q: Q):
             image='https://www.h2o.ai/wp-content/themes/h2o2018/templates/dist/images/h2o_logo.svg',
             items=[
                 ui.nav_group('Menu', items=[
-                    ui.nav_item(name='#menu/spam', label='Spam'),
-                    ui.nav_item(name='#menu/ham', label='Ham'),
-                    ui.nav_item(name='#menu/eggs', label='Eggs'),
-                    ui.nav_item(name='#menu/toast', label='Toast', disabled=True),
+                    ui.nav_item(name='#menu/spam', label='Spam', tooltip='I contain unwanted messages.'),
+                    ui.nav_item(name='#menu/ham', label='Ham', tooltip='I am tasty!'),
+                    ui.nav_item(name='#menu/eggs', label='Eggs', tooltip='Make me a scrambled egg.'),
+                    ui.nav_item(name='#menu/toast', label='Toast', tooltip='I love toasters!', disabled=True),
                 ]),
                 ui.nav_group('Help', items=[
                     ui.nav_item(name='#about', label='About', icon='Info'),

--- a/py/h2o_wave/types.py
+++ b/py/h2o_wave/types.py
@@ -7463,13 +7463,13 @@ class NavItem:
             label: str,
             icon: Optional[str] = None,
             disabled: Optional[bool] = None,
-            title: Optional[str] = None,
+            tooltip: Optional[str] = None,
     ):
         _guard_scalar('NavItem.name', name, (str,), True, False, False)
         _guard_scalar('NavItem.label', label, (str,), False, False, False)
         _guard_scalar('NavItem.icon', icon, (str,), False, True, False)
         _guard_scalar('NavItem.disabled', disabled, (bool,), False, True, False)
-        _guard_scalar('NavItem.title', title, (str,), False, True, False)
+        _guard_scalar('NavItem.tooltip', tooltip, (str,), False, True, False)
         self.name = name
         """The name of this item. Prefix the name with a '#' to trigger hash-change navigation."""
         self.label = label
@@ -7478,8 +7478,8 @@ class NavItem:
         """An optional icon to display next to the label."""
         self.disabled = disabled
         """True if this item should be disabled."""
-        self.title = title
-        """The item title, typically displayed as a tooltip."""
+        self.tooltip = tooltip
+        """An optional tooltip message displayed when a user hovers over this item."""
 
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""
@@ -7487,13 +7487,13 @@ class NavItem:
         _guard_scalar('NavItem.label', self.label, (str,), False, False, False)
         _guard_scalar('NavItem.icon', self.icon, (str,), False, True, False)
         _guard_scalar('NavItem.disabled', self.disabled, (bool,), False, True, False)
-        _guard_scalar('NavItem.title', self.title, (str,), False, True, False)
+        _guard_scalar('NavItem.tooltip', self.tooltip, (str,), False, True, False)
         return _dump(
             name=self.name,
             label=self.label,
             icon=self.icon,
             disabled=self.disabled,
-            title=self.title,
+            tooltip=self.tooltip,
         )
 
     @staticmethod
@@ -7507,19 +7507,19 @@ class NavItem:
         _guard_scalar('NavItem.icon', __d_icon, (str,), False, True, False)
         __d_disabled: Any = __d.get('disabled')
         _guard_scalar('NavItem.disabled', __d_disabled, (bool,), False, True, False)
-        __d_title: Any = __d.get('title')
-        _guard_scalar('NavItem.title', __d_title, (str,), False, True, False)
+        __d_tooltip: Any = __d.get('tooltip')
+        _guard_scalar('NavItem.tooltip', __d_tooltip, (str,), False, True, False)
         name: str = __d_name
         label: str = __d_label
         icon: Optional[str] = __d_icon
         disabled: Optional[bool] = __d_disabled
-        title: Optional[str] = __d_title
+        tooltip: Optional[str] = __d_tooltip
         return NavItem(
             name,
             label,
             icon,
             disabled,
-            title,
+            tooltip,
         )
 
 

--- a/py/h2o_wave/types.py
+++ b/py/h2o_wave/types.py
@@ -7463,11 +7463,13 @@ class NavItem:
             label: str,
             icon: Optional[str] = None,
             disabled: Optional[bool] = None,
+            title: Optional[str] = None,
     ):
         _guard_scalar('NavItem.name', name, (str,), True, False, False)
         _guard_scalar('NavItem.label', label, (str,), False, False, False)
         _guard_scalar('NavItem.icon', icon, (str,), False, True, False)
         _guard_scalar('NavItem.disabled', disabled, (bool,), False, True, False)
+        _guard_scalar('NavItem.title', title, (str,), False, True, False)
         self.name = name
         """The name of this item. Prefix the name with a '#' to trigger hash-change navigation."""
         self.label = label
@@ -7476,6 +7478,8 @@ class NavItem:
         """An optional icon to display next to the label."""
         self.disabled = disabled
         """True if this item should be disabled."""
+        self.title = title
+        """The item title, typically displayed as a tooltip."""
 
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""
@@ -7483,11 +7487,13 @@ class NavItem:
         _guard_scalar('NavItem.label', self.label, (str,), False, False, False)
         _guard_scalar('NavItem.icon', self.icon, (str,), False, True, False)
         _guard_scalar('NavItem.disabled', self.disabled, (bool,), False, True, False)
+        _guard_scalar('NavItem.title', self.title, (str,), False, True, False)
         return _dump(
             name=self.name,
             label=self.label,
             icon=self.icon,
             disabled=self.disabled,
+            title=self.title,
         )
 
     @staticmethod
@@ -7501,15 +7507,19 @@ class NavItem:
         _guard_scalar('NavItem.icon', __d_icon, (str,), False, True, False)
         __d_disabled: Any = __d.get('disabled')
         _guard_scalar('NavItem.disabled', __d_disabled, (bool,), False, True, False)
+        __d_title: Any = __d.get('title')
+        _guard_scalar('NavItem.title', __d_title, (str,), False, True, False)
         name: str = __d_name
         label: str = __d_label
         icon: Optional[str] = __d_icon
         disabled: Optional[bool] = __d_disabled
+        title: Optional[str] = __d_title
         return NavItem(
             name,
             label,
             icon,
             disabled,
+            title,
         )
 
 

--- a/py/h2o_wave/ui.py
+++ b/py/h2o_wave/ui.py
@@ -2623,6 +2623,7 @@ def nav_item(
         label: str,
         icon: Optional[str] = None,
         disabled: Optional[bool] = None,
+        title: Optional[str] = None,
 ) -> NavItem:
     """Create a navigation item.
 
@@ -2631,6 +2632,7 @@ def nav_item(
         label: The label to display.
         icon: An optional icon to display next to the label.
         disabled: True if this item should be disabled.
+        title: The item title, typically displayed as a tooltip.
     Returns:
         A `h2o_wave.types.NavItem` instance.
     """
@@ -2639,6 +2641,7 @@ def nav_item(
         label,
         icon,
         disabled,
+        title,
     )
 
 

--- a/py/h2o_wave/ui.py
+++ b/py/h2o_wave/ui.py
@@ -2623,7 +2623,7 @@ def nav_item(
         label: str,
         icon: Optional[str] = None,
         disabled: Optional[bool] = None,
-        title: Optional[str] = None,
+        tooltip: Optional[str] = None,
 ) -> NavItem:
     """Create a navigation item.
 
@@ -2632,7 +2632,7 @@ def nav_item(
         label: The label to display.
         icon: An optional icon to display next to the label.
         disabled: True if this item should be disabled.
-        title: The item title, typically displayed as a tooltip.
+        tooltip: An optional tooltip message displayed when a user hovers over this item.
     Returns:
         A `h2o_wave.types.NavItem` instance.
     """
@@ -2641,7 +2641,7 @@ def nav_item(
         label,
         icon,
         disabled,
-        title,
+        tooltip,
     )
 
 

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -3045,7 +3045,7 @@ ui_grid_card <- function(
 #' @param label The label to display.
 #' @param icon An optional icon to display next to the label.
 #' @param disabled True if this item should be disabled.
-#' @param title The item title, typically displayed as a tooltip.
+#' @param tooltip An optional tooltip message displayed when a user hovers over this item.
 #' @return A NavItem instance.
 #' @export
 ui_nav_item <- function(
@@ -3053,18 +3053,18 @@ ui_nav_item <- function(
   label,
   icon = NULL,
   disabled = NULL,
-  title = NULL) {
+  tooltip = NULL) {
   .guard_scalar("name", "character", name)
   .guard_scalar("label", "character", label)
   .guard_scalar("icon", "character", icon)
   .guard_scalar("disabled", "logical", disabled)
-  .guard_scalar("title", "character", title)
+  .guard_scalar("tooltip", "character", tooltip)
   .o <- list(
     name=name,
     label=label,
     icon=icon,
     disabled=disabled,
-    title=title)
+    tooltip=tooltip)
   class(.o) <- append(class(.o), c(.wave_obj, "WaveNavItem"))
   return(.o)
 }

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -3045,22 +3045,26 @@ ui_grid_card <- function(
 #' @param label The label to display.
 #' @param icon An optional icon to display next to the label.
 #' @param disabled True if this item should be disabled.
+#' @param title The item title, typically displayed as a tooltip.
 #' @return A NavItem instance.
 #' @export
 ui_nav_item <- function(
   name,
   label,
   icon = NULL,
-  disabled = NULL) {
+  disabled = NULL,
+  title = NULL) {
   .guard_scalar("name", "character", name)
   .guard_scalar("label", "character", label)
   .guard_scalar("icon", "character", icon)
   .guard_scalar("disabled", "logical", disabled)
+  .guard_scalar("title", "character", title)
   .o <- list(
     name=name,
     label=label,
     icon=icon,
-    disabled=disabled)
+    disabled=disabled,
+    title=title)
   class(.o) <- append(class(.o), c(.wave_obj, "WaveNavItem"))
   return(.o)
 }

--- a/tools/intellij-plugin/src/main/resources/templates/wave-components.xml
+++ b/tools/intellij-plugin/src/main/resources/templates/wave-components.xml
@@ -1526,12 +1526,12 @@
       <option name="Python" value="true"/>
     </context>
   </template>
-  <template name="w_full_nav_item" value="ui.nav_item(name='$name$',label='$label$',icon='$icon$',disabled=$disabled$,title='$title$'),$END$" description="Create Wave NavItem with full attributes." toReformat="true" toShortenFQNames="true">
+  <template name="w_full_nav_item" value="ui.nav_item(name='$name$',label='$label$',icon='$icon$',disabled=$disabled$,tooltip='$tooltip$'),$END$" description="Create Wave NavItem with full attributes." toReformat="true" toShortenFQNames="true">
     <variable name="name" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="label" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="icon" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="disabled" expression="" defaultValue="&quot;False&quot;" alwaysStopAt="true"/>
-    <variable name="title" expression="" defaultValue="" alwaysStopAt="true"/>
+    <variable name="tooltip" expression="" defaultValue="" alwaysStopAt="true"/>
     <context>
       <option name="Python" value="true"/>
     </context>

--- a/tools/intellij-plugin/src/main/resources/templates/wave-components.xml
+++ b/tools/intellij-plugin/src/main/resources/templates/wave-components.xml
@@ -1526,11 +1526,12 @@
       <option name="Python" value="true"/>
     </context>
   </template>
-  <template name="w_full_nav_item" value="ui.nav_item(name='$name$',label='$label$',icon='$icon$',disabled=$disabled$),$END$" description="Create Wave NavItem with full attributes." toReformat="true" toShortenFQNames="true">
+  <template name="w_full_nav_item" value="ui.nav_item(name='$name$',label='$label$',icon='$icon$',disabled=$disabled$,title='$title$'),$END$" description="Create Wave NavItem with full attributes." toReformat="true" toShortenFQNames="true">
     <variable name="name" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="label" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="icon" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="disabled" expression="" defaultValue="&quot;False&quot;" alwaysStopAt="true"/>
+    <variable name="title" expression="" defaultValue="" alwaysStopAt="true"/>
     <context>
       <option name="Python" value="true"/>
     </context>

--- a/tools/wavegen/wave-components.json
+++ b/tools/wavegen/wave-components.json
@@ -1220,7 +1220,7 @@
   "Wave Full NavItem": {
     "prefix": "w_full_nav_item",
     "body": [
-      "ui.nav_item(name='$1', label='$2', icon='$3', disabled=${4:False}),$0"
+      "ui.nav_item(name='$1', label='$2', icon='$3', disabled=${4:False}, title='$5'),$0"
     ],
     "description": "Create a full Wave NavItem."
   },

--- a/tools/wavegen/wave-components.json
+++ b/tools/wavegen/wave-components.json
@@ -1220,7 +1220,7 @@
   "Wave Full NavItem": {
     "prefix": "w_full_nav_item",
     "body": [
-      "ui.nav_item(name='$1', label='$2', icon='$3', disabled=${4:False}, title='$5'),$0"
+      "ui.nav_item(name='$1', label='$2', icon='$3', disabled=${4:False}, tooltip='$5'),$0"
     ],
     "description": "Create a full Wave NavItem."
   },

--- a/ui/src/nav.tsx
+++ b/ui/src/nav.tsx
@@ -32,8 +32,8 @@ export interface NavItem {
   icon?: S
   /** True if this item should be disabled. */
   disabled?: B
-  /** The item title, typically displayed as a tooltip. */
-  title?: S
+  /** An optional tooltip message displayed when a user hovers over this item. */
+  tooltip?: S
 }
 
 /** Create a group of navigation items. */
@@ -117,12 +117,12 @@ export const
     const groups = items.map((g): Fluent.INavLinkGroup => ({
       name: g.label,
       collapseByDefault: g.collapsed,
-      links: g.items.map(({ name, label, icon, disabled, title }): Fluent.INavLink => ({
+      links: g.items.map(({ name, label, icon, disabled, tooltip }): Fluent.INavLink => ({
         key: name,
         name: label,
         icon,
         disabled,
-        title,
+        title: tooltip,
         style: disabled ? { opacity: 0.7 } : undefined,
         url: '',
         onClick: () => {
@@ -142,7 +142,7 @@ export const
     const render = () => {
       const { title, subtitle, icon, icon_color = '$text', image, persona, secondary_items, color = 'card' } = state
       return (
-        <div data-test={name} className={clas(getEffectClass(toCardEffect(color)), css.card)} style={{ background: color === 'primary' ? cssVar('$saturatedPrimary') : undefined }}>
+        <div data-test={name} className={clas(getEffectClass(toCardEffect(color)), css.card)}>
           <div className={css.header}>
             {(image || icon) && (
               <div className={css.brand}>

--- a/ui/src/nav.tsx
+++ b/ui/src/nav.tsx
@@ -142,7 +142,7 @@ export const
     const render = () => {
       const { title, subtitle, icon, icon_color = '$text', image, persona, secondary_items, color = 'card' } = state
       return (
-        <div data-test={name} className={clas(getEffectClass(toCardEffect(color)), css.card)}>
+        <div data-test={name} className={clas(getEffectClass(toCardEffect(color)), css.card)} style={{ background: color === 'primary' ? cssVar('$saturatedPrimary') : undefined }}>
           <div className={css.header}>
             {(image || icon) && (
               <div className={css.brand}>

--- a/ui/src/nav.tsx
+++ b/ui/src/nav.tsx
@@ -32,6 +32,8 @@ export interface NavItem {
   icon?: S
   /** True if this item should be disabled. */
   disabled?: B
+  /** The item title, typically displayed as a tooltip. */
+  title?: S
 }
 
 /** Create a group of navigation items. */
@@ -115,11 +117,12 @@ export const
     const groups = items.map((g): Fluent.INavLinkGroup => ({
       name: g.label,
       collapseByDefault: g.collapsed,
-      links: g.items.map(({ name, label, icon, disabled }): Fluent.INavLink => ({
+      links: g.items.map(({ name, label, icon, disabled, title }): Fluent.INavLink => ({
         key: name,
         name: label,
         icon,
         disabled,
+        title,
         style: disabled ? { opacity: 0.7 } : undefined,
         url: '',
         onClick: () => {


### PR DESCRIPTION
This PR introduces optional `tooltip` attribute to `nav_item`, which is displayed as a tooltip when user hovers over the nav item.

https://user-images.githubusercontent.com/23740173/150335269-732618c6-5e84-4f60-8970-c4e4a85b99a3.mov

Closes #692 