### PR TITLE
feat: Display additional information on plot tooltips

### DIFF
--- a/ui/src/plot.tsx
+++ b/ui/src/plot.tsx
@@ -1060,9 +1060,11 @@ export const
           space = spaceTypeOf(raw_data, marks),
           data = refactorData(raw_data, plot.marks),
           { Chart } = await import('@antv/g2'),
+          tooltipCfg = Object.keys(data[0]).join('*'),
           chart = plot.marks ? new Chart(makeChart(el, space, plot.marks, model.interactions || [])) : null
         currentPlot.current = plot
         if (chart) {
+          chart.line().position(tooltipCfg).tooltip(tooltipCfg)
           currentChart.current = chart
           chart.data(data)
           if (model.events) {

--- a/ui/src/plot.tsx
+++ b/ui/src/plot.tsx
@@ -1062,21 +1062,19 @@ export const
             showCrosshairs: true,
             crosshairs: { type: 'xy' },
             // XXX pass container element
-            customContent: (name, items) => {
+            customContent: (title, items) => {
               const container = document.createElement('div')
               container.className = 'g2-tooltip'
-              let listItem = ''
-              items.forEach(({ data, name, mappingData, color }) => {
-                Object.keys(data).forEach(item => {
-                  listItem += `<li class="g2-tooltip-list-item" data-index={index} style="margin-bottom:4px;display:flex;align-items: center;">
-                      <span style="background-color:${(item === name || data[item] === name) && (mappingData?.color || color)};" class="g2-tooltip-marker"></span>
-                      <span style="display:inline-flex;flex:1;justify-content:space-between">
-                      <span style="margin-right: 16px;">${item}:</span><span>${data[item] instanceof Date ? data[item].toISOString().split('T')[0] : data[item]}</span>
-                      </span>
-                    </li>`
-                })
-              })
-              container.innerHTML = listItem
+              container.innerHTML = items.map(({ data, name, mappingData, color }) =>
+                Object.keys(data).map(item =>
+                  `<li class="g2-tooltip-list-item" data-index={index} style="margin-bottom:4px;display:flex;align-items: center;">
+                    <span style="background-color:${(item === name || data[item] === name) && (mappingData?.color || color)};" class="g2-tooltip-marker"></span>
+                    <span style="display:inline-flex;flex:1;justify-content:space-between">
+                    <span style="margin-right: 16px;">${item}:</span><span>${data[item] instanceof Date ? data[item].toISOString().split('T')[0] : data[item]}</span>
+                    </span>
+                  </li>`
+                ).join('')
+              ).join('')
               return container
             }
           })

--- a/ui/src/plot.tsx
+++ b/ui/src/plot.tsx
@@ -16,6 +16,7 @@ import { Chart } from '@antv/g2'
 import { AdjustOption, AnnotationPosition, ArcOption, AxisOption, ChartCfg, CoordinateActions, CoordinateOption, DataMarkerOption, DataRegionOption, GeometryOption, LineOption, RegionOption, ScaleOption, TextOption } from '@antv/g2/lib/interface'
 import { B, Dict, F, Model, parseI, parseU, Rec, S, unpack, V } from 'h2o-wave'
 import React from 'react'
+import ReactDOM from 'react-dom'
 import { stylesheet } from 'typestyle'
 import { Fmt, parseFormat } from './intl'
 import { cards, grid } from './layout'
@@ -1071,16 +1072,20 @@ export const
             customContent: (title, items) => {
               const container = document.createElement('div')
               container.className = 'g2-tooltip'
-              container.innerHTML = items.map(({ data, mappingData, color }) =>
-                Object.keys(data).map(item =>
-                  `<li class="g2-tooltip-list-item" data-index={index} style="margin-bottom:4px;display:flex;align-items: center;">
-                    <span style="background-color:${mappingData?.color || color};" class="g2-tooltip-marker"></span>
-                    <span style="display:inline-flex;flex:1;justify-content:space-between">
-                    <span style="margin-right: 16px;">${item}:</span><span>${data[item] instanceof Date ? data[item].toISOString().split('T')[0] : data[item]}</span>
-                    </span>
-                  </li>`
-                ).join('')
-              ).join('')
+              const ContainerContent = () => <>
+                {items.map(({ data, mappingData, color }) =>
+                  Object.keys(data).map((item, idx) =>
+                    <li key={idx} className="g2-tooltip-list-item" data-index={idx} style={{ display: 'flex', alignItems: 'center', marginBottom: 4 }}>
+                      <span style={{ backgroundColor: mappingData?.color || color }} className="g2-tooltip-marker" />
+                      <span style={{ display: 'inline-flex', flex: 1, justifyContent: 'space-between' }}>
+                        <span style={{ marginRight: 16 }}>{item}:</span>
+                        <span>{data[item] instanceof Date ? data[item].toISOString().split('T')[0] : data[item]}</span>
+                      </span>
+                    </li>
+                  )
+                )}
+              </>
+              ReactDOM.render(<ContainerContent />, container)
               return container
             }
           })

--- a/ui/src/plot.tsx
+++ b/ui/src/plot.tsx
@@ -1061,6 +1061,12 @@ export const
           chart.tooltip({
             showCrosshairs: true,
             crosshairs: { type: 'xy' },
+            domStyles: {
+              'g2-tooltip': {
+                backgroundColor: cssVar('$card'),
+                color: cssVar('$text')
+              },
+            },
             // XXX pass container element
             customContent: (title, items) => {
               const container = document.createElement('div')

--- a/ui/src/plot.tsx
+++ b/ui/src/plot.tsx
@@ -1064,7 +1064,39 @@ export const
           chart = plot.marks ? new Chart(makeChart(el, space, plot.marks, model.interactions || [])) : null
         currentPlot.current = plot
         if (chart) {
-          chart.line().position(tooltipCfg).tooltip(tooltipCfg)
+          marks.forEach(({ type }) => {
+            switch (type) {
+              case 'interval':
+                chart.interval().position(tooltipCfg).tooltip(tooltipCfg)
+                break
+              case 'line':
+                chart.line().position(tooltipCfg).tooltip(tooltipCfg)
+                break
+              case 'path':
+                chart.path().position(tooltipCfg).tooltip(tooltipCfg)
+                break
+              case 'point':
+                chart.point().position(tooltipCfg).tooltip(tooltipCfg)
+                break
+              case 'area':
+                chart.area().position(tooltipCfg).tooltip(tooltipCfg)
+                break
+              case 'polygon':
+                chart.polygon().position(tooltipCfg).tooltip(tooltipCfg)
+                break
+              case 'schema':
+                chart.schema().position(tooltipCfg).tooltip(tooltipCfg)
+                break
+              case 'edge':
+                chart.edge().position(tooltipCfg).tooltip(tooltipCfg)
+                break
+              case 'heatmap':
+                chart.heatmap().position(tooltipCfg).tooltip(tooltipCfg)
+                break
+              default:
+                break
+            }
+          })
           currentChart.current = chart
           chart.data(data)
           if (model.events) {
@@ -1072,11 +1104,16 @@ export const
               switch (event) {
                 case 'select_marks': {
                   chart.interaction('element-single-selected')
-                  chart.on('element:statechange', (ev: any) => {
-                    const e = ev.gEvent.originalEvent
-                    if (e.stateStatus && e.state === 'selected') {
-                      if (model.name) wave.emit(model.name, event, [e.element?.data])
-                    }
+                  chart.on('element:click', (ev: any) => {
+                    const
+                      { x, data: eventData } = ev,
+                      { points, data, shape } = eventData,
+                      selectedElements = chart.getElementsBy(el => el.getStates().includes('selected')),
+                      dataInterval = shape === 'line' ? data.filter((item: any, idx: number) => {
+                        if (idx !== points.length - 1 && x >= points[idx].x && x <= points[idx + 1].x) return true
+                        if (idx !== 0 && x <= points[idx].x && x >= points[idx - 1].x) return true
+                      }) : data
+                    if (selectedElements.length && model.name) wave.emit(model.name, event, [dataInterval])
                   })
                 }
               }
@@ -1097,7 +1134,7 @@ export const
       const
         raw_data = unpack<any[]>(model.data),
         data = refactorData(raw_data, currentPlot.current.marks)
-      currentChart.current.changeData(data)
+      currentChart.current.changeData(data) // TODO: init tooltip again?
 
     }, [currentChart, currentPlot, model])
 

--- a/ui/src/plot.tsx
+++ b/ui/src/plot.tsx
@@ -977,7 +977,8 @@ const
         interactions: interactions.map(type => ({ type })),
         tooltip: {
           showCrosshairs: true,
-          crosshairs: { type: 'xy' }
+          crosshairs: { type: 'xy' },
+          showTitle: false
           // XXX pass container element
         }
       }
@@ -1045,6 +1046,9 @@ export const
           init()
         }
       },
+      setChartTooltip = (chart: any, tooltipCfg: any) => {
+        chart.position(tooltipCfg).tooltip(tooltipCfg)
+      },
       init = async () => {
         // Map CSS var colors to their hex values.
         cat10 = cat10.map(cssVarValue)
@@ -1067,33 +1071,31 @@ export const
           marks.forEach(({ type }) => {
             switch (type) {
               case 'interval':
-                chart.interval().position(tooltipCfg).tooltip(tooltipCfg)
+                setChartTooltip(chart.interval(), tooltipCfg)
                 break
               case 'line':
-                chart.line().position(tooltipCfg).tooltip(tooltipCfg)
+                setChartTooltip(chart.line(), tooltipCfg)
                 break
               case 'path':
-                chart.path().position(tooltipCfg).tooltip(tooltipCfg)
+                setChartTooltip(chart.path(), tooltipCfg)
                 break
               case 'point':
-                chart.point().position(tooltipCfg).tooltip(tooltipCfg)
+                setChartTooltip(chart.point(), tooltipCfg)
                 break
               case 'area':
-                chart.area().position(tooltipCfg).tooltip(tooltipCfg)
+                setChartTooltip(chart.area(), tooltipCfg)
                 break
               case 'polygon':
-                chart.polygon().position(tooltipCfg).tooltip(tooltipCfg)
+                setChartTooltip(chart.polygon(), tooltipCfg)
                 break
               case 'schema':
-                chart.schema().position(tooltipCfg).tooltip(tooltipCfg)
+                setChartTooltip(chart.schema(), tooltipCfg)
                 break
               case 'edge':
-                chart.edge().position(tooltipCfg).tooltip(tooltipCfg)
+                setChartTooltip(chart.edge(), tooltipCfg)
                 break
               case 'heatmap':
-                chart.heatmap().position(tooltipCfg).tooltip(tooltipCfg)
-                break
-              default:
+                setChartTooltip(chart.heatmap(), tooltipCfg)
                 break
             }
           })
@@ -1104,16 +1106,11 @@ export const
               switch (event) {
                 case 'select_marks': {
                   chart.interaction('element-single-selected')
-                  chart.on('element:click', (ev: any) => {
-                    const
-                      { x, data: eventData } = ev,
-                      { points, data, shape } = eventData,
-                      selectedElements = chart.getElementsBy(el => el.getStates().includes('selected')),
-                      dataInterval = shape === 'line' ? data.filter((item: any, idx: number) => {
-                        if (idx !== points.length - 1 && x >= points[idx].x && x <= points[idx + 1].x) return true
-                        if (idx !== 0 && x <= points[idx].x && x >= points[idx - 1].x) return true
-                      }) : data
-                    if (selectedElements.length && model.name) wave.emit(model.name, event, [dataInterval])
+                  chart.on('element:statechange', (ev: any) => {
+                    const e = ev.gEvent.originalEvent
+                    if (e.stateStatus && e.state === 'selected') {
+                      if (model.name) wave.emit(model.name, event, [e.element?.data])
+                    }
                   })
                 }
               }
@@ -1134,7 +1131,7 @@ export const
       const
         raw_data = unpack<any[]>(model.data),
         data = refactorData(raw_data, currentPlot.current.marks)
-      currentChart.current.changeData(data) // TODO: init tooltip again?
+      currentChart.current.changeData(data)
 
     }, [currentChart, currentPlot, model])
 

--- a/ui/src/plot.tsx
+++ b/ui/src/plot.tsx
@@ -1027,6 +1027,21 @@ export interface Visualization {
   interactions?: S[]
 }
 
+const tooltipContainer = document.createElement('div')
+tooltipContainer.className = 'g2-tooltip'
+
+const PlotTooltip = ({ items }: any) => items.map(({ data, mappingData, color }: any) =>
+  Object.keys(data).map((item, idx) =>
+    <li key={idx} className="g2-tooltip-list-item" data-index={idx} style={{ display: 'flex', alignItems: 'center', marginBottom: 4 }}>
+      <span style={{ backgroundColor: mappingData?.color || color }} className="g2-tooltip-marker" />
+      <span style={{ display: 'inline-flex', flex: 1, justifyContent: 'space-between' }}>
+        <span style={{ marginRight: 16 }}>{item}:</span>
+        <span>{data[item] instanceof Date ? data[item].toISOString().split('T')[0] : data[item]}</span>
+      </span>
+    </li>
+  )
+)
+
 export const
   XVisualization = ({ model }: { model: Visualization }) => {
     const
@@ -1068,25 +1083,9 @@ export const
                 color: cssVar('$text')
               },
             },
-            // XXX pass container element
-            customContent: (title, items) => {
-              const container = document.createElement('div')
-              container.className = 'g2-tooltip'
-              const ContainerContent = () => <>
-                {items.map(({ data, mappingData, color }) =>
-                  Object.keys(data).map((item, idx) =>
-                    <li key={idx} className="g2-tooltip-list-item" data-index={idx} style={{ display: 'flex', alignItems: 'center', marginBottom: 4 }}>
-                      <span style={{ backgroundColor: mappingData?.color || color }} className="g2-tooltip-marker" />
-                      <span style={{ display: 'inline-flex', flex: 1, justifyContent: 'space-between' }}>
-                        <span style={{ marginRight: 16 }}>{item}:</span>
-                        <span>{data[item] instanceof Date ? data[item].toISOString().split('T')[0] : data[item]}</span>
-                      </span>
-                    </li>
-                  )
-                )}
-              </>
-              ReactDOM.render(<ContainerContent />, container)
-              return container
+            customContent: (_title, items) => {
+              ReactDOM.render(<PlotTooltip items={items} />, tooltipContainer)
+              return tooltipContainer
             }
           })
           currentChart.current = chart

--- a/ui/src/plot.tsx
+++ b/ui/src/plot.tsx
@@ -975,12 +975,6 @@ const
         annotations,
         // Custom interactions.
         interactions: interactions.map(type => ({ type })),
-        tooltip: {
-          showCrosshairs: true,
-          crosshairs: { type: 'xy' },
-          showTitle: false
-          // XXX pass container element
-        }
       }
     }
   }
@@ -1061,12 +1055,30 @@ export const
           space = spaceTypeOf(raw_data, marks),
           data = refactorData(raw_data, plot.marks),
           { Chart } = await import('@antv/g2'),
-          tooltipCfg = Object.keys(data[0]).join('*'),
           chart = plot.marks ? new Chart(makeChart(el, space, plot.marks, model.interactions || [])) : null
         currentPlot.current = plot
         if (chart) {
-          marks.forEach(({ type }) => {
-            if (type) chart[type]().position(tooltipCfg).tooltip(tooltipCfg)
+          chart.tooltip({
+            showCrosshairs: true,
+            crosshairs: { type: 'xy' },
+            // XXX pass container element
+            customContent: (name, items) => {
+              const container = document.createElement('div')
+              container.className = 'g2-tooltip'
+              let listItem = ''
+              items.forEach(({ data, name, mappingData, color }) => {
+                Object.keys(data).forEach(item => {
+                  listItem += `<li class="g2-tooltip-list-item" data-index={index} style="margin-bottom:4px;display:flex;align-items: center;">
+                      <span style="background-color:${(item === name || data[item] === name) && (mappingData?.color || color)};" class="g2-tooltip-marker"></span>
+                      <span style="display:inline-flex;flex:1;justify-content:space-between">
+                      <span style="margin-right: 16px;">${item}:</span><span>${data[item] instanceof Date ? data[item].toISOString().split('T')[0] : data[item]}</span>
+                      </span>
+                    </li>`
+                })
+              })
+              container.innerHTML = listItem
+              return container
+            }
           })
           currentChart.current = chart
           chart.data(data)

--- a/ui/src/plot.tsx
+++ b/ui/src/plot.tsx
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { Chart } from '@antv/g2'
-import { AdjustOption, AnnotationPosition, ArcOption, AxisOption, ChartCfg, CoordinateActions, CoordinateOption, DataMarkerOption, DataRegionOption, GeometryOption, LineOption, RegionOption, ScaleOption, TextOption } from '@antv/g2/lib/interface'
+import { AdjustOption, AnnotationPosition, ArcOption, AxisOption, ChartCfg, CoordinateActions, CoordinateOption, DataMarkerOption, DataRegionOption, GeometryOption, LineOption, RegionOption, ScaleOption, TextOption, TooltipItem } from '@antv/g2/lib/interface'
 import { B, Dict, F, Model, parseI, parseU, Rec, S, unpack, V } from 'h2o-wave'
 import React from 'react'
 import ReactDOM from 'react-dom'
@@ -1030,17 +1030,22 @@ export interface Visualization {
 const tooltipContainer = document.createElement('div')
 tooltipContainer.className = 'g2-tooltip'
 
-const PlotTooltip = ({ items }: any) => items.map(({ data, mappingData, color }: any) =>
-  Object.keys(data).map((item, idx) =>
-    <li key={idx} className="g2-tooltip-list-item" data-index={idx} style={{ display: 'flex', alignItems: 'center', marginBottom: 4 }}>
-      <span style={{ backgroundColor: mappingData?.color || color }} className="g2-tooltip-marker" />
-      <span style={{ display: 'inline-flex', flex: 1, justifyContent: 'space-between' }}>
-        <span style={{ marginRight: 16 }}>{item}:</span>
-        <span>{data[item] instanceof Date ? data[item].toISOString().split('T')[0] : data[item]}</span>
-      </span>
-    </li>
-  )
-)
+const PlotTooltip = ({ items }: { items: TooltipItem[] }) =>
+  <>
+    {items.map(({ data, mappingData, color }: TooltipItem) =>
+      Object.keys(data).map((item, idx) =>
+        <li key={idx} className="g2-tooltip-list-item" data-index={idx} style={{ display: 'flex', alignItems: 'center', marginBottom: 4 }}>
+          <span style={{ backgroundColor: mappingData?.color || color }} className="g2-tooltip-marker" />
+          <span style={{ display: 'inline-flex', flex: 1, justifyContent: 'space-between' }}>
+            <span style={{ marginRight: 16 }}>{item}:</span>
+            <span>{data[item] instanceof Date ? data[item].toISOString().split('T')[0] : data[item]}</span>
+          </span>
+        </li>
+      )
+    )}
+  </>
+
+
 
 export const
   XVisualization = ({ model }: { model: Visualization }) => {

--- a/ui/src/plot.tsx
+++ b/ui/src/plot.tsx
@@ -1046,9 +1046,6 @@ export const
           init()
         }
       },
-      setChartTooltip = (chart: any, tooltipCfg: any) => {
-        chart.position(tooltipCfg).tooltip(tooltipCfg)
-      },
       init = async () => {
         // Map CSS var colors to their hex values.
         cat10 = cat10.map(cssVarValue)
@@ -1069,35 +1066,7 @@ export const
         currentPlot.current = plot
         if (chart) {
           marks.forEach(({ type }) => {
-            switch (type) {
-              case 'interval':
-                setChartTooltip(chart.interval(), tooltipCfg)
-                break
-              case 'line':
-                setChartTooltip(chart.line(), tooltipCfg)
-                break
-              case 'path':
-                setChartTooltip(chart.path(), tooltipCfg)
-                break
-              case 'point':
-                setChartTooltip(chart.point(), tooltipCfg)
-                break
-              case 'area':
-                setChartTooltip(chart.area(), tooltipCfg)
-                break
-              case 'polygon':
-                setChartTooltip(chart.polygon(), tooltipCfg)
-                break
-              case 'schema':
-                setChartTooltip(chart.schema(), tooltipCfg)
-                break
-              case 'edge':
-                setChartTooltip(chart.edge(), tooltipCfg)
-                break
-              case 'heatmap':
-                setChartTooltip(chart.heatmap(), tooltipCfg)
-                break
-            }
+            if (type) chart[type]().position(tooltipCfg).tooltip(tooltipCfg)
           })
           currentChart.current = chart
           chart.data(data)

--- a/ui/src/plot.tsx
+++ b/ui/src/plot.tsx
@@ -1065,10 +1065,10 @@ export const
             customContent: (title, items) => {
               const container = document.createElement('div')
               container.className = 'g2-tooltip'
-              container.innerHTML = items.map(({ data, name, mappingData, color }) =>
+              container.innerHTML = items.map(({ data, mappingData, color }) =>
                 Object.keys(data).map(item =>
                   `<li class="g2-tooltip-list-item" data-index={index} style="margin-bottom:4px;display:flex;align-items: center;">
-                    <span style="background-color:${(item === name || data[item] === name) && (mappingData?.color || color)};" class="g2-tooltip-marker"></span>
+                    <span style="background-color:${mappingData?.color || color};" class="g2-tooltip-marker"></span>
                     <span style="display:inline-flex;flex:1;justify-content:space-between">
                     <span style="margin-right: 16px;">${item}:</span><span>${data[item] instanceof Date ? data[item].toISOString().split('T')[0] : data[item]}</span>
                     </span>


### PR DESCRIPTION
All plot data are shown in tooltip now, not only data user is plotting.

![image](https://user-images.githubusercontent.com/23740173/162183060-94e80ac4-7ad3-4f7d-bd81-5d743cd15289.png)

![image](https://user-images.githubusercontent.com/23740173/164679769-80d8d99f-2711-426a-b04b-2f00421974b5.png)


Closes #644 