### PR TITLE
fix: remove click handler for right click

### DIFF
--- a/ui/src/table.tsx
+++ b/ui/src/table.tsx
@@ -347,7 +347,7 @@ const
             />
           </Fluent.Sticky>
         )
-      }, [groups, onColumnContextMenu]),
+      }, [groups]),
       onRenderRow = (props?: Fluent.IDetailsRowProps) => props
         ? <Fluent.DetailsRow {...props} styles={{
           cell: { alignSelf: 'center', fontSize: 14, lineHeight: 20, color: cssVar('$text9') },

--- a/ui/src/table.tsx
+++ b/ui/src/table.tsx
@@ -330,7 +330,6 @@ const
           <Fluent.Sticky stickyPosition={Fluent.StickyPositionType.Header} isScrollSynced>
             <Fluent.DetailsHeader
               {...props}
-              onColumnContextMenu={onColumnContextMenu}
               styles={{
                 ...props.styles,
                 root: {


### PR DESCRIPTION
Prevent user from opening contextual menu on non-filterable column headers by right-clicking

![2022-03-15 15 01 49](https://user-images.githubusercontent.com/15820796/158442535-9aa5d436-42a8-4bf5-a2f7-eb18b30f4ef8.gif)

Closes #1276 