### PR TITLE
Tiny doc update - missing ')'

### DIFF
--- a/website/widgets/overview.md
+++ b/website/widgets/overview.md
@@ -59,7 +59,7 @@ native Wave components and use custom HTML only as a last resort solution.
 - [wide_pie_stat](/docs/widgets/stat/wide_pie_stat)
 - [wide_bar_stat](/docs/widgets/stat/wide_bar_stat)
 - [wide_gauge_stat](/docs/widgets/stat/wide_gauge_stat)
-- [wide_series_stat](/docs/widgets/stat/wide_series_stat
+- [wide_series_stat](/docs/widgets/stat/wide_series_stat)
 
 ## Form
 


### PR DESCRIPTION
missing `)` for markdown link

![image](https://user-images.githubusercontent.com/64787868/151900679-7c1a015f-db71-42a6-8f5b-5a947ee68c45.png)
