### PR TITLE
Fix changing the default wave server port using env var

### DIFF
--- a/py/h2o_wave/cli.py
+++ b/py/h2o_wave/cli.py
@@ -87,7 +87,7 @@ def run(app: str, no_reload: bool, no_autostart: bool):
         app = app_path.replace(os.path.sep, '.')
 
     # Try to start Wave daemon if not running or turned off.
-    server_port = int(os.environ.get('H2O_WAVE_LISTEN', 10101))
+    server_port = int(os.environ.get('H2O_WAVE_LISTEN', ':10101').split(':')[-1])
     server_not_running = _scan_free_port(server_port) == server_port
     try:
         waved = 'waved.exe' if 'Windows' in platform.system() else './waved'


### PR DESCRIPTION
The Python code was expecting an integer in H2O_WAVE_LISTEN while the
Golang side was expecting :#####.  Fix this by updating the Python side
to parse the string version.

Fixes #1220.