### PR TITLE
fix: make table filter icon clickable

### DIFF
--- a/ui/src/table.tsx
+++ b/ui/src/table.tsx
@@ -263,7 +263,7 @@ const
       [colContextMenuList, setColContextMenuList] = React.useState<Fluent.IContextualMenuProps | null>(null),
       selectedFiltersRef = React.useRef(selectedFilters),
       onColumnClick = (e: React.MouseEvent<HTMLElement>, column: WaveColumn) => {
-        const isMenuClicked = (e.target as HTMLElement).closest('[data-icon-name=\'ChevronDown\']')
+        const isMenuClicked = (e.target as HTMLElement).closest('[data-icon-name="ChevronDown"]')
 
         if (isMenuClicked) onColumnContextMenu(column, e)
         else if (column.isSortable) {

--- a/ui/src/table.tsx
+++ b/ui/src/table.tsx
@@ -263,7 +263,7 @@ const
       [colContextMenuList, setColContextMenuList] = React.useState<Fluent.IContextualMenuProps | null>(null),
       selectedFiltersRef = React.useRef(selectedFilters),
       onColumnClick = (e: React.MouseEvent<HTMLElement>, column: WaveColumn) => {
-        const isMenuClicked = (e.target as HTMLElement).getAttribute('data-icon-name') === 'ChevronDown'
+        const isMenuClicked = (e.target as HTMLElement).closest('[data-icon-name=\'ChevronDown\']')
 
         if (isMenuClicked) onColumnContextMenu(column, e)
         else if (column.isSortable) {


### PR DESCRIPTION
Fixes the click handler for Chevron Down icon on Table component. Didn't spot the same incorrect behavior on other icons.

### Before
![2022-03-04 10 40 20](https://user-images.githubusercontent.com/15820796/157077089-75e8c964-cd9e-4247-bf9d-9f6ccd2a8746.gif)

### Afte
![2022-03-07 13 35 35](https://user-images.githubusercontent.com/15820796/157077101-35347b3e-6756-4686-8576-5e250f90ac94.gif)