### PR TITLE
fix: Unify plot time scales.

### DIFF
--- a/ui/src/date_picker.tsx
+++ b/ui/src/date_picker.tsx
@@ -68,7 +68,7 @@ export const
       onSelectDate = (d: Date | null | undefined) => {
         const val = (d === null || d === undefined) ? defaultVal : formatDate(d)
         wave.args[m.name] = val
-        setValue(val ? new Date(`${val} 00:00:00`) : undefined)
+        setValue(val ? new Date(`${val}T00:00:00`) : undefined)
         if (m.trigger) wave.push()
       }
 

--- a/ui/src/plot.tsx
+++ b/ui/src/plot.tsx
@@ -295,7 +295,8 @@ const
     for (const d of ds) {
       if (d) {
         const s = d[f]
-        if (s && isS(s)) d[f] = new Date(s) // must be ISO string
+        // Must be ISO string. If just date specified, add time.
+        if (s && isS(s)) d[f] = new Date(s.includes('T') ? s : `${s}T00:00:00`)
       }
     }
   },


### PR DESCRIPTION
@aalencar FYI #1123 broke the datepicker in Safari. The reason was incorrect datetime format. Fixed it in this PR.

Closes #1300