### PR TITLE
fix: set the dropdown input to "width" prop

### DIFF
--- a/ui/src/form.tsx
+++ b/ui/src/form.tsx
@@ -258,7 +258,7 @@ const
     if (m.checkbox) return <XToolTip content={m.checkbox.tooltip} expand={false}><XCheckbox model={m.checkbox} /></XToolTip>
     if (m.toggle) return <XToolTip content={m.toggle.tooltip} expand={false}><XToggle model={m.toggle} /></XToolTip>
     if (m.choice_group) return <XToolTip content={m.choice_group.tooltip}><XChoiceGroup model={m.choice_group} /></XToolTip>
-    if (m.dropdown) return <XToolTip content={m.dropdown.tooltip}><XDropdown model={m.dropdown} /></XToolTip>
+    if (m.dropdown) return <XToolTip expand={false} content={m.dropdown.tooltip}><XDropdown model={m.dropdown} /></XToolTip>
     if (m.checklist) return <XToolTip content={m.checklist.tooltip}><XChecklist model={m.checklist} /></XToolTip>
     if (m.combobox) return <XToolTip content={m.combobox.tooltip}><XCombobox model={m.combobox} /></XToolTip>
     if (m.slider) return <XToolTip content={m.slider.tooltip}><XSlider model={m.slider} /></XToolTip>

--- a/ui/src/form.tsx
+++ b/ui/src/form.tsx
@@ -258,7 +258,7 @@ const
     if (m.checkbox) return <XToolTip content={m.checkbox.tooltip} expand={false}><XCheckbox model={m.checkbox} /></XToolTip>
     if (m.toggle) return <XToolTip content={m.toggle.tooltip} expand={false}><XToggle model={m.toggle} /></XToolTip>
     if (m.choice_group) return <XToolTip content={m.choice_group.tooltip}><XChoiceGroup model={m.choice_group} /></XToolTip>
-    if (m.dropdown) return <XToolTip expand={false} content={m.dropdown.tooltip}><XDropdown model={m.dropdown} /></XToolTip>
+    if (m.dropdown) return <XToolTip content={m.dropdown.tooltip}><XDropdown model={m.dropdown} /></XToolTip>
     if (m.checklist) return <XToolTip content={m.checklist.tooltip}><XChecklist model={m.checklist} /></XToolTip>
     if (m.combobox) return <XToolTip content={m.combobox.tooltip}><XCombobox model={m.combobox} /></XToolTip>
     if (m.slider) return <XToolTip content={m.slider.tooltip}><XSlider model={m.slider} /></XToolTip>

--- a/ui/src/tooltip.tsx
+++ b/ui/src/tooltip.tsx
@@ -17,6 +17,7 @@ import { B, S } from 'h2o-wave'
 import React from 'react'
 import { stylesheet } from 'typestyle'
 import { Markdown } from './markdown'
+import { cssVar } from './theme'
 
 const
   css = stylesheet({
@@ -29,7 +30,7 @@ const
       flexGrow: 1
     },
     icon: {
-      color: '#323130',
+      color: cssVar('$text'),
       fontWeight: 400,
       fontSize: '14px',
       userSelect: 'none',
@@ -44,7 +45,7 @@ const
   })
 
 export const
-  XToolTip = ({ children, content, showIcon, expand }: {
+  XToolTip = ({ children, content, showIcon = true, expand = true }: {
     children: React.ReactChild,
     content?: S,
     showIcon?: B,
@@ -52,17 +53,14 @@ export const
   }) => {
     if (!content) return <>{children}</>
 
-    const
-      tooltipProps: Fluent.ITooltipProps = {
-        onRenderContent: () => (<div><Markdown source={content} /></div>)
-      }
+    const tooltipProps: Fluent.ITooltipProps = { onRenderContent: () => <div><Markdown source={content} /></div> }
     return (
       <div className={css.container} data-test='tooltip'>
         {
-          showIcon === undefined || showIcon
+          showIcon
             ? (
               <>
-                <div className={expand === undefined || expand ? css.element : css.preventOverflow }>{children}</div>
+                <div className={expand ? css.element : css.preventOverflow}>{children}</div>
                 <Fluent.TooltipHost tooltipProps={tooltipProps}>
                   <Fluent.FontIcon className={css.icon} iconName='Info' />
                 </Fluent.TooltipHost>

--- a/ui/src/tooltip.tsx
+++ b/ui/src/tooltip.tsx
@@ -36,6 +36,10 @@ const
       textAlign: 'left',
       marginLeft: '0.5em',
       cursor: 'pointer'
+    },
+    preventOverflow: {
+      minWidth: 0,
+      flex: '1 1 0'
     }
   })
 
@@ -58,7 +62,7 @@ export const
           showIcon === undefined || showIcon
             ? (
               <>
-                <div className={expand === undefined || expand ? css.element : ''}>{children}</div>
+                <div className={expand === undefined || expand ? css.element : css.preventOverflow }>{children}</div>
                 <Fluent.TooltipHost tooltipProps={tooltipProps}>
                   <Fluent.FontIcon className={css.icon} iconName='Info' />
                 </Fluent.TooltipHost>

--- a/ui/src/tooltip.tsx
+++ b/ui/src/tooltip.tsx
@@ -17,7 +17,7 @@ import { B, S } from 'h2o-wave'
 import React from 'react'
 import { stylesheet } from 'typestyle'
 import { Markdown } from './markdown'
-import { cssVar } from './theme'
+import { clas, cssVar } from './theme'
 
 const
   css = stylesheet({
@@ -26,7 +26,7 @@ const
       alignItems: 'flex-start',
       alignContent: 'flex-start'
     },
-    element: {
+    expand: {
       flexGrow: 1
     },
     icon: {
@@ -39,8 +39,7 @@ const
       cursor: 'pointer'
     },
     preventOverflow: {
-      minWidth: 0,
-      flex: '1 1 0'
+      minWidth: 0
     }
   })
 
@@ -60,7 +59,7 @@ export const
           showIcon
             ? (
               <>
-                <div className={expand ? css.element : css.preventOverflow}>{children}</div>
+                <div className={clas(css.preventOverflow, expand ? css.expand : '')}>{children}</div>
                 <Fluent.TooltipHost tooltipProps={tooltipProps}>
                   <Fluent.FontIcon className={css.icon} iconName='Info' />
                 </Fluent.TooltipHost>


### PR DESCRIPTION
@mturoci 
Looks like the `width` prop on Dropdown was not being used. 

`Fluent.Dropdown` has a property called `dropdownWidth` which is used to control the size of the dropdown. I used `width` prop to control the size of the input instead. 

Example using `ui.dropdown` with tooltip and width = 200px:

![2022-03-15 15 54 39](https://user-images.githubusercontent.com/15820796/158451621-9f991a37-c7ad-4374-8015-a330b6be8f75.gif)

With tooltip and not specifying the width:

![2022-03-15 16 00 05](https://user-images.githubusercontent.com/15820796/158451994-6576f040-24d8-4b30-8709-fc8e14217448.gif)

@psinger is this the intended behavior?

Closes #1164 