### PR TITLE
fix: Kill hanging waved process when app fails to start.

### DIFF
--- a/py/setup.py
+++ b/py/setup.py
@@ -71,11 +71,10 @@ setuptools.setup(
     ],
     python_requires='>=3.6.1',
     install_requires=[
-        'certifi',  # Workaround for urllib.error.URLError SSL: CERTIFICATE_VERIFY_FAILED on OSX
         'Click',
         'httpx==0.16.1',
         'starlette==0.13.8',
-        'uvicorn==0.12.2',
+        'uvicorn==0.16',
     ],
     entry_points=dict(
         console_scripts=["wave = h2o_wave.cli:main"]


### PR DESCRIPTION
* Kill waved server process created during `wave run` if the app exits with failure.
* Had to update uvicorn to `0.16` due to https://github.com/encode/uvicorn/pull/1278 - uvicorn previously returned 0 exit code no matter what meaning there was no way of distinguishing when the app failed.
* Minor: Remove unnecessary `certifi` dep.