### PR TITLE
fix: Allow sorting of grouped by rows

### DIFF
--- a/ui/src/table.test.tsx
+++ b/ui/src/table.test.tsx
@@ -644,6 +644,20 @@ describe('Table.tsx', () => {
       expect(getAllByRole('gridcell')[3].textContent).toBe(cell21)
     })
 
+    it('Checks if groups contain rows after sort is applied', () => {
+      const { container, getAllByText, getByTestId, getAllByRole } = render(<XTable model={tableProps} />)
+
+      fireEvent.click(getByTestId('groupby'))
+      fireEvent.click(getAllByText('Col1')[1]!)
+      fireEvent.click(container.querySelector('.ms-GroupHeader-expand')!)
+
+      expect(getAllByRole('gridcell')[3].textContent).toBe(cell11)
+
+      fireEvent.click(container.querySelector('.ms-DetailsHeader-cellTitle i[class*=sortingIcon]')!)
+
+      expect(getAllByRole('gridcell')[3].textContent).toBe(cell11)
+    })
+
     it('Searches grouped list', () => {
       const { container, getAllByText, getByTestId, getAllByRole } = render(<XTable model={tableProps} />)
 

--- a/ui/src/table.test.tsx
+++ b/ui/src/table.test.tsx
@@ -630,32 +630,27 @@ describe('Table.tsx', () => {
       expect(groupHeaders[2]).toHaveTextContent('2012-09-14T18:26:01(1)')
     })
 
-    it('Checks if groups contain rows after sort is applied', () => {
-      const { container, getAllByText, getByTestId, getAllByRole } = render(<XTable model={tableProps} />)
-
-      fireEvent.click(getByTestId('groupby'))
-      fireEvent.click(getAllByText('Col1')[1]!)
-      fireEvent.click(container.querySelector('.ms-DetailsHeader-collapseButton')!)
-
-      expect(getAllByRole('gridcell')[3].textContent).toBe(cell21)
-
-      fireEvent.click(container.querySelector('.ms-DetailsHeader-cellTitle i[class*=sortingIcon]')!)
-
-      expect(getAllByRole('gridcell')[3].textContent).toBe(cell21)
-    })
-
     it('Sorts rows inside the group of the grouped list', () => {
+      // test with non-alphabetical groups order to check whether group alphabetical sorting on groupby is considered
+      tableProps = {
+        ...tableProps,
+        rows: [
+          { name: 'rowname1', cells: [cell11, 'Group2'] },
+          { name: 'rowname2', cells: [cell21, 'Group2'] },
+          { name: 'rowname3', cells: [cell31, 'Group1'] }
+        ]
+      }
       const { container, getAllByText, getByTestId, getAllByRole } = render(<XTable model={tableProps} />)
 
       fireEvent.click(getByTestId('groupby'))
       fireEvent.click(getAllByText('Col2')[1]!)
       fireEvent.click(container.querySelector('.ms-DetailsHeader-collapseButton')!)
 
-      expect(getAllByRole('gridcell')[3].textContent).toBe(cell11)
+      expect(getAllByRole('gridcell')[8].textContent).toBe(cell11)
 
       fireEvent.click(container.querySelector('.ms-DetailsHeader-cellTitle i[class*=sortingIcon]')!)
 
-      expect(getAllByRole('gridcell')[3].textContent).toBe(cell21)
+      expect(getAllByRole('gridcell')[8].textContent).toBe(cell21)
     })
 
     it('Searches grouped list', () => {

--- a/ui/src/table.test.tsx
+++ b/ui/src/table.test.tsx
@@ -630,7 +630,21 @@ describe('Table.tsx', () => {
       expect(groupHeaders[2]).toHaveTextContent('2012-09-14T18:26:01(1)')
     })
 
-    it('Sorts grouped list', () => {
+    it('Checks if groups contain rows after sort is applied', () => {
+      const { container, getAllByText, getByTestId, getAllByRole } = render(<XTable model={tableProps} />)
+
+      fireEvent.click(getByTestId('groupby'))
+      fireEvent.click(getAllByText('Col1')[1]!)
+      fireEvent.click(container.querySelector('.ms-DetailsHeader-collapseButton')!)
+
+      expect(getAllByRole('gridcell')[3].textContent).toBe(cell21)
+
+      fireEvent.click(container.querySelector('.ms-DetailsHeader-cellTitle i[class*=sortingIcon]')!)
+
+      expect(getAllByRole('gridcell')[3].textContent).toBe(cell21)
+    })
+
+    it('Sorts rows inside the group of the grouped list', () => {
       const { container, getAllByText, getByTestId, getAllByRole } = render(<XTable model={tableProps} />)
 
       fireEvent.click(getByTestId('groupby'))
@@ -642,20 +656,6 @@ describe('Table.tsx', () => {
       fireEvent.click(container.querySelector('.ms-DetailsHeader-cellTitle i[class*=sortingIcon]')!)
 
       expect(getAllByRole('gridcell')[3].textContent).toBe(cell21)
-    })
-
-    it('Checks if groups contain rows after sort is applied', () => {
-      const { container, getAllByText, getByTestId, getAllByRole } = render(<XTable model={tableProps} />)
-
-      fireEvent.click(getByTestId('groupby'))
-      fireEvent.click(getAllByText('Col1')[1]!)
-      fireEvent.click(container.querySelector('.ms-GroupHeader-expand')!)
-
-      expect(getAllByRole('gridcell')[3].textContent).toBe(cell11)
-
-      fireEvent.click(container.querySelector('.ms-DetailsHeader-cellTitle i[class*=sortingIcon]')!)
-
-      expect(getAllByRole('gridcell')[3].textContent).toBe(cell11)
     })
 
     it('Searches grouped list', () => {
@@ -741,7 +741,7 @@ describe('Table.tsx', () => {
       expect(getAllByRole('row')).toHaveLength(tableHeaderRow + groupHeaderRow + filteredItem)
     })
 
-    it('Sorts grouped list', () => {
+    it('Sorts rows inside the group of the grouped list', () => {
       const { container, getAllByRole } = render(<XTable model={tableProps} />)
 
       expect(getAllByRole('gridcell')[3].textContent).toBe(cell11)

--- a/ui/src/table.tsx
+++ b/ui/src/table.tsx
@@ -735,7 +735,7 @@ export const
 
         setGroups(groups => {
           if (groups) {
-            setFilteredItems(filteredItems => groups?.reduce((acc, group) =>
+            setFilteredItems(filteredItems => [...groups].sort((group1, group2) => group1.startIndex - group2.startIndex).reduce((acc, group) =>
               [...acc, ...filteredItems.slice(group.startIndex, acc.length + group.count).sort(sortingF(column, sortAsc))],
               [] as any[]) || [])
           }

--- a/ui/src/table.tsx
+++ b/ui/src/table.tsx
@@ -735,9 +735,11 @@ export const
 
         setGroups(groups => {
           if (groups) {
-            setFilteredItems(filteredItems => [...groups].sort((group1, group2) => group1.startIndex - group2.startIndex).reduce((acc, group) =>
-              [...acc, ...filteredItems.slice(group.startIndex, acc.length + group.count).sort(sortingF(column, sortAsc))],
-              [] as any[]) || [])
+            setFilteredItems(filteredItems => [...groups]
+              // sorts groups by startIndex to match its order in filteredItems
+              .sort((group1, group2) => group1.startIndex - group2.startIndex)
+              .reduce((acc, group) => [...acc, ...filteredItems.slice(group.startIndex, acc.length + group.count).sort(sortingF(column, sortAsc))],
+                [] as any[]) || [])
           }
           else setFilteredItems(filteredItems => [...filteredItems].sort(sortingF(column, sortAsc)))
           return groups


### PR DESCRIPTION
Fixes missing table rows in specific cases when sorting grouped list. Sorting of grouped list does not sort groups, but only the rows inside the groups.

Closes #1287 