### PR TITLE
docs: Make plots look normal in docs/widgets section.

### DIFF
--- a/py/examples/wizard.py
+++ b/py/examples/wizard.py
@@ -1,47 +1,32 @@
 # Wizard
 # Create a multi-step #wizard using #form cards.
 # ---
-from h2o_wave import Q, ui, main, app, cypress, Cypress
+from h2o_wave import Q, ui, main, app, cypress, Cypress, data
 
 
 @app('/demo')
 async def serve(q: Q):
-    if not q.client.initialized:  # First visit, create an empty form card for our wizard
-        q.page['wizard'] = ui.form_card(box='1 1 2 4', items=[])
-        q.client.initialized = True
-
-    ui.button(name='default'),
-    wizard = q.page['wizard']  # Get a reference to the wizard form
-    if q.args.step1:
-        wizard.items = [
-            ui.text_xl('Wizard - Step 1'),
-            ui.text('What is your name?', name='text'),
-            ui.textbox(name='nickname', label='My name is...', value='Gandalf'),
-            ui.buttons([ui.button(name='step2', label='Next', primary=True)]),
-        ]
-    elif q.args.step2:
-        q.client.nickname = q.args.nickname
-        wizard.items = [
-            ui.text_xl('Wizard - Step 2'),
-            ui.text(f'Hi {q.args.nickname}! How do you feel right now?', name='text'),
-            ui.textbox(name='feeling', label='I feel...', value='magical'),
-            ui.buttons([ui.button(name='step3', label='Next', primary=True)]),
-        ]
-    elif q.args.step3:
-        wizard.items = [
-            ui.text_xl('Wizard - Done'),
-            ui.text(
-                f'What a coincidence, {q.client.nickname}! I feel {q.args.feeling} too!',
-                name='text',
-            ),
-            ui.buttons([ui.button(name='step1', label='Try Again', primary=True)]),
-        ]
-    else:
-        wizard.items = [
-            ui.text_xl('Wizard Example'),
-            ui.text("Let's have a conversation, shall we?"),
-            ui.buttons([ui.button(name='step1', label='Of course!', primary=True)]),
-        ]
+    q.page['example'] = ui.plot_card(
+        box='1 1 4 5',
+        title='Label Customization',
+        data=data('profession salary', 10, rows=[
+            ('medicine', 33000),
+            ('fire fighting', 18000),
+            ('pedagogy', 24000),
+            ('psychology', 22500),
+            ('computer science', 36000),
+        ]),
+        plot=ui.plot([
+            ui.mark(
+                type='interval',
+                x='=profession',
+                y='=salary', y_min=0,
+                label='=${{intl price minimum_fraction_digits=2 maximum_fraction_digits=2}}',
+                label_offset=0, label_position='middle', label_rotation='-90', label_fill_color='#fff',
+                label_font_weight='bold'
+            )
+        ])
+    )
 
     await q.page.save()
 

--- a/ui/src/plot.tsx
+++ b/ui/src/plot.tsx
@@ -776,6 +776,12 @@ const
           },
           interval: {
             rect: {
+              default: {
+                // TODO: Check if this stroke is not settable in polar charts.
+                style: {
+                  stroke: cssVar('$card'),
+                },
+              },
               selected: {
                 style: {
                   stroke: cssVar('$text'),

--- a/ui/src/plot.tsx
+++ b/ui/src/plot.tsx
@@ -776,12 +776,6 @@ const
           },
           interval: {
             rect: {
-              default: {
-                // TODO: Check if this stroke is not settable in polar charts.
-                style: {
-                  stroke: cssVar('$card'),
-                },
-              },
               selected: {
                 style: {
                   stroke: cssVar('$text'),

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -141,6 +141,17 @@ module.exports = {
       },
       {
         "type": "category",
+        "label": "Plots",
+        "items": [
+          "widgets/plots/point",
+          "widgets/plots/interval",
+          "widgets/plots/line",
+          "widgets/plots/area",
+          "widgets/plots/path",
+        ]
+      },
+      {
+        "type": "category",
         "label": "Overlays",
         "items": [
           "widgets/overlays/dialog",

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -143,11 +143,24 @@ module.exports = {
         "type": "category",
         "label": "Plots",
         "items": [
+          "widgets/plots/overview",
           "widgets/plots/point",
           "widgets/plots/interval",
           "widgets/plots/line",
           "widgets/plots/area",
           "widgets/plots/path",
+          {
+            "type": "category",
+            "label": "Third Party Plots",
+            "items": [
+              "widgets/plots/third-party/altair",
+              "widgets/plots/third-party/bokeh",
+              "widgets/plots/third-party/d3",
+              "widgets/plots/third-party/matplotlib",
+              "widgets/plots/third-party/plotly",
+              "widgets/plots/third-party/vegalite",
+            ]
+          }
         ]
       },
       {

--- a/website/widgets/plots/area.md
+++ b/website/widgets/plots/area.md
@@ -3,9 +3,9 @@ title: Area
 custom_edit_url: null
 ---
 
-Use area charts if total value is as important as individual values and you want
+Use area charts if the total value is as important as individual values and you want
 to show the relationship between these two. However, area charts work well only if
-the value differences are larger, otherwise you end up with a single big area covering
+the value differences are larger otherwise you end up with a single big area covering
 most of the chart.
 
 Check the full API at [ui.plot_card](/docs/api/ui#plot_card).
@@ -16,19 +16,18 @@ from h2o_wave import data
 q.page['example'] = ui.plot_card(
     box='1 1 4 5',
     title='Area',
-    data=data('date price', 10, rows=[
-        ('2020-03-20', 124),
-        ('2020-05-18', 580),
-        ('2020-08-24', 528),
-        ('2020-02-12', 361),
-        ('2020-03-11', 228),
-        ('2020-09-26', 418),
-        ('2020-11-12', 824),
-        ('2020-12-21', 539),
-        ('2020-03-18', 712),
-        ('2020-07-11', 213),
+    data=data('year price', 9, rows=[
+        ('1991', 15468),
+        ('1992', 16100),
+        ('1993', 15900),
+        ('1994', 17409),
+        ('1995', 17000),
+        ('1996', 31056),
+        ('1997', 31982),
+        ('1998', 32040),
+        ('1999', 33233),
     ]),
-    plot=ui.plot([ui.mark(type='area', x_scale='time', x='=date', y='=price', y_min=0)])
+    plot=ui.plot([ui.mark(type='area', x='=year', y='=price', y_min=0)])
 )
 ```
 
@@ -42,20 +41,34 @@ from h2o_wave import data
 q.page['example'] = ui.plot_card(
     box='1 1 4 5',
     title='Area, stacked',
-    data=data('product date price', 10, rows=[
-        ('P1', '2020-03-20', 124),
-        ('P2', '2020-05-18', 580),
-        ('P3', '2020-08-24', 528),
-        ('P1', '2020-02-12', 361),
-        ('P2', '2020-03-11', 228),
-        ('P3', '2020-09-26', 418),
-        ('P1', '2020-11-12', 824),
-        ('P2', '2020-12-21', 539),
-        ('P3', '2020-03-18', 712),
-        ('P1', '2020-07-11', 213),
+    data=data('month city temperature', 24, rows=[
+        ('Jan', 'Tokyo', 7),
+        ('Jan', 'London', 3.9),
+        ('Feb', 'Tokyo', 6.9),
+        ('Feb', 'London', 4.2),
+        ('Mar', 'Tokyo', 9.5),
+        ('Mar', 'London', 5.7),
+        ('Apr', 'Tokyo', 14.5),
+        ('Apr', 'London', 8.5),
+        ('May', 'Tokyo', 18.4),
+        ('May', 'London', 11.9),
+        ('Jun', 'Tokyo', 21.5),
+        ('Jun', 'London', 15.2),
+        ('Jul', 'Tokyo', 25.2),
+        ('Jul', 'London', 17),
+        ('Aug', 'Tokyo', 26.5),
+        ('Aug', 'London', 16.6),
+        ('Sep', 'Tokyo', 23.3),
+        ('Sep', 'London', 14.2),
+        ('Oct', 'Tokyo', 18.3),
+        ('Oct', 'London', 10.3),
+        ('Nov', 'Tokyo', 13.9),
+        ('Nov', 'London', 6.6),
+        ('Dec', 'Tokyo', 9.6),
+        ('Dec', 'London', 4.8),
     ]),
     plot=ui.plot([
-        ui.mark(type='area', x_scale='time', x='=date', y='=price', color='=product', y_min=0)
+        ui.mark(type='area', x='=month', y='=temperature', color='=city', y_min=0)
     ])
 )
 ```
@@ -70,20 +83,38 @@ from h2o_wave import data
 q.page['example'] = ui.plot_card(
     box='1 1 4 5',
     title='Area, stacked',
-    data=data('product date price', 10, rows=[
-        ('P1', '2020-03-20', 124),
-        ('P2', '2020-05-18', 580),
-        ('P3', '2020-08-24', 528),
-        ('P1', '2020-02-12', 361),
-        ('P2', '2020-03-11', 228),
-        ('P3', '2020-09-26', 418),
-        ('P1', '2020-11-12', 824),
-        ('P2', '2020-12-21', 539),
-        ('P3', '2020-03-18', 712),
-        ('P1', '2020-07-11', 213),
+    data=data('country year value', 28, rows=[
+        ('Asia', '1750', 502),
+        ('Asia', '1800', 635),
+        ('Asia', '1850', 809),
+        ('Asia', '1900', 5268),
+        ('Asia', '1950', 4400),
+        ('Asia', '1999', 3634),
+        ('Asia', '2050', 947),
+        ('Africa', '1750', 106),
+        ('Africa', '1800', 107),
+        ('Africa', '1850', 111),
+        ('Africa', '1900', 1766),
+        ('Africa', '1950', 221),
+        ('Africa', '1999', 767),
+        ('Africa', '2050', 133),
+        ('Europe', '1750', 163),
+        ('Europe', '1800', 203),
+        ('Europe', '1850', 276),
+        ('Europe', '1900', 628),
+        ('Europe', '1950', 547),
+        ('Europe', '1999', 729),
+        ('Europe', '2050', 408),
+        ('Oceania', '1750', 200),
+        ('Oceania', '1800', 200),
+        ('Oceania', '1850', 200),
+        ('Oceania', '1900', 460),
+        ('Oceania', '1950', 230),
+        ('Oceania', '1999', 300),
+        ('Oceania', '2050', 300),
     ]),
     plot=ui.plot([
-        ui.mark(type='area', x_scale='time', x='=date', y='=price', y_min=0, color='=product', stack='auto')
+        ui.mark(type='area', x_scale='time', x='=year', y='=value', y_min=0, color='=country', stack='auto')
     ])
 )
 ```
@@ -98,17 +129,38 @@ from h2o_wave import data
 q.page['example'] = ui.plot_card(
     box='1 1 4 5',
     title='Area, range',
-    data=data('date low high', 10, rows=[
-        ('2020-03-20', 22, 124),
-        ('2020-05-18', 51, 580),
-        ('2020-08-24', 69, 528),
-        ('2020-02-12', 23, 361),
-        ('2020-03-11', 44, 228),
-        ('2020-09-26', 69, 418),
-        ('2020-11-12', 96, 824),
-        ('2020-12-21', 81, 539),
-        ('2020-03-18', 85, 712),
-        ('2020-07-11', 18, 213),
+    data=data('date low high', 31, rows=[
+        (1246406400000, 14.3, 27.7),
+        (1246492800000, 14.5, 27.8),
+        (1246579200000, 15.5, 29.6),
+        (1246665600000, 16.7, 30.7),
+        (1246752000000, 16.5, 25.0),
+        (1246838400000, 17.8, 25.7),
+        (1246924800000, 13.5, 24.8),
+        (1247011200000, 10.5, 21.4),
+        (1247097600000, 9.2, 23.8),
+        (1247184000000, 11.6, 21.8),
+        (1247270400000, 10.7, 23.7),
+        (1247356800000, 11.0, 23.3),
+        (1247443200000, 11.6, 23.7),
+        (1247529600000, 11.8, 20.7),
+        (1247616000000, 12.6, 22.4),
+        (1247702400000, 13.6, 19.6),
+        (1247788800000, 11.4, 22.6),
+        (1247875200000, 13.2, 25.0),
+        (1247961600000, 14.2, 21.6),
+        (1248048000000, 13.1, 17.1),
+        (1248134400000, 12.2, 15.5),
+        (1248220800000, 12.0, 20.8),
+        (1248307200000, 12.0, 17.1),
+        (1248393600000, 12.7, 18.3),
+        (1248480000000, 12.4, 19.4),
+        (1248566400000, 12.6, 19.9),
+        (1248652800000, 11.9, 20.2),
+        (1248739200000, 11.0, 19.3),
+        (1248825600000, 10.8, 17.8),
+        (1248912000000, 11.8, 18.5),
+        (1248998400000, 10.8, 16.1),
     ]),
     plot=ui.plot([ui.mark(type='area', x_scale='time', x='=date', y0='=low', y='=high')])
 )
@@ -124,19 +176,29 @@ from h2o_wave import data
 q.page['example'] = ui.plot_card(
     box='1 1 4 5',
     title='Area, negative values',
-    data=data('date price', 10, rows=[
-        ('2020-03-20', 124),
-        ('2020-05-18', -580),
-        ('2020-08-24', 528),
-        ('2020-02-12', 361),
-        ('2020-03-11', -228),
-        ('2020-09-26', -418),
-        ('2020-11-12', -824),
-        ('2020-12-21', 539),
-        ('2020-03-18', 712),
-        ('2020-07-11', 213),
+    data=data('year value', 20, rows=[
+        ('1996', 322),
+        ('1997', 324),
+        ('1998', -329),
+        ('1999', 342),
+        ('2000', -348),
+        ('2001', -334),
+        ('2002', 325),
+        ('2003', 316),
+        ('2004', 318),
+        ('2005', -330),
+        ('2006', 355),
+        ('2007', -366),
+        ('2008', -337),
+        ('2009', -352),
+        ('2010', -377),
+        ('2011', 383),
+        ('2012', 344),
+        ('2013', 366),
+        ('2014', -389),
+        ('2015', 334),
     ]),
-    plot=ui.plot([ui.mark(type='area', x_scale='time', x='=date', y='=price')])
+    plot=ui.plot([ui.mark(type='area', x='=year', y='=value')])
 )
 ```
 
@@ -150,19 +212,18 @@ from h2o_wave import data
 q.page['example'] = ui.plot_card(
     box='1 1 4 5',
     title='Area, negative values',
-    data=data('date price', 10, rows=[
-        ('2020-03-20', 124),
-        ('2020-05-18', 580),
-        ('2020-08-24', 528),
-        ('2020-02-12', 361),
-        ('2020-03-11', 228),
-        ('2020-09-26', 418),
-        ('2020-11-12', 824),
-        ('2020-12-21', 539),
-        ('2020-03-18', 712),
-        ('2020-07-11', 213),
+    data=data('year price', 9, rows=[
+        ('1991', 15468),
+        ('1992', 16100),
+        ('1993', 15900),
+        ('1994', 17409),
+        ('1995', 17000),
+        ('1996', 31056),
+        ('1997', 31982),
+        ('1998', 32040),
+        ('1999', 33233),
     ]),
-    plot=ui.plot([ui.mark(type='area', x_scale='time', x='=date', y='=price', curve='smooth', y_min=0)])
+    plot=ui.plot([ui.mark(type='area', x_scale='time', x='=year', y='=price', curve='smooth', y_min=0)])
 )
 ```
 
@@ -176,28 +237,27 @@ from h2o_wave import data
 q.page['example'] = ui.plot_card(
     box='1 1 4 5',
     title='Area + Line',
-    data=data('date price', 10, rows=[
-        ('2020-03-20', 124),
-        ('2020-05-18', 580),
-        ('2020-08-24', 528),
-        ('2020-02-12', 361),
-        ('2020-03-11', 228),
-        ('2020-09-26', 418),
-        ('2020-11-12', 824),
-        ('2020-12-21', 539),
-        ('2020-03-18', 712),
-        ('2020-07-11', 213),
+    data=data('year price', 9, rows=[
+        ('1991', 15468),
+        ('1992', 16100),
+        ('1993', 15900),
+        ('1994', 17409),
+        ('1995', 17000),
+        ('1996', 31056),
+        ('1997', 31982),
+        ('1998', 32040),
+        ('1999', 33233),
     ]),
     plot=ui.plot([
-        ui.mark(type='area', x_scale='time', x='=date', y='=price', y_min=0),
-        ui.mark(type='line', x='=date', y='=price')
+        ui.mark(type='area', x='=year', y='=price', y_min=0),
+        ui.mark(type='line', x='=year', y='=price')
     ])
 )
 ```
 
 ### Line groups
 
-Make an combined area + line plot showing multiple categories.
+Make a combined area + line plot showing multiple categories.
 
 ```py
 from h2o_wave import data
@@ -205,21 +265,35 @@ from h2o_wave import data
 q.page['example'] = ui.plot_card(
     box='1 1 4 5',
     title='Area + Line, groups',
-    data=data('product date price', 10, rows=[
-        ('P1', '2020-03-20', 124),
-        ('P2', '2020-05-18', 580),
-        ('P3', '2020-08-24', 528),
-        ('P1', '2020-02-12', 361),
-        ('P2', '2020-03-11', 228),
-        ('P3', '2020-09-26', 418),
-        ('P1', '2020-11-12', 824),
-        ('P2', '2020-12-21', 539),
-        ('P3', '2020-03-18', 712),
-        ('P1', '2020-07-11', 213),
+    data=data('month city temperature', 24, rows=[
+        ('Jan', 'Tokyo', 7),
+        ('Jan', 'London', 3.9),
+        ('Feb', 'Tokyo', 6.9),
+        ('Feb', 'London', 4.2),
+        ('Mar', 'Tokyo', 9.5),
+        ('Mar', 'London', 5.7),
+        ('Apr', 'Tokyo', 14.5),
+        ('Apr', 'London', 8.5),
+        ('May', 'Tokyo', 18.4),
+        ('May', 'London', 11.9),
+        ('Jun', 'Tokyo', 21.5),
+        ('Jun', 'London', 15.2),
+        ('Jul', 'Tokyo', 25.2),
+        ('Jul', 'London', 17),
+        ('Aug', 'Tokyo', 26.5),
+        ('Aug', 'London', 16.6),
+        ('Sep', 'Tokyo', 23.3),
+        ('Sep', 'London', 14.2),
+        ('Oct', 'Tokyo', 18.3),
+        ('Oct', 'London', 10.3),
+        ('Nov', 'Tokyo', 13.9),
+        ('Nov', 'London', 6.6),
+        ('Dec', 'Tokyo', 9.6),
+        ('Dec', 'London', 4.8),
     ]),
     plot=ui.plot([
-        ui.mark(type='area', x_scale='time', x='=date', y='=price', color='=product', y_min=0),
-        ui.mark(type='line', x='=date', y='=price', color='=product')
+        ui.mark(type='area', x='=month', y='=temperature', color='=city', y_min=0),
+        ui.mark(type='line', x='=month', y='=temperature', color='=city')
     ])
 )
 ```
@@ -234,21 +308,20 @@ from h2o_wave import data
 q.page['example'] = ui.plot_card(
     box='1 1 4 5',
     title='Area + Line, smooth',
-    data=data('date price', 10, rows=[
-        ('2020-03-20', 124),
-        ('2020-05-18', 580),
-        ('2020-08-24', 528),
-        ('2020-02-12', 361),
-        ('2020-03-11', 228),
-        ('2020-09-26', 418),
-        ('2020-11-12', 824),
-        ('2020-12-21', 539),
-        ('2020-03-18', 712),
-        ('2020-07-11', 213),
+    data=data('year price', 9, rows=[
+        ('1991', 15468),
+        ('1992', 16100),
+        ('1993', 15900),
+        ('1994', 17409),
+        ('1995', 17000),
+        ('1996', 31056),
+        ('1997', 31982),
+        ('1998', 32040),
+        ('1999', 33233),
     ]),
     plot=ui.plot([
-        ui.mark(type='area', x_scale='time', x='=date', y='=price', curve='smooth', y_min=0),
-        ui.mark(type='line', x='=date', y='=price', curve='smooth')
+        ui.mark(type='area', x='=year', y='=price', curve='smooth', y_min=0),
+        ui.mark(type='line', x='=year', y='=price', curve='smooth')
     ])
 )
 ```

--- a/website/widgets/plots/interval.md
+++ b/website/widgets/plots/interval.md
@@ -186,7 +186,7 @@ q.page['example'] = ui.plot_card(
         ('Jul', 37.4),
         ('Aug', 42.4),
     ]),
-    plot=ui.plot([ui.mark(coord='polar', type='interval', x='=month', y='=rainfall', y_min=0)])
+    plot=ui.plot([ui.mark(coord='polar', type='interval', x='=month', y='=rainfall', y_min=0, stroke_color='$card')])
 )
 ```
 
@@ -226,7 +226,8 @@ q.page['example'] = ui.plot_card(
             y='=rainfall',
             color='=city',
             stack='auto',
-            y_min=0
+            y_min=0,
+            stroke_color='$card'
         )
     ])
 )

--- a/website/widgets/plots/interval.md
+++ b/website/widgets/plots/interval.md
@@ -3,8 +3,7 @@ title: Interval
 custom_edit_url: null
 ---
 
-Create interval plots, usually bar charts. Interval plots are good for showing how
-your data is trending.
+Create interval plots, usually bar charts. Interval plots are good for showing how your data is trending.
 
 ```py
 from h2o_wave import data
@@ -12,19 +11,14 @@ from h2o_wave import data
 q.page['example'] = ui.plot_card(
     box='1 1 4 5',
     title='Interval',
-    data=data('product price', 10, rows=[
-        ('P1', 124),
-        ('P2', 580),
-        ('P3', 528),
-        ('P1', 361),
-        ('P2', 228),
-        ('P3', 418),
-        ('P1', 824),
-        ('P2', 539),
-        ('P3', 712),
-        ('P1', 213),
+    data=data('profession salary', 5, rows=[
+        ('medicine', 23000),
+        ('fire fighting', 18000),
+        ('pedagogy', 24000),
+        ('psychology', 22500),
+        ('computer science', 36000),
     ]),
-    plot=ui.plot([ui.mark(type='interval', x='=product', y='=price', y_min=0)])
+    plot=ui.plot([ui.mark(type='interval', x='=profession', y='=salary', y_min=0)])
 )
 ```
 
@@ -32,7 +26,7 @@ Check the full API at [ui.plot_card](/docs/api/ui#plot_card).
 
 ## Transpose
 
-In order to transpose the plot, simply switch the `x` and `y` coordinate values.
+To transpose the plot, simply switch the `x` and `y` coordinate values.
 
 ```py
 from h2o_wave import data
@@ -40,61 +34,20 @@ from h2o_wave import data
 q.page['example'] = ui.plot_card(
     box='1 1 4 5',
     title='Interval transposed',
-    data=data('product price', 10, rows=[
-        ('P1', 124),
-        ('P2', 580),
-        ('P3', 528),
-        ('P1', 361),
-        ('P2', 228),
-        ('P3', 418),
-        ('P1', 824),
-        ('P2', 539),
-        ('P3', 712),
-        ('P1', 213),
+    data=data('profession salary', 5, rows=[
+        ('medicine', 33000),
+        ('fire fighting', 18000),
+        ('pedagogy', 24000),
+        ('psychology', 22500),
+        ('computer science', 36000),
     ]),
-    plot=ui.plot([ui.mark(type='interval', x='=price', y='=product', y_min=0)])
-)
-```
-
-## Theta
-
-Make a "racetrack" plot (a bar plot in polar coordinates, transposed).
-
-```py
-from h2o_wave import data
-
-q.page['example'] = ui.plot_card(
-    box='1 1 4 5',
-    title='Intervals, theta, stacked',
-    data=data('country product price', 10, rows=[
-        ('USA', 'P1', 124),
-        ('China', 'P2', 580),
-        ('USA', 'P3', 528),
-        ('China', 'P1', 361),
-        ('USA', 'P2', 228),
-        ('China', 'P3', 418),
-        ('USA', 'P1', 824),
-        ('China', 'P2', 539),
-        ('USA', 'P3', 712),
-        ('USA', 'P1', 213),
-    ]),
-    plot=ui.plot([
-        ui.mark(
-            coord='theta',
-            type='interval', 
-            x='=product', 
-            y='=price',
-            color='=country',
-            stack='auto',
-            y_min=0
-        )
-    ])
+    plot=ui.plot([ui.mark(type='interval', x='=salary', y='=profession', y_min=0)])
 )
 ```
 
 ## Stacked
 
-Useful when you want to display third dimension to your bar charts.
+Useful when you want to display the third dimension to your bar charts and would like to emphasize the difference in totals across columns.
 
 ```py
 from h2o_wave import data
@@ -102,21 +55,47 @@ from h2o_wave import data
 q.page['example'] = ui.plot_card(
     box='1 1 4 5',
     title='Intervals, stacked',
-    data=data('country product price', 10, rows=[
-        ('USA', 'P1', 124),
-        ('China', 'P2', 580),
-        ('USA', 'P3', 528),
-        ('China', 'P1', 361),
-        ('USA', 'P2', 228),
-        ('China', 'P3', 418),
-        ('USA', 'P1', 824),
-        ('China', 'P2', 539),
-        ('USA', 'P3', 712),
-        ('USA', 'P1', 213),
+    data=data('day type time', 10, rows=[
+        ('Mon.','series1', 2800),
+        ('Mon.','series2', 2260),
+        ('Tues.','series1', 1800),
+        ('Tues.','series2', 1300),
+        ('Wed.','series1', 950),
+        ('Wed.','series2', 900),
+        ('Thur.','series1', 500),
+        ('Thur.','series2', 390),
+        ('Fri.','series1', 170),
+        ('Fri.','series2', 100),
     ]),
     plot=ui.plot([
-        ui.mark(type='interval', x='=product', y='=price', color='=country', stack='auto', y_min=0)
+        ui.mark(type='interval', x='=day', y='=time', color='=type', stack='auto', y_min=0)
     ])
+)
+```
+
+## Grouped
+
+Make a grouped column plot.
+
+```py
+from h2o_wave import data
+
+q.page['example'] = ui.plot_card(
+    box='1 1 4 5',
+    title='Intervals, groups',
+    data=data('day type time', 10, rows=[
+        ('Mon.','series1', 2800),
+        ('Mon.','series2', 2260),
+        ('Tues.','series1', 1800),
+        ('Tues.','series2', 1300),
+        ('Wed.','series1', 950),
+        ('Wed.','series2', 900),
+        ('Thur.','series1', 500),
+        ('Thur.','series2', 390),
+        ('Fri.','series1', 170),
+        ('Fri.','series2', 100),
+    ]),
+    plot=ui.plot([ui.mark(type='interval', x='=day', y='=time', color='=type', dodge='auto', y_min=0)])
 )
 ```
 
@@ -130,26 +109,28 @@ from h2o_wave import data
 q.page['example'] = ui.plot_card(
     box='1 1 4 5',
     title='Intervals, stacked and dodged',
-    data=data('category country product price', 10, rows=[
-        ('G1', 'USA', 'P1', 124),
-        ('G1', 'China', 'P2', 580),
-        ('G1', 'USA', 'P3', 528),
-        ('G1', 'China', 'P1', 361),
-        ('G1', 'USA', 'P2', 228),
-        ('G2', 'China', 'P3', 418),
-        ('G2', 'USA', 'P1', 824),
-        ('G2', 'China', 'P2', 539),
-        ('G2', 'USA', 'P3', 712),
-        ('G2', 'USA', 'P1', 213),
+    data=data('day type time gender', 12, rows=[
+        ('Mon.','series1', 2800, 'male'),
+        ('Mon.','series1', 1800, 'female'),
+        ('Mon.','series2', 2260, 'female'),
+        ('Mon.','series2', 710, 'male'),
+        ('Tues.','series1', 1800, 'male'),
+        ('Tues.','series1', 290, 'female'),
+        ('Tues.','series2', 1300, 'female'),
+        ('Tues.','series2', 960, 'male'),
+        ('Wed.','series1', 950, 'male'),
+        ('Wed.','series1', 2730, 'female'),
+        ('Wed.','series2', 1390, 'male'),
+        ('Wed.','series2', 900, 'female'),
     ]),
     plot=ui.plot([
         ui.mark(
             type='interval',
-            x='=product',
-            y='=price',
-            color='=country',
+            x='=day',
+            y='=time',
+            color='=type',
             stack='auto',
-            dodge='=category',
+            dodge='=gender',
             y_min=0
         )
     ])
@@ -158,8 +139,7 @@ q.page['example'] = ui.plot_card(
 
 ## Range
 
-Make a column plot with each bar representing high/low (or start/end) values.
-Transposing this produces a gantt plot.
+Make a column plot with each bar representing high/low (or start/end) values. Transposing this produces a Gantt plot.
 
 ```py
 from h2o_wave import data
@@ -167,19 +147,14 @@ from h2o_wave import data
 q.page['example'] = ui.plot_card(
     box='1 1 4 5',
     title='Interval, range',
-    data=data('product low high', 10, rows=[
-        ('P1', 22, 124),
-        ('P1', 51, 580),
-        ('P1', 69, 528),
-        ('P1', 23, 361),
-        ('P1', 44, 228),
-        ('P2', 69, 418),
-        ('P2', 96, 824),
-        ('P2', 81, 539),
-        ('P2', 85, 712),
-        ('P2', 18, 213),
+    data=data('profession max min', 5, rows=[
+        ('medicine', 110000, 23000),
+        ('fire fighting', 120000, 18000),
+        ('pedagogy', 125000, 24000),
+        ('psychology', 130000, 22500),
+        ('computer science', 151000, 36000),
     ]),
-    plot=ui.plot([ui.mark(type='interval', x='=product', y0='=low', y='=high')])
+    plot=ui.plot([ui.mark(type='interval', x='=profession', y0='=min', y='=max')])
 )
 ```
 
@@ -193,19 +168,25 @@ from h2o_wave import data
 q.page['example'] = ui.plot_card(
     box='1 1 4 5',
     title='Interval, polar',
-    data=data('product price', 10, rows=[
-        ('P1', 124),
-        ('P2', 580),
-        ('P3', 528),
-        ('P1', 361),
-        ('P2', 228),
-        ('P3', 418),
-        ('P1', 824),
-        ('P2', 539),
-        ('P3', 712),
-        ('P1', 213),
+    data=data('month rainfall', 16, rows=[
+        ('Jan', 18.9),
+        ('Feb', 28.8),
+        ('Mar', 39.3),
+        ('Apr', 31.4),
+        ('May', 47),
+        ('Jun', 20.3),
+        ('Jul', 24),
+        ('Aug', 35.6),
+        ('Jan', 12.4),
+        ('Feb', 23.2),
+        ('Mar', 34.5),
+        ('Apr', 29.7),
+        ('May', 42),
+        ('Jun', 35.5),
+        ('Jul', 37.4),
+        ('Aug', 42.4),
     ]),
-    plot=ui.plot([ui.mark(coord='polar', type='interval', x='=product', y='=price', y_min=0)])
+    plot=ui.plot([ui.mark(coord='polar', type='interval', x='=month', y='=rainfall', y_min=0)])
 )
 ```
 
@@ -219,25 +200,93 @@ from h2o_wave import data
 q.page['example'] = ui.plot_card(
     box='1 1 4 5',
     title='Intervals, polar, stacked',
-    data=data('country product price', 10, rows=[
-        ('USA', 'P1', 124),
-        ('China', 'P2', 580),
-        ('USA', 'P3', 528),
-        ('China', 'P1', 361),
-        ('USA', 'P2', 228),
-        ('China', 'P3', 418),
-        ('USA', 'P1', 824),
-        ('China', 'P2', 539),
-        ('USA', 'P3', 712),
-        ('USA', 'P1', 213),
+    data=data('city month rainfall', 16, rows=[
+        ('London', 'Jan', 18.9),
+        ('London', 'Feb', 28.8),
+        ('London', 'Mar', 39.3),
+        ('London', 'Apr', 31.4),
+        ('London', 'May', 47),
+        ('London', 'Jun', 20.3),
+        ('London', 'Jul', 24),
+        ('London', 'Aug', 35.6),
+        ('Berlin', 'Jan', 12.4),
+        ('Berlin', 'Feb', 23.2),
+        ('Berlin', 'Mar', 34.5),
+        ('Berlin', 'Apr', 29.7),
+        ('Berlin', 'May', 42),
+        ('Berlin', 'Jun', 35.5),
+        ('Berlin', 'Jul', 37.4),
+        ('Berlin', 'Aug', 42.4),
     ]),
     plot=ui.plot([
         ui.mark(
             coord='polar',
             type='interval',
-            x='=product',
-            y='=price',
-            color='=country',
+            x='=month',
+            y='=rainfall',
+            color='=city',
+            stack='auto',
+            y_min=0
+        )
+    ])
+)
+```
+
+## Theta
+
+Make a "racetrack" plot (a bar plot in polar coordinates, transposed).
+
+```py
+from h2o_wave import data
+
+q.page['example'] = ui.plot_card(
+    box='1 1 4 5',
+    title='Intervals, theta, stacked',
+    data=data('question percent', 8, rows=[
+        ('Question 1', 0.21),
+        ('Question 2', 0.4),
+        ('Question 3', 0.49),
+        ('Question 4', 0.52),
+        ('Question 5', 0.53),
+        ('Question 6', 0.84),
+        ('Question 7', 0.88),
+        ('Question 8', 0.9),
+    ]),
+    plot=ui.plot([
+        ui.mark(coord='theta', type='interval', x='=question', y='=percent', stack='auto', y_min=0)
+    ])
+)
+```
+
+## Theta stacked
+
+Make a stacked "racetrack" plot.
+
+```py
+from h2o_wave import data
+
+q.page['example'] = ui.plot_card(
+    box='1 1 4 5',
+    title='Intervals, theta, stacked',
+    data=data('day type time', 10, rows=[
+        ('Mon.','series1', 470),
+        ('Mon.','series2', 700),
+        ('Tues.','series1', 1800),
+        ('Tues.','series2', 1300),
+        ('Wed.','series1', 1650),
+        ('Wed.','series2', 1900),
+        ('Thur.','series1', 2500),
+        ('Thur.','series2', 1470),
+        ('Fri.','series1', 2800),
+        ('Fri.','series2', 2260),
+    ]),
+    plot=ui.plot([
+        ui.mark(
+            coord='theta',
+            type='interval', 
+            x='=day', 
+            y='=time',
+            color='=type',
             stack='auto',
             y_min=0
         )
@@ -255,24 +304,18 @@ from h2o_wave import data
 q.page['example'] = ui.plot_card(
     box='1 1 4 5',
     title='Label Customization',
-    data=data('product price', 10, rows=[
-        ('P1', 124),
-        ('P2', 580),
-        ('P3', 528),
-        ('P1', 361),
-        ('P2', 228),
-        ('P3', 418),
-        ('P1', 824),
-        ('P2', 539),
-        ('P3', 712),
-        ('P1', 213),
+    data=data('profession salary', 5, rows=[
+        ('medicine', 33000),
+        ('fire fighting', 18000),
+        ('pedagogy', 24000),
+        ('psychology', 22500),
+        ('computer science', 36000),
     ]),
     plot=ui.plot([
         ui.mark(
             type='interval', 
-            x='=product',
-            y='=${{intl price minimum_fraction_digits=2 maximum_fraction_digits=2}}', y_min=0,
-            color='#333333',
+            x='=profession',
+            y='=salary', y_min=0,
             label='=${{intl price minimum_fraction_digits=2 maximum_fraction_digits=2}}',
             label_offset=0, label_position='middle', label_rotation='-90', label_fill_color='#fff',
             label_font_weight='bold'
@@ -291,40 +334,14 @@ from h2o_wave import data
 q.page['example'] = ui.plot_card(
     box='1 1 4 5',
     title='Interval, helix',
-    data=data('product price', 10, rows=[ (f'P{i}', i) for i in range(200)]),
+    data=data('product price', 200, rows=[ (f'P{i}', i) for i in range(200)]),
     plot=ui.plot([ui.mark(coord='helix', type='interval', x='=product', y='=price', y_min=0)])
-)
-```
-
-## Groups
-
-Make a grouped column plot.
-
-```py
-from h2o_wave import data
-
-q.page['example'] = ui.plot_card(
-    box='1 1 4 5',
-    title='Intervals, groups',
-    data=data('country product price', 10, rows=[
-        ('USA', 'P1', 124),
-        ('China', 'P2', 580),
-        ('USA', 'P3', 528),
-        ('China', 'P1', 361),
-        ('USA', 'P2', 228),
-        ('China', 'P3', 418),
-        ('USA', 'P1', 824),
-        ('China', 'P2', 539),
-        ('USA', 'P3', 712),
-        ('USA', 'P1', 213),
-    ]),
-    plot=ui.plot([ui.mark(type='interval', x='=product', y='=price', color='=country', dodge='auto', y_min=0)])
 )
 ```
 
 ## Histogram
 
-Best used for numerical data when shape of distribution is needed.
+Best used for numerical data when the shape of the distribution is needed.
 
 ```py
 from h2o_wave import data
@@ -332,17 +349,15 @@ from h2o_wave import data
 q.page['example'] = ui.plot_card(
     box='1 1 4 5',
     title='Interval, range',
-    data=data('price low high', 10, rows=[
-        (123, 22, 124),
-        (471, 51, 580),
-        (421, 69, 528),
-        (119, 23, 361),
-        (196, 44, 228),
-        (123, 69, 418),
-        (691, 96, 824),
-        (391, 81, 539),
-        (709, 85, 712),
-        (123, 18, 213),
+    data=data('price low high', 8, rows=[
+        (4, 50, 100),
+        (6, 100, 150),
+        (8, 150, 200),
+        (16, 350, 400),
+        (18, 400, 450),
+        (10, 200, 250),
+        (12, 250, 300),
+        (14, 300, 350),
     ]),
     plot=ui.plot([ui.mark(type='interval', y='=price', x1='=low', x2='=high', y_min=0)])
 )

--- a/website/widgets/plots/line.md
+++ b/website/widgets/plots/line.md
@@ -3,8 +3,7 @@ title: Line
 custom_edit_url: null
 ---
 
-Used to track changes over periods of time and also compare with other changes (more lines within same plot).
-Better than bar charts for small changes.
+Used to track changes over time and also compare with other changes (more lines within the same plot). Better than bar charts for small changes.
 
 ```py
 from h2o_wave import data
@@ -12,19 +11,18 @@ from h2o_wave import data
 q.page['example'] = ui.plot_card(
     box='1 1 4 5',
     title='Line, groups',
-    data=data('date price', 10, rows=[
-        ('2020-03-20', 124),
-        ('2020-05-18', 580),
-        ('2020-08-24', 528),
-        ('2020-02-12', 361),
-        ('2020-03-11', 228),
-        ('2020-09-26', 418),
-        ('2020-11-12', 824),
-        ('2020-12-21', 539),
-        ('2020-03-18', 712),
-        ('2020-07-11', 213),
+    data=data('year value', 8, rows=[
+        ('1991', 3),
+        ('1992', 4),
+        ('1993', 3.5),
+        ('1994', 5),
+        ('1995', 4.9),
+        ('1996', 6),
+        ('1997', 7),
+        ('1998', 9),
+        ('1999', 13),
     ]),
-    plot=ui.plot([ui.mark(type='line', x_scale='time', x='=date', y='=price', y_min=0)])
+    plot=ui.plot([ui.mark(type='line', x_scale='time', x='=year', y='=value', y_min=0)])
 )
 ```
 
@@ -32,7 +30,7 @@ Check the full API at [ui.plot_card](/docs/api/ui#plot_card).
 
 ## Groups
 
-Use `color` attribute to group by a categorical column.
+Use the `color` attribute to group by a categorical column.
 
 ```py
 from h2o_wave import data
@@ -40,19 +38,33 @@ from h2o_wave import data
 q.page['example'] = ui.plot_card(
     box='1 1 4 5',
     title='Line',
-    data=data('product date price', 10, rows=[
-        ('P1', '2020-03-20', 124),
-        ('P2', '2020-05-18', 580),
-        ('P3', '2020-08-24', 528),
-        ('P1', '2020-02-12', 361),
-        ('P2', '2020-03-11', 228),
-        ('P3', '2020-09-26', 418),
-        ('P1', '2020-11-12', 824),
-        ('P2', '2020-12-21', 539),
-        ('P3', '2020-03-18', 712),
-        ('P1', '2020-07-11', 213),
+    data=data('month city temperature', 24, rows=[
+        ('Jan', 'Tokyo', 7),
+        ('Jan', 'London', 3.9),
+        ('Feb', 'Tokyo', 6.9),
+        ('Feb', 'London', 4.2),
+        ('Mar', 'Tokyo', 9.5),
+        ('Mar', 'London', 5.7),
+        ('Apr', 'Tokyo', 14.5),
+        ('Apr', 'London', 8.5),
+        ('May', 'Tokyo', 18.4),
+        ('May', 'London', 11.9),
+        ('Jun', 'Tokyo', 21.5),
+        ('Jun', 'London', 15.2),
+        ('Jul', 'Tokyo', 25.2),
+        ('Jul', 'London', 17),
+        ('Aug', 'Tokyo', 26.5),
+        ('Aug', 'London', 16.6),
+        ('Sep', 'Tokyo', 23.3),
+        ('Sep', 'London', 14.2),
+        ('Oct', 'Tokyo', 18.3),
+        ('Oct', 'London', 10.3),
+        ('Nov', 'Tokyo', 13.9),
+        ('Nov', 'London', 6.6),
+        ('Dec', 'Tokyo', 9.6),
+        ('Dec', 'London', 4.8),
     ]),
-    plot=ui.plot([ui.mark(type='line', x_scale='time', x='=date', y='=price', color='=product', y_min=0)])
+    plot=ui.plot([ui.mark(type='line', x='=month', y='=temperature', color='=city', y_min=0)])
 )
 ```
 
@@ -69,20 +81,22 @@ from h2o_wave import data
 q.page['example'] = ui.plot_card(
     box='1 1 4 5',
     title='Line, smooth',
-    data=data('date price', 10, rows=[
-        ('2020-03-20', 124),
-        ('2020-05-18', 580),
-        ('2020-08-24', 528),
-        ('2020-02-12', 361),
-        ('2020-03-11', 228),
-        ('2020-09-26', 418),
-        ('2020-11-12', 824),
-        ('2020-12-21', 539),
-        ('2020-03-18', 712),
-        ('2020-07-11', 213),
+    data=data('month price', 12, rows=[
+        ('Jan', 51),
+        ('Feb', 91),
+        ('Mar', 34),
+        ('Apr', 47),
+        ('May', 63),
+        ('June', 58),
+        ('July', 56),
+        ('Aug', 77),
+        ('Sep', 99),
+        ('Oct', 106),
+        ('Nov', 88),
+        ('Dec', 56),
     ]),
     plot=ui.plot([
-        ui.mark(type='line', x_scale='time', x='=date', y='=price', curve='smooth', y_min=0)
+        ui.mark(type='line', x='=month', y='=price', curve='smooth', y_min=0)
     ])
 )
 ```
@@ -95,20 +109,22 @@ from h2o_wave import data
 q.page['example'] = ui.plot_card(
     box='1 1 4 5',
     title='Line, step',
-    data=data('date price', 10, rows=[
-        ('2020-03-20', 124),
-        ('2020-05-18', 580),
-        ('2020-08-24', 528),
-        ('2020-02-12', 361),
-        ('2020-03-11', 228),
-        ('2020-09-26', 418),
-        ('2020-11-12', 824),
-        ('2020-12-21', 539),
-        ('2020-03-18', 712),
-        ('2020-07-11', 213),
+    data=data('month price', 12, rows=[
+        ('Jan', 51),
+        ('Feb', 91),
+        ('Mar', 34),
+        ('Apr', 47),
+        ('May', 63),
+        ('June', 58),
+        ('July', 56),
+        ('Aug', 77),
+        ('Sep', 99),
+        ('Oct', 106),
+        ('Nov', 88),
+        ('Dec', 56),
     ]),
     plot=ui.plot([
-        ui.mark(type='line', x_scale='time', x='=date', y='=price', curve='step', y_min=0)
+        ui.mark(type='line', x='=month', y='=price', curve='step', y_min=0)
     ])
 )
 ```
@@ -121,20 +137,22 @@ from h2o_wave import data
 q.page['example'] = ui.plot_card(
     box='1 1 4 5',
     title='Line, step-after',
-    data=data('date price', 10, rows=[
-        ('2020-03-20', 124),
-        ('2020-05-18', 580),
-        ('2020-08-24', 528),
-        ('2020-02-12', 361),
-        ('2020-03-11', 228),
-        ('2020-09-26', 418),
-        ('2020-11-12', 824),
-        ('2020-12-21', 539),
-        ('2020-03-18', 712),
-        ('2020-07-11', 213),
+    data=data('month price', 12, rows=[
+        ('Jan', 51),
+        ('Feb', 91),
+        ('Mar', 34),
+        ('Apr', 47),
+        ('May', 63),
+        ('June', 58),
+        ('July', 56),
+        ('Aug', 77),
+        ('Sep', 99),
+        ('Oct', 106),
+        ('Nov', 88),
+        ('Dec', 56),
     ]),
     plot=ui.plot([
-        ui.mark(type='line', x_scale='time', x='=date', y='=price', curve='step-after', y_min=0)
+        ui.mark(type='line', x='=month', y='=price', curve='step-after', y_min=0)
     ])
 )
 ```
@@ -147,20 +165,22 @@ from h2o_wave import data
 q.page['example'] = ui.plot_card(
     box='1 1 4 5',
     title='Line, step before',
-    data=data('date price', 10, rows=[
-        ('2020-03-20', 124),
-        ('2020-05-18', 580),
-        ('2020-08-24', 528),
-        ('2020-02-12', 361),
-        ('2020-03-11', 228),
-        ('2020-09-26', 418),
-        ('2020-11-12', 824),
-        ('2020-12-21', 539),
-        ('2020-03-18', 712),
-        ('2020-07-11', 213),
+    data=data('month price', 12, rows=[
+        ('Jan', 51),
+        ('Feb', 91),
+        ('Mar', 34),
+        ('Apr', 47),
+        ('May', 63),
+        ('June', 58),
+        ('July', 56),
+        ('Aug', 77),
+        ('Sep', 99),
+        ('Oct', 106),
+        ('Nov', 88),
+        ('Dec', 56),
     ]),
     plot=ui.plot([
-        ui.mark(type='line', x_scale='time', x='=date', y='=price', curve='step-before', y_min=0)
+        ui.mark(type='line', x='=month', y='=price', curve='step-before', y_min=0)
     ])
 )
 ```
@@ -175,58 +195,27 @@ from h2o_wave import data
 q.page['example'] = ui.plot_card(
     box='1 1 4 5',
     title='Line, labels',
-    data=data('date price', 10, rows=[
-        ('2020-03-20', 124),
-        ('2020-05-18', 580),
-        ('2020-08-24', 528),
-        ('2020-02-12', 361),
-        ('2020-03-11', 228),
-        ('2020-09-26', 418),
-        ('2020-11-12', 824),
-        ('2020-12-21', 539),
-        ('2020-03-18', 712),
-        ('2020-07-11', 213),
+    data=data('year price', 9, rows=[
+        ('1991', 3),
+        ('1992', 4),
+        ('1993', 3.5),
+        ('1994', 5),
+        ('1995', 4.9),
+        ('1996', 6),
+        ('1997', 7),
+        ('1998', 9),
+        ('1999', 13),
     ]),
     plot=ui.plot([
-        ui.mark(type='line', x_scale='time', x='=date', y='=price', y_min=0,
+        ui.mark(type='line', x_scale='time', x='=year', y='=price', y_min=0,
                 label='=${{intl price minimum_fraction_digits=2 maximum_fraction_digits=2}}')
-    ])
-)
-```
-
-### No overlap
-
-Make a line plot with non-overlapping labels.
-
-```py
-from h2o_wave import data
-
-q.page['example'] = ui.plot_card(
-    box='1 1 4 5',
-    title='Line, labels',
-    data=data('date price', 10, rows=[
-        ('2020-03-20', 124),
-        ('2020-05-18', 580),
-        ('2020-08-24', 528),
-        ('2020-02-12', 361),
-        ('2020-03-11', 228),
-        ('2020-09-26', 418),
-        ('2020-11-12', 824),
-        ('2020-12-21', 539),
-        ('2020-03-18', 712),
-        ('2020-07-11', 213),
-    ]),
-    plot=ui.plot([
-      ui.mark(type='line', x_scale='time', x='=date', y='=price', y_min=0,
-              label='=${{intl price minimum_fraction_digits=2 maximum_fraction_digits=2}}',
-              label_overlap='hide')
     ])
 )
 ```
 
 ### Custom labels
 
-Customize label rendering to improve readability.
+Customize label rendering as you see fit.
 
 ```py
 from h2o_wave import data
@@ -234,22 +223,21 @@ from h2o_wave import data
 q.page['example'] = ui.plot_card(
     box='1 1 4 5',
     title='Line, labels',
-    data=data('date price', 10, rows=[
-        ('2020-03-20', 124),
-        ('2020-05-18', 580),
-        ('2020-08-24', 528),
-        ('2020-02-12', 361),
-        ('2020-03-11', 228),
-        ('2020-09-26', 418),
-        ('2020-11-12', 824),
-        ('2020-12-21', 539),
-        ('2020-03-18', 712),
-        ('2020-07-11', 213),
+    data=data('year price', 9, rows=[
+        ('1991', 3),
+        ('1992', 4),
+        ('1993', 3.5),
+        ('1994', 5),
+        ('1995', 4.9),
+        ('1996', 6),
+        ('1997', 7),
+        ('1998', 9),
+        ('1999', 13),
     ]),
     plot=ui.plot([
-      ui.mark(type='line', x_scale='time', x='=date', y='=price', y_min=0,
+      ui.mark(type='line', x_scale='time', x='=year', y='=price', y_min=0,
               label='=${{intl price minimum_fraction_digits=2 maximum_fraction_digits=2}}',
-              label_fill_color='rgba(0,0,0,0.65)', label_stroke_color='$blue', label_stroke_size=2)
+              label_fill_color='rgba(0,0,0,0.65)', label_stroke_color='$red', label_stroke_size=2)
     ])
 )
 ```

--- a/website/widgets/plots/overview.md
+++ b/website/widgets/plots/overview.md
@@ -22,19 +22,19 @@ from h2o_wave import data
 q.page['example'] = ui.plot_card(
     box='1 1 4 5',
     title='Point',
-    data=data('price performance', 10, rows=[
-        (0.1, 0.6),
-        (0.2, 0.5),
-        (0.3, 0.3),
-        (0.4, 0.2),
-        (0.4, 0.5),
-        (0.2, 0.2),
-        (0.8, 0.5),
-        (0.3, 0.3),
-        (0.2, 0.4),
-        (0.1, 0.0),
+    data=data('height weight', 10, rows=[
+        (170, 59),
+        (159.1, 47.6),
+        (166, 69.8),
+        (176.2, 66.8),
+        (160.2, 75.2),
+        (180.3, 76.4),
+        (164.5, 63.2),
+        (173, 60.9),
+        (183.5, 74.8),
+        (175.5, 70),
     ]),
-    plot=ui.plot([ui.mark(type='point', x='=price', y='=performance')])
+    plot=ui.plot([ui.mark(type='point', x='=weight', y='=height')])
 )
 ```
 
@@ -51,20 +51,20 @@ from h2o_wave import data
 q.page['example'] = ui.plot_card(
     box='1 1 4 5',
     title='Numeric-Numeric',
-    data=data('price performance', pack=True, rows=[
-        (0.1, 0.6),
-        (0.2, 0.5),
-        (0.3, 0.3),
-        (0.4, 0.2),
-        (0.4, 0.5),
-        (0.2, 0.2),
-        (0.8, 0.5),
-        (0.3, 0.3),
-        (0.2, 0.4),
-        (0.1, 0.0),
+    data=data('height weight', 10, rows=[
+        (170, 59),
+        (159.1, 47.6),
+        (166, 69.8),
+        (176.2, 66.8),
+        (160.2, 75.2),
+        (180.3, 76.4),
+        (164.5, 63.2),
+        (173, 60.9),
+        (183.5, 74.8),
+        (175.5, 70),
     ]),
     plot=ui.plot([
-        ui.mark(type='point', x='=price', y='=performance', x_min=0, x_max=100, y_min=0, y_max=100),  # the plot
+        ui.mark(type='point', x='=weight', y='=height', x_min=0, x_max=100, y_min=0, y_max=100),  # the plot
         ui.mark(x=50, y=50, label='point'),  # A single reference point
         ui.mark(x=40, label='vertical line'),
         ui.mark(y=40, label='horizontal line'),
@@ -93,20 +93,15 @@ from h2o_wave import data
 q.page['example'] = ui.plot_card(
     box='1 1 4 5',
     title='Interval, range',
-    data=data('product low high', 10, rows=[
-        ('P1', 22, 124),
-        ('P1', 51, 580),
-        ('P1', 69, 528),
-        ('P1', 23, 361),
-        ('P1', 44, 228),
-        ('P2', 69, 418),
-        ('P2', 96, 824),
-        ('P2', 81, 539),
-        ('P2', 85, 712),
-        ('P2', 18, 213),
+    data=data('profession salary', 5, rows=[
+        ('medicine', 33000),
+        ('fire fighting', 18000),
+        ('pedagogy', 24000),
+        ('psychology', 22500),
+        ('computer science', 36000),
     ]),
     events=['select_marks'],
-    plot=ui.plot([ui.mark(type='interval', x='=product', y0='=low', y='=high')])
+    plot=ui.plot([ui.mark(type='interval', x='=salary', y='=profession', y_min=0)])
 )
 ```
 
@@ -120,21 +115,22 @@ from h2o_wave import data
 q.page['example'] = ui.plot_card(
     box='1 1 4 5',
     title='Line title',
-    data=data('date price', 10, rows=[
-        ('2020-03-20', 124),
-        ('2020-05-18', 580),
-        ('2020-08-24', 528),
-        ('2020-02-12', 361),
-        ('2020-03-11', 228),
-        ('2020-09-26', 418),
-        ('2020-11-12', 824),
-        ('2020-12-21', 539),
-        ('2020-03-18', 712),
-        ('2020-07-11', 213),
+    data=data('month price', 12, rows=[
+        ('Jan', 51),
+        ('Feb', 91),
+        ('Mar', 34),
+        ('Apr', 47),
+        ('May', 63),
+        ('June', 58),
+        ('July', 56),
+        ('Aug', 77),
+        ('Sep', 99),
+        ('Oct', 106),
+        ('Nov', 88),
+        ('Dec', 56),
     ]),
     plot=ui.plot([
-        ui.mark(type='line', x_scale='time', x='=date', y='=price',
-                y_min=0, x_title='Date', y_title='Price')
+        ui.mark(type='line', x='=month', y='=price', y_min=0, x_title='Month', y_title='Price')
     ])
 )
 ```
@@ -153,19 +149,14 @@ q.page['example'] = ui.wide_plot_card(
     Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quia aliquam maxime quos facere
     necessitatibus tempore eum odio, qui illum. Repellat modi dolor facilis odio ex possimus
     ''',
-    data=data('product price', 10, rows=[
-        ('P1', 124),
-        ('P2', 580),
-        ('P3', 528),
-        ('P1', 361),
-        ('P2', 228),
-        ('P3', 418),
-        ('P1', 824),
-        ('P2', 539),
-        ('P3', 712),
-        ('P1', 213),
+    data=data('profession salary', 5, rows=[
+        ('medicine', 23000),
+        ('fire fighting', 18000),
+        ('pedagogy', 24000),
+        ('psychology', 22500),
+        ('computer science', 36000),
     ]),
-    plot=ui.plot([ui.mark(type='interval', x='=product', y='=price', y_min=0)])
+    plot=ui.plot([ui.mark(type='interval', x='=profession', y='=salary', y_min=0)])
 )
 ```
 

--- a/website/widgets/plots/path.md
+++ b/website/widgets/plots/path.md
@@ -11,19 +11,21 @@ from h2o_wave import data
 q.page['example'] = ui.plot_card(
     box='1 1 4 5',
     title='Path',
-    data=data('price performance', 10, rows=[
-        (0.1, 0.6),
-        (0.2, 0.5),
-        (0.3, 0.3),
-        (0.4, 0.2),
-        (0.4, 0.5),
-        (0.2, 0.2),
-        (0.8, 0.5),
-        (0.3, 0.3),
-        (0.2, 0.4),
-        (0.1, 0.0),
+    data=data('consumption price', 12, rows=[
+        (0.65, 1),
+        (0.66, 1.05),
+        (0.64, 1.1),
+        (0.63, 1.12),
+        (0.58, 1.14),
+        (0.59, 1),
+        (0.57, 0.96),
+        (0.55, 0.92),
+        (0.54, 0.88),
+        (0.42, 0.89),
+        (0.28, 1),
+        (0.15, 1.1),
     ]),
-    plot=ui.plot([ui.mark(type='path', x='=price', y='=performance')])
+    plot=ui.plot([ui.mark(type='path', x='=price ', y='=consumption')])
 )
 ```
 
@@ -31,7 +33,7 @@ Check the full API at [ui.plot_card](/docs/api/ui#plot_card).
 
 ## Curve
 
-Don't like default sharp edges? Play around with `curve` attribute!
+Don't like default sharp edges? Play around with the `curve` attribute!
 
 ### Smooth
 

--- a/website/widgets/plots/path.md
+++ b/website/widgets/plots/path.md
@@ -11,31 +11,25 @@ from h2o_wave import data
 q.page['example'] = ui.plot_card(
     box='1 1 4 5',
     title='Path',
-    data=data('consumption price', 12, rows=[
-        (0.65, 1),
-        (0.66, 1.05),
-        (0.64, 1.1),
-        (0.63, 1.12),
-        (0.58, 1.14),
-        (0.59, 1),
-        (0.57, 0.96),
-        (0.55, 0.92),
-        (0.54, 0.88),
-        (0.42, 0.89),
-        (0.28, 1),
-        (0.15, 1.1),
+    data=data('price performance', 10, rows=[
+        (0.1, 0.6),
+        (0.2, 0.5),
+        (0.3, 0.3),
+        (0.4, 0.2),
+        (0.4, 0.5),
+        (0.2, 0.2),
+        (0.8, 0.5),
+        (0.3, 0.3),
+        (0.2, 0.4),
+        (0.1, 0.0),
     ]),
-    plot=ui.plot([ui.mark(type='path', x='=price ', y='=consumption')])
+    plot=ui.plot([ui.mark(type='path', x='=price', y='=performance')])
 )
 ```
 
 Check the full API at [ui.plot_card](/docs/api/ui#plot_card).
 
-## Curve
-
-Don't like default sharp edges? Play around with the `curve` attribute!
-
-### Smooth
+## Smooth
 
 ```py
 from h2o_wave import data
@@ -56,78 +50,6 @@ q.page['example'] = ui.plot_card(
         (0.1, 0.0),
     ]),
     plot=ui.plot([ui.mark(type='path', x='=price', y='=performance', curve='smooth')])
-)
-```
-
-### Step
-
-```py
-from h2o_wave import data
-
-q.page['example'] = ui.plot_card(
-    box='1 1 4 5',
-    title='Path, step',
-    data=data('price performance', 10, rows=[
-        (0.1, 0.6),
-        (0.2, 0.5),
-        (0.3, 0.3),
-        (0.4, 0.2),
-        (0.4, 0.5),
-        (0.2, 0.2),
-        (0.8, 0.5),
-        (0.3, 0.3),
-        (0.2, 0.4),
-        (0.1, 0.0),
-    ]),
-    plot=ui.plot([ui.mark(type='path', x='=price', y='=performance', curve='step')])
-)
-```
-
-### Step before
-
-```py
-from h2o_wave import data
-
-q.page['example'] = ui.plot_card(
-    box='1 1 4 5',
-    title='Path, step-before',
-    data=data('price performance', 10, rows=[
-        (0.1, 0.6),
-        (0.2, 0.5),
-        (0.3, 0.3),
-        (0.4, 0.2),
-        (0.4, 0.5),
-        (0.2, 0.2),
-        (0.8, 0.5),
-        (0.3, 0.3),
-        (0.2, 0.4),
-        (0.1, 0.0),
-    ]),
-    plot=ui.plot([ui.mark(type='path', x='=price', y='=performance', curve='step-before')])
-)
-```
-
-### Step after
-
-```py
-from h2o_wave import data
-
-q.page['example'] = ui.plot_card(
-    box='1 1 4 5',
-    title='Path, step-after',
-    data=data('price performance', 10, rows=[
-        (0.1, 0.6),
-        (0.2, 0.5),
-        (0.3, 0.3),
-        (0.4, 0.2),
-        (0.4, 0.5),
-        (0.2, 0.2),
-        (0.8, 0.5),
-        (0.3, 0.3),
-        (0.2, 0.4),
-        (0.1, 0.0),
-    ]),
-    plot=ui.plot([ui.mark(type='path', x='=price', y='=performance', curve='step-after')])
 )
 ```
 

--- a/website/widgets/plots/point.md
+++ b/website/widgets/plots/point.md
@@ -3,13 +3,12 @@ title: Point
 custom_edit_url: null
 ---
 
-Used for observing a relationship between two numeric variables and exploring common data pattterns or finding outliers.
+Used for observing a relationship between two numeric variables and exploring common data patterns or finding outliers.
 Based on the patterns identified, the values can be visually grouped into clusters.
 
 ## Scatter
 
-The most basic point plot. Good for relatively small datasets where
-points don't overlap.
+The most basic point plot. Good for relatively small datasets where points don't overlap.
 
 ```py
 from h2o_wave import data
@@ -17,19 +16,19 @@ from h2o_wave import data
 q.page['example'] = ui.plot_card(
     box='1 1 4 5',
     title='Point',
-    data=data('price performance', 10, rows=[
-        (0.1, 0.6),
-        (0.2, 0.5),
-        (0.3, 0.3),
-        (0.4, 0.2),
-        (0.4, 0.5),
-        (0.2, 0.2),
-        (0.8, 0.5),
-        (0.3, 0.3),
-        (0.2, 0.4),
-        (0.1, 0.0),
+    data=data('height weight', 10, rows=[
+        (170, 59),
+        (159.1, 47.6),
+        (166, 69.8),
+        (176.2, 66.8),
+        (160.2, 75.2),
+        (180.3, 76.4),
+        (164.5, 63.2),
+        (173, 60.9),
+        (183.5, 74.8),
+        (175.5, 70),
     ]),
-    plot=ui.plot([ui.mark(type='point', x='=price', y='=performance')])
+    plot=ui.plot([ui.mark(type='point', x='=weight', y='=height')])
 )
 ```
 
@@ -45,19 +44,21 @@ from h2o_wave import data
 q.page['example'] = ui.plot_card(
     box='1 1 4 5',
     title='Point',
-    data=data('price performance discount', 10, rows=[
-        (0.1, 0.6, 0.2),
-        (0.2, 0.5, 0.3),
-        (0.3, 0.3, 0.2),
-        (0.4, 0.2, 0.5),
-        (0.4, 0.5, 0.8),
-        (0.2, 0.2, 0.7),
-        (0.8, 0.5, 0.9),
-        (0.3, 0.3, 0.3),
-        (0.2, 0.4, 0.4),
-        (0.1, 0.0, 0.9),
+    data=data('lifeExpectancy GDP population', 10, rows=[
+        (75.32, 12779.37964, 40301927),
+        (72.39, 9065.800825, 190010647),
+        (80.653, 36319.23501, 33390141),
+        (78.273, 8948.102923, 11416987),
+        (72.961, 4959.114854, 1318683096),
+        (82.208, 39724.97867, 6980412),
+        (82.603, 31656.06806, 127467972),
+        (76.423, 5937.029526, 3600523),
+        (79.829, 36126.4927, 8199783),
+        (79.441, 33692.60508, 10392226),
+        (81.235, 34435.36744, 20434176),
+        (80.204, 25185.00911, 4115771)
     ]),
-    plot=ui.plot([ui.mark(type='point', x='=price', y='=performance', size='=discount')])
+    plot=ui.plot([ui.mark(type='point', x='=GDP', y='=lifeExpectancy', size='=population')])
 )
 ```
 
@@ -71,26 +72,25 @@ from h2o_wave import data
 q.page['example'] = ui.plot_card(
     box='1 1 4 5',
     title='Point',
-    data=data('price performance type', 10, rows=[
-        (0.1, 0.6, 'T1'),
-        (0.2, 0.5, 'T1'),
-        (0.3, 0.3, 'T1'),
-        (0.4, 0.2, 'T1'),
-        (0.4, 0.5, 'T1'),
-        (0.2, 0.2, 'T2'),
-        (0.8, 0.5, 'T2'),
-        (0.3, 0.3, 'T2'),
-        (0.2, 0.4, 'T2'),
-        (0.1, 0.0, 'T2'),
+    data=data('gender height weight', 10, rows=[
+        ('female', 170, 59),
+        ('female', 159.1, 47.6),
+        ('female', 166, 69.8),
+        ('female', 176.2, 66.8),
+        ('female', 160.2, 75.2),
+        ('male', 180.3, 76.4),
+        ('male', 164.5, 63.2),
+        ('male', 173, 60.9),
+        ('male', 183.5, 74.8),
+        ('male', 175.5, 70),
     ]),
-    plot=ui.plot([ui.mark(type='point', x='=price', y='=performance', shape='=type')])
+    plot=ui.plot([ui.mark(type='point', x='=weight', y='=height', shape='=gender')])
 )
 ```
 
 ## Heatmap
 
-For cases when you have just too many points which overlap and together create just a single big
-point, it migh be a better idea to use a heat map.
+For cases when you have just too many points that overlap and together create just a single big point, it might be a better idea to use a heat map.
 
 ```py
 from h2o_wave import data
@@ -98,27 +98,28 @@ from h2o_wave import data
 q.page['example'] = ui.plot_card(
     box='1 1 4 5',
     title='Heatmap',
-    data=data('country product profit', 10, rows=[
-        ('China', 'car', 214),
-        ('USA', 'bus', 523),
-        ('USA', 'car', 532),
-        ('China', 'bus', 799),
-        ('USA', 'car', 234),
-        ('China', 'bus', 214),
-        ('USA', 'car', 936),
-        ('USA', 'bus', 703),
-        ('China', 'car', 259),
-        ('USA', 'bus', 104),
+    data=data('year person sales', 10, rows=[
+        ('2021', 'Joe', 10),
+        ('2022', 'Jane', 58),
+        ('2023', 'Ann', 114),
+        ('2021', 'Tim', 31),
+        ('2023', 'Joe', 96),
+        ('2021', 'Jane', 55),
+        ('2023', 'Jane', 5),
+        ('2022', 'Tim', 85),
+        ('2023', 'Tim', 132),
+        ('2022', 'Joe', 54),
+        ('2021', 'Ann', 78),
+        ('2022', 'Ann', 18),
     ]),
-    plot=ui.plot([ui.mark(type='polygon', x='=country', y='=product', color='=profit',
+    plot=ui.plot([ui.mark(type='polygon', x='=person', y='=year', color='=sales',
                 color_range='#fee8c8 #fdbb84 #e34a33')])
 )
 ```
 
 ## Map
 
-Make a plot to compare quantities across categories. Similar to a heatmap,
-but using size-encoding instead of color-encoding.
+Make a plot to compare quantities across categories. Similar to a heatmap, but using size-encoding instead of color-encoding.
 
 ```py
 from h2o_wave import data
@@ -126,19 +127,21 @@ from h2o_wave import data
 q.page['example'] = ui.plot_card(
     box='1 1 4 5',
     title='Points, size-encoded',
-    data=data('country product profit', 10, rows=[
-        ('China', 'car', 214),
-        ('USA', 'bus', 523),
-        ('USA', 'car', 532),
-        ('China', 'bus', 799),
-        ('USA', 'car', 234),
-        ('China', 'bus', 214),
-        ('USA', 'car', 936),
-        ('USA', 'bus', 703),
-        ('China', 'car', 259),
-        ('USA', 'bus', 104),
+    data=data('year person sales', 10, rows=[
+        ('2021', 'Joe', 10),
+        ('2022', 'Jane', 58),
+        ('2023', 'Ann', 114),
+        ('2021', 'Tim', 31),
+        ('2023', 'Joe', 96),
+        ('2021', 'Jane', 55),
+        ('2023', 'Jane', 5),
+        ('2022', 'Tim', 85),
+        ('2023', 'Tim', 132),
+        ('2022', 'Joe', 54),
+        ('2021', 'Ann', 78),
+        ('2022', 'Ann', 18),
     ]),
-    plot=ui.plot([ui.mark(type='point', x='=country', y='=product', size='=profit', shape='circle')])
+    plot=ui.plot([ui.mark(type='point', x='=person', y='=year', size='=sales', shape='circle')])
 )
 ```
 
@@ -152,25 +155,25 @@ from h2o_wave import data
 q.page['example'] = ui.plot_card(
     box='1 1 4 5',
     title='Point, groups',
-    data=data('product price profit', 10, rows=[
-        ('P1', 124.4, 214),
-        ('P2', 580.4, 523),
-        ('P3', 528, 532),
-        ('P1', 361, 799),
-        ('P2', 228, 234),
-        ('P3', 418, 214),
-        ('P1', 824, 936),
-        ('P2', 539, 703),
-        ('P3', 712, 259),
-        ('P1', 213, 104),
+    data=data('gender height weight', 10, rows=[
+        ('female', 170, 59),
+        ('female', 159.1, 47.6),
+        ('female', 166, 69.8),
+        ('female', 176.2, 66.8),
+        ('female', 160.2, 75.2),
+        ('male', 180.3, 76.4),
+        ('male', 164.5, 63.2),
+        ('male', 173, 60.9),
+        ('male', 183.5, 74.8),
+        ('male', 175.5, 70),
     ]),
-    plot=ui.plot([ui.mark(type='point', x='=price', y='=profit', color='=product', shape='circle')])
+    plot=ui.plot([ui.mark(type='point', x='=weight', y='=height', color='=gender', shape='circle')])
 )
 ```
 
 ## Customization
 
-Customize a plot's fill/stroke color, size and opacity.
+Customize a plot's fill/stroke color, size, and opacity.
 
 ```py
 from h2o_wave import data
@@ -178,19 +181,21 @@ from h2o_wave import data
 q.page['example'] = ui.plot_card(
     box='1 1 4 5',
     title='Point',
-    data=data('price performance discount', 10, rows=[
-        (0.1, 0.6, 0.2),
-        (0.2, 0.5, 0.3),
-        (0.3, 0.3, 0.2),
-        (0.4, 0.2, 0.5),
-        (0.4, 0.5, 0.8),
-        (0.2, 0.2, 0.7),
-        (0.8, 0.5, 0.9),
-        (0.3, 0.3, 0.3),
-        (0.2, 0.4, 0.4),
-        (0.1, 0.0, 0.9),
+    data=data('lifeExpectancy GDP population', 10, rows=[
+        (75.32, 12779.37964, 40301927),
+        (72.39, 9065.800825, 190010647),
+        (80.653, 36319.23501, 33390141),
+        (78.273, 8948.102923, 11416987),
+        (72.961, 4959.114854, 1318683096),
+        (82.208, 39724.97867, 6980412),
+        (82.603, 31656.06806, 127467972),
+        (76.423, 5937.029526, 3600523),
+        (79.829, 36126.4927, 8199783),
+        (79.441, 33692.60508, 10392226),
+        (81.235, 34435.36744, 20434176),
+        (80.204, 25185.00911, 4115771)
     ]),
-    plot=ui.plot([ui.mark(type='point', x='=price', y='=performance', size='=discount', size_range='4 30',
+    plot=ui.plot([ui.mark(type='point', x='=GDP', y='=lifeExpectancy', size='=population', size_range='4 30',
                           fill_color='#eb4559', stroke_color='#eb4559', stroke_size=1, fill_opacity=0.3,
                           stroke_opacity=1)])
 )
@@ -198,7 +203,7 @@ q.page['example'] = ui.plot_card(
 
 ## Annotations
 
-Add annotations (points, lines and regions) to a plot.
+Add annotations (points, lines, and regions) to a plot.
 
 ```py
 from h2o_wave import data
@@ -206,20 +211,20 @@ from h2o_wave import data
 q.page['example'] = ui.plot_card(
     box='1 1 4 5',
     title='Point',
-    data=data('price performance', 10, rows=[
-        (0.1, 0.6),
-        (0.2, 0.5),
-        (0.3, 0.3),
-        (0.4, 0.2),
-        (0.4, 0.5),
-        (0.2, 0.2),
-        (0.8, 0.5),
-        (0.3, 0.3),
-        (0.2, 0.4),
-        (0.1, 0.0),
+    data=data('height weight', 10, rows=[
+        (170, 59),
+        (159.1, 47.6),
+        (166, 69.8),
+        (176.2, 66.8),
+        (160.2, 75.2),
+        (180.3, 76.4),
+        (164.5, 63.2),
+        (173, 60.9),
+        (183.5, 74.8),
+        (175.5, 70),
     ]),
     plot=ui.plot([
-        ui.mark(type='point', x='=price', y='=performance', x_min=0, x_max=100, y_min=0, y_max=100),  # the plot
+        ui.mark(type='point', x='=weight', y='=height', x_min=0, x_max=100, y_min=0, y_max=100),  # the plot
         ui.mark(x=50, y=50, label='point'),  # A single reference point
         ui.mark(x=40, label='vertical line'),
         ui.mark(y=40, label='horizontal line'),


### PR DESCRIPTION
This PR aims to better fit sample data for plot widgets in order to get natural-looking plot shapes.


https://user-images.githubusercontent.com/64769322/159261642-ea2dfb86-edca-497c-97c0-fc10233243e9.mov

## Needs discussion

As part of this PR, I also found a few subtle bugs that are already fixed in the most recent `g2` version. Here are the most notable ones (left - current, right - upgrade):

Seems like angling is no longer supported. (Can fix #805)
![image](https://user-images.githubusercontent.com/64769322/159261988-8c94f58c-5763-4c99-a0af-4a71960f3afb.png)

Polar coordinate plots do not render text ellipsis, but correct axis values instead.
![image](https://user-images.githubusercontent.com/64769322/159262047-d9db70be-93c2-43ec-8f21-f3d211155a0a.png)

Smooth path curves have changed a bit, but nothing serious.
![image](https://user-images.githubusercontent.com/64769322/159262334-6843a593-9702-41b1-b26e-2bf98920f26d.png)

https://github.com/h2oai/wave/discussions/1041 - This might be a problem as well although I suspect that an incorrect plot type was chosen for the underlying data rather than a bug.

@lo5 lmk if we are good with upgrading.