### PR TITLE
feat: Allow ui.text_annotator to be read-only

### DIFF
--- a/py/h2o_wave/types.py
+++ b/py/h2o_wave/types.py
@@ -6095,12 +6095,14 @@ class TextAnnotator:
             tags: List[TextAnnotatorTag],
             items: List[TextAnnotatorItem],
             trigger: Optional[bool] = None,
+            readonly: Optional[bool] = None,
     ):
         _guard_scalar('TextAnnotator.name', name, (str,), True, False, False)
         _guard_scalar('TextAnnotator.title', title, (str,), False, False, False)
         _guard_vector('TextAnnotator.tags', tags, (TextAnnotatorTag,), False, False, False)
         _guard_vector('TextAnnotator.items', items, (TextAnnotatorItem,), False, False, False)
         _guard_scalar('TextAnnotator.trigger', trigger, (bool,), False, True, False)
+        _guard_scalar('TextAnnotator.readonly', readonly, (bool,), False, True, False)
         self.name = name
         """An identifying name for this component."""
         self.title = title
@@ -6111,6 +6113,8 @@ class TextAnnotator:
         """Pretagged parts of text content."""
         self.trigger = trigger
         """True if the form should be submitted when the annotator value changes."""
+        self.readonly = readonly
+        """True to prevent user interaction with annotator component."""
 
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""
@@ -6119,12 +6123,14 @@ class TextAnnotator:
         _guard_vector('TextAnnotator.tags', self.tags, (TextAnnotatorTag,), False, False, False)
         _guard_vector('TextAnnotator.items', self.items, (TextAnnotatorItem,), False, False, False)
         _guard_scalar('TextAnnotator.trigger', self.trigger, (bool,), False, True, False)
+        _guard_scalar('TextAnnotator.readonly', self.readonly, (bool,), False, True, False)
         return _dump(
             name=self.name,
             title=self.title,
             tags=[__e.dump() for __e in self.tags],
             items=[__e.dump() for __e in self.items],
             trigger=self.trigger,
+            readonly=self.readonly,
         )
 
     @staticmethod
@@ -6140,17 +6146,21 @@ class TextAnnotator:
         _guard_vector('TextAnnotator.items', __d_items, (dict,), False, False, False)
         __d_trigger: Any = __d.get('trigger')
         _guard_scalar('TextAnnotator.trigger', __d_trigger, (bool,), False, True, False)
+        __d_readonly: Any = __d.get('readonly')
+        _guard_scalar('TextAnnotator.readonly', __d_readonly, (bool,), False, True, False)
         name: str = __d_name
         title: str = __d_title
         tags: List[TextAnnotatorTag] = [TextAnnotatorTag.load(__e) for __e in __d_tags]
         items: List[TextAnnotatorItem] = [TextAnnotatorItem.load(__e) for __e in __d_items]
         trigger: Optional[bool] = __d_trigger
+        readonly: Optional[bool] = __d_readonly
         return TextAnnotator(
             name,
             title,
             tags,
             items,
             trigger,
+            readonly,
         )
 
 

--- a/py/h2o_wave/types.py
+++ b/py/h2o_wave/types.py
@@ -6114,7 +6114,7 @@ class TextAnnotator:
         self.trigger = trigger
         """True if the form should be submitted when the annotator value changes."""
         self.readonly = readonly
-        """True to prevent user interaction with the annotator component."""
+        """True to prevent user interaction with the annotator component. Defaults to False."""
 
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""

--- a/py/h2o_wave/types.py
+++ b/py/h2o_wave/types.py
@@ -6114,7 +6114,7 @@ class TextAnnotator:
         self.trigger = trigger
         """True if the form should be submitted when the annotator value changes."""
         self.readonly = readonly
-        """True to prevent user interaction with annotator component."""
+        """True to prevent user interaction with the annotator component."""
 
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""

--- a/py/h2o_wave/ui.py
+++ b/py/h2o_wave/ui.py
@@ -2284,7 +2284,7 @@ def text_annotator(
         tags: List of tags the user can annotate with.
         items: Pretagged parts of text content.
         trigger: True if the form should be submitted when the annotator value changes.
-        readonly: True to prevent user interaction with annotator component.
+        readonly: True to prevent user interaction with the annotator component.
     Returns:
         A `h2o_wave.types.TextAnnotator` instance.
     """

--- a/py/h2o_wave/ui.py
+++ b/py/h2o_wave/ui.py
@@ -2284,7 +2284,7 @@ def text_annotator(
         tags: List of tags the user can annotate with.
         items: Pretagged parts of text content.
         trigger: True if the form should be submitted when the annotator value changes.
-        readonly: True to prevent user interaction with the annotator component.
+        readonly: True to prevent user interaction with the annotator component. Defaults to False.
     Returns:
         A `h2o_wave.types.TextAnnotator` instance.
     """

--- a/py/h2o_wave/ui.py
+++ b/py/h2o_wave/ui.py
@@ -2272,6 +2272,7 @@ def text_annotator(
         tags: List[TextAnnotatorTag],
         items: List[TextAnnotatorItem],
         trigger: Optional[bool] = None,
+        readonly: Optional[bool] = None,
 ) -> Component:
     """Create a text annotator component.
 
@@ -2283,6 +2284,7 @@ def text_annotator(
         tags: List of tags the user can annotate with.
         items: Pretagged parts of text content.
         trigger: True if the form should be submitted when the annotator value changes.
+        readonly: True to prevent user interaction with annotator component.
     Returns:
         A `h2o_wave.types.TextAnnotator` instance.
     """
@@ -2292,6 +2294,7 @@ def text_annotator(
         tags,
         items,
         trigger,
+        readonly,
     ))
 
 

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -2660,7 +2660,7 @@ ui_text_annotator_item <- function(
 #' @param tags List of tags the user can annotate with.
 #' @param items Pretagged parts of text content.
 #' @param trigger True if the form should be submitted when the annotator value changes.
-#' @param readonly True to prevent user interaction with the annotator component.
+#' @param readonly True to prevent user interaction with the annotator component. Defaults to False.
 #' @return A TextAnnotator instance.
 #' @export
 ui_text_annotator <- function(

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -2660,6 +2660,7 @@ ui_text_annotator_item <- function(
 #' @param tags List of tags the user can annotate with.
 #' @param items Pretagged parts of text content.
 #' @param trigger True if the form should be submitted when the annotator value changes.
+#' @param readonly True to prevent user interaction with annotator component.
 #' @return A TextAnnotator instance.
 #' @export
 ui_text_annotator <- function(
@@ -2667,18 +2668,21 @@ ui_text_annotator <- function(
   title,
   tags,
   items,
-  trigger = NULL) {
+  trigger = NULL,
+  readonly = NULL) {
   .guard_scalar("name", "character", name)
   .guard_scalar("title", "character", title)
   .guard_vector("tags", "WaveTextAnnotatorTag", tags)
   .guard_vector("items", "WaveTextAnnotatorItem", items)
   .guard_scalar("trigger", "logical", trigger)
+  .guard_scalar("readonly", "logical", readonly)
   .o <- list(text_annotator=list(
     name=name,
     title=title,
     tags=tags,
     items=items,
-    trigger=trigger))
+    trigger=trigger,
+    readonly=readonly))
   class(.o) <- append(class(.o), c(.wave_obj, "WaveComponent"))
   return(.o)
 }

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -2660,7 +2660,7 @@ ui_text_annotator_item <- function(
 #' @param tags List of tags the user can annotate with.
 #' @param items Pretagged parts of text content.
 #' @param trigger True if the form should be submitted when the annotator value changes.
-#' @param readonly True to prevent user interaction with annotator component.
+#' @param readonly True to prevent user interaction with the annotator component.
 #' @return A TextAnnotator instance.
 #' @export
 ui_text_annotator <- function(

--- a/tools/intellij-plugin/src/main/resources/templates/wave-components.xml
+++ b/tools/intellij-plugin/src/main/resources/templates/wave-components.xml
@@ -2347,10 +2347,11 @@
       <option name="Python" value="true"/>
     </context>
   </template>
-  <template name="w_full_text_annotator" value="ui.text_annotator(name='$name$',title='$title$',trigger=$trigger$,tags=[&#10;	$tags$	&#10;],items=[&#10;	$items$	&#10;]),$END$" description="Create Wave TextAnnotator with full attributes." toReformat="true" toShortenFQNames="true">
+  <template name="w_full_text_annotator" value="ui.text_annotator(name='$name$',title='$title$',trigger=$trigger$,readonly=$readonly$,tags=[&#10;	$tags$	&#10;],items=[&#10;	$items$	&#10;]),$END$" description="Create Wave TextAnnotator with full attributes." toReformat="true" toShortenFQNames="true">
     <variable name="name" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="title" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="trigger" expression="" defaultValue="&quot;False&quot;" alwaysStopAt="true"/>
+    <variable name="readonly" expression="" defaultValue="&quot;False&quot;" alwaysStopAt="true"/>
     <variable name="tags" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="items" expression="" defaultValue="" alwaysStopAt="true"/>
     <context>

--- a/tools/vscode-extension/component-snippets.json
+++ b/tools/vscode-extension/component-snippets.json
@@ -1696,7 +1696,7 @@
   "Wave Full TextAnnotator": {
     "prefix": "w_full_text_annotator",
     "body": [
-      "ui.text_annotator(name='$1', title='$2', trigger=${3:False}, tags=[\n\t\t$4\t\t\n], items=[\n\t\t$5\t\t\n]),$0"
+      "ui.text_annotator(name='$1', title='$2', trigger=${3:False}, readonly=${4:False}, tags=[\n\t\t$5\t\t\n], items=[\n\t\t$6\t\t\n]),$0"
     ],
     "description": "Create a full Wave TextAnnotator."
   },

--- a/ui/src/text_annotator.test.tsx
+++ b/ui/src/text_annotator.test.tsx
@@ -103,61 +103,10 @@ describe('TextAnnotator.tsx', () => {
       }
     })
 
-    it('Does not change args on remove', () => {
+    it('Does not contain the active tag', () => {
       const { container } = render(<XTextAnnotator model={annotatorProps} />)
 
-      fireEvent.mouseUp(container.querySelector('i')!)
-      expect(wave.args[name]).toMatchObject(items)
-    })
-
-    it('Does not change args on annotate', () => {
-      const { getByText } = render(<XTextAnnotator model={annotatorProps} />)
-
-      fireEvent.click(getByText('Tag 1'))
-      fireEvent.mouseDown(getByText('Hello'))
-      fireEvent.mouseUp(getByText('there'))
-
-      expect(wave.args[name]).toMatchObject(items)
-    })
-
-    it('Does not remove browser text selection highlight after annotate', () => {
-      const { getByText } = render(<XTextAnnotator model={annotatorProps} />)
-
-      fireEvent.click(getByText('Tag 1'))
-      fireEvent.mouseDown(getByText('Hello'))
-      fireEvent.mouseUp(getByText('there'))
-
-      expect(getSelectionMock).not.toHaveBeenCalled()
-    })
-
-    it('Does not call sync on remove if trigger specified', () => {
-      const { container } = render(<XTextAnnotator model={{ ...annotatorProps, trigger: true }} />)
-
-      fireEvent.mouseUp(container.querySelector('i')!)
-      expect(pushMock).not.toHaveBeenCalled()
-    })
-
-    it('Does not call sync on annotate if trigger specified', () => {
-      const { getByText } = render(<XTextAnnotator model={{ ...annotatorProps, trigger: true }} />)
-
-      fireEvent.click(getByText('Tag 1'))
-      fireEvent.mouseDown(getByText('Hello'))
-      fireEvent.mouseUp(getByText('there'))
-
-      expect(pushMock).not.toHaveBeenCalled()
-    })
-
-    it('Does not show remove icon on hover', () => {
-      const { container, getByText } = render(<XTextAnnotator model={annotatorProps} />)
-
-      const removeIcon = container.querySelector('i')
-      expect(removeIcon).not.toBeVisible()
-      fireEvent.mouseOver(getByText('good'))
-      expect(removeIcon).not.toBeVisible()
-      fireEvent.mouseOut(getByText('good'))
-      expect(removeIcon).not.toBeVisible()
-      fireEvent.mouseOver(getByText('Pretty'))
-      expect(removeIcon).not.toBeVisible()
+      expect(container.querySelector('[class*=activeTag]')).not.toBeInTheDocument()
     })
   })
 })

--- a/ui/src/text_annotator.test.tsx
+++ b/ui/src/text_annotator.test.tsx
@@ -6,9 +6,10 @@ import { wave } from './ui'
 const
   name = 'textAnnotator',
   items = [{ text: 'Hello there! ' }, { text: 'Pretty good', tag: 'tag1' }, { text: ' day' }],
-  annotatorProps: TextAnnotator = { name, title: name, tags: [{ name: 'tag1', label: 'Tag 1', color: '$red' }], items },
   getSelectionMock = jest.fn(),
   pushMock = jest.fn()
+
+let annotatorProps: TextAnnotator = { name, title: name, tags: [{ name: 'tag1', label: 'Tag 1', color: '$red' }], items }
 
 describe('TextAnnotator.tsx', () => {
   beforeAll(() => {
@@ -92,5 +93,71 @@ describe('TextAnnotator.tsx', () => {
     const mark2 = getByText('Pretty')
     fireEvent.mouseOver(mark2)
     expect(removeIcon).toBeVisible()
+  })
+
+  describe('readonly', () => {
+    beforeEach(() => {
+      annotatorProps = {
+        ...annotatorProps,
+        readonly: true
+      }
+    })
+
+    it('Does not change args on remove', () => {
+      const { container } = render(<XTextAnnotator model={annotatorProps} />)
+
+      fireEvent.mouseUp(container.querySelector('i')!)
+      expect(wave.args[name]).toMatchObject(items)
+    })
+
+    it('Does not change args on annotate', () => {
+      const { getByText } = render(<XTextAnnotator model={annotatorProps} />)
+
+      fireEvent.click(getByText('Tag 1'))
+      fireEvent.mouseDown(getByText('Hello'))
+      fireEvent.mouseUp(getByText('there'))
+
+      expect(wave.args[name]).toMatchObject(items)
+    })
+
+    it('Does not remove browser text selection highlight after annotate', () => {
+      const { getByText } = render(<XTextAnnotator model={annotatorProps} />)
+
+      fireEvent.click(getByText('Tag 1'))
+      fireEvent.mouseDown(getByText('Hello'))
+      fireEvent.mouseUp(getByText('there'))
+
+      expect(getSelectionMock).not.toHaveBeenCalled()
+    })
+
+    it('Does not call sync on remove if trigger specified', () => {
+      const { container } = render(<XTextAnnotator model={{ ...annotatorProps, trigger: true }} />)
+
+      fireEvent.mouseUp(container.querySelector('i')!)
+      expect(pushMock).not.toHaveBeenCalled()
+    })
+
+    it('Does not call sync on annotate if trigger specified', () => {
+      const { getByText } = render(<XTextAnnotator model={{ ...annotatorProps, trigger: true }} />)
+
+      fireEvent.click(getByText('Tag 1'))
+      fireEvent.mouseDown(getByText('Hello'))
+      fireEvent.mouseUp(getByText('there'))
+
+      expect(pushMock).not.toHaveBeenCalled()
+    })
+
+    it('Does not show remove icon on hover', () => {
+      const { container, getByText } = render(<XTextAnnotator model={annotatorProps} />)
+
+      const removeIcon = container.querySelector('i')
+      expect(removeIcon).not.toBeVisible()
+      fireEvent.mouseOver(getByText('good'))
+      expect(removeIcon).not.toBeVisible()
+      fireEvent.mouseOut(getByText('good'))
+      expect(removeIcon).not.toBeVisible()
+      fireEvent.mouseOver(getByText('Pretty'))
+      expect(removeIcon).not.toBeVisible()
+    })
   })
 })

--- a/ui/src/text_annotator.test.tsx
+++ b/ui/src/text_annotator.test.tsx
@@ -6,10 +6,9 @@ import { wave } from './ui'
 const
   name = 'textAnnotator',
   items = [{ text: 'Hello there! ' }, { text: 'Pretty good', tag: 'tag1' }, { text: ' day' }],
+  annotatorProps: TextAnnotator = { name, title: name, tags: [{ name: 'tag1', label: 'Tag 1', color: '$red' }], items },
   getSelectionMock = jest.fn(),
   pushMock = jest.fn()
-
-let annotatorProps: TextAnnotator = { name, title: name, tags: [{ name: 'tag1', label: 'Tag 1', color: '$red' }], items }
 
 describe('TextAnnotator.tsx', () => {
   beforeAll(() => {

--- a/ui/src/text_annotator.test.tsx
+++ b/ui/src/text_annotator.test.tsx
@@ -96,15 +96,8 @@ describe('TextAnnotator.tsx', () => {
   })
 
   describe('readonly', () => {
-    beforeEach(() => {
-      annotatorProps = {
-        ...annotatorProps,
-        readonly: true
-      }
-    })
-
     it('Does not contain the active tag', () => {
-      const { container } = render(<XTextAnnotator model={annotatorProps} />)
+      const { container } = render(<XTextAnnotator model={{ ...annotatorProps, readonly: true }} />)
 
       expect(container.querySelector('[class*=activeTag]')).not.toBeInTheDocument()
     })

--- a/ui/src/text_annotator.tsx
+++ b/ui/src/text_annotator.tsx
@@ -39,7 +39,7 @@ export interface TextAnnotator {
   items: TextAnnotatorItem[]
   /** True if the form should be submitted when the annotator value changes. */
   trigger?: B
-  /** True to prevent user interaction with the annotator component. */
+  /** True to prevent user interaction with the annotator component. Defaults to False. */
   readonly?: B
 }
 
@@ -101,13 +101,14 @@ const css = stylesheet({
     left: -5,
     top: -3,
     background: cssVar('$card')
-  }
+  },
+  readonly: { pointerEvents: 'none' }
 })
 
 export const XTextAnnotator = ({ model }: { model: TextAnnotator }) => {
   const
     [startIdx, setStartIdx] = React.useState<U | null>(null),
-    [activeTag, setActiveTag] = React.useState<S | undefined>(model.tags[0]?.name),
+    [activeTag, setActiveTag] = React.useState<S | undefined>(model.readonly ? undefined : model.tags[0]?.name),
     [hoveredTagIdx, setHoveredTagIdx] = React.useState<U | null>(),
     tagColorMap = model.tags.reduce((map, t) => {
       map.set(t.name, t.color)
@@ -189,12 +190,12 @@ export const XTextAnnotator = ({ model }: { model: TextAnnotator }) => {
         isLast = tokens[idx + 1]?.tag !== tag
       return (
         <mark
-          onMouseOver={model.readonly ? undefined : onMarkHover(idx)}
-          onMouseOut={model.readonly ? undefined : onMarkMouseOut}
+          onMouseOver={onMarkHover(idx)}
+          onMouseOut={onMarkMouseOut}
           className={clas(css.mark, isFirst ? css.firstMark : '', isLast ? css.lastMark : '')}
           style={{ backgroundColor: cssVar(color), color: getContrast(color) }}>
           {text}
-          <Fluent.Icon iconName='CircleAdditionSolid' styles={{ root: removeIconStyle }} className={clas(css.removeIcon, 'wave-w6')} onMouseUp={model.readonly ? undefined : removeAnnotation(idx)} />
+          <Fluent.Icon iconName='CircleAdditionSolid' styles={{ root: removeIconStyle }} className={clas(css.removeIcon, 'wave-w6')} onMouseUp={removeAnnotation(idx)} />
           {/* HACK: Put color underlay under remove icon because its glyph is transparent and doesn't look good on tags. */}
           <span style={removeIconStyle as React.CSSProperties} className={css.iconUnderlay}></span>
         </mark>
@@ -214,7 +215,7 @@ export const XTextAnnotator = ({ model }: { model: TextAnnotator }) => {
       })
       return (
         <div key={name} data-test={name} className={clas(css.tagWrapper, activeTag === name ? style.activeTag : '')}>
-          <div className={clas(css.tag, style.tag, 'wave-s12')} onClick={model.readonly ? undefined : activateTag(name)}>{label}</div>
+          <div className={clas(css.tag, style.tag, 'wave-s12')} onClick={activateTag(name)}>{label}</div>
         </div>
       )
     })
@@ -223,12 +224,12 @@ export const XTextAnnotator = ({ model }: { model: TextAnnotator }) => {
   React.useEffect(() => { wave.args[model.name] = model.items as unknown as Rec[] }, [])
 
   return (
-    <div data-test={model.name}>
+    <div data-test={model.name} className={model.readonly ? css.readonly : ''}>
       <div className={clas('wave-s16 wave-w6', css.title)}>{model.title}</div>
       <div className={css.tags}>{tags}</div>
       <div className={clas(css.content, 'wave-s16 wave-t7 wave-w3')}>{
         tokens.map(({ text, tag }, idx) => (
-          <span key={idx} onMouseDown={model.readonly ? undefined : updateStartIdx(idx)} onMouseUp={model.readonly ? undefined : annotate(idx)}>{tag ? getMark(text, idx, tag) : text}</span>
+          <span key={idx} onMouseDown={updateStartIdx(idx)} onMouseUp={annotate(idx)}>{tag ? getMark(text, idx, tag) : text}</span>
         ))
       }
       </div>

--- a/ui/src/text_annotator.tsx
+++ b/ui/src/text_annotator.tsx
@@ -39,6 +39,8 @@ export interface TextAnnotator {
   items: TextAnnotatorItem[]
   /** True if the form should be submitted when the annotator value changes. */
   trigger?: B
+  /** True to prevent user interaction with annotator component. */
+  readonly?: B
 }
 
 const css = stylesheet({
@@ -55,7 +57,6 @@ const css = stylesheet({
     padding: padding(4, 16),
     textAlign: 'center',
     borderRadius: 4,
-    cursor: 'pointer',
   },
   tagWrapper: {
     marginRight: 4,
@@ -188,12 +189,12 @@ export const XTextAnnotator = ({ model }: { model: TextAnnotator }) => {
         isLast = tokens[idx + 1]?.tag !== tag
       return (
         <mark
-          onMouseOver={onMarkHover(idx)}
-          onMouseOut={onMarkMouseOut}
+          onMouseOver={model.readonly ? undefined : onMarkHover(idx)}
+          onMouseOut={model.readonly ? undefined : onMarkMouseOut}
           className={clas(css.mark, isFirst ? css.firstMark : '', isLast ? css.lastMark : '')}
           style={{ backgroundColor: cssVar(color), color: getContrast(color) }}>
           {text}
-          <Fluent.Icon iconName='CircleAdditionSolid' styles={{ root: removeIconStyle }} className={clas(css.removeIcon, 'wave-w6')} onMouseUp={removeAnnotation(idx)} />
+          <Fluent.Icon iconName='CircleAdditionSolid' styles={{ root: removeIconStyle }} className={clas(css.removeIcon, 'wave-w6')} onMouseUp={model.readonly ? undefined : removeAnnotation(idx)} />
           {/* HACK: Put color underlay under remove icon because its glyph is transparent and doesn't look good on tags. */}
           <span style={removeIconStyle as React.CSSProperties} className={css.iconUnderlay}></span>
         </mark>
@@ -204,6 +205,7 @@ export const XTextAnnotator = ({ model }: { model: TextAnnotator }) => {
         tag: {
           background: cssVar(color),
           color: getContrast(color),
+          cursor: model.readonly ? 'default' : 'pointer',
         },
         activeTag: {
           border: border(2, cssVar('$themePrimary')),
@@ -212,7 +214,7 @@ export const XTextAnnotator = ({ model }: { model: TextAnnotator }) => {
       })
       return (
         <div key={name} data-test={name} className={clas(css.tagWrapper, activeTag === name ? style.activeTag : '')}>
-          <div className={clas(css.tag, style.tag, 'wave-s12')} onClick={activateTag(name)}>{label}</div>
+          <div className={clas(css.tag, style.tag, 'wave-s12')} onClick={model.readonly ? undefined : activateTag(name)}>{label}</div>
         </div>
       )
     })
@@ -226,7 +228,7 @@ export const XTextAnnotator = ({ model }: { model: TextAnnotator }) => {
       <div className={css.tags}>{tags}</div>
       <div className={clas(css.content, 'wave-s16 wave-t7 wave-w3')}>{
         tokens.map(({ text, tag }, idx) => (
-          <span key={idx} onMouseDown={updateStartIdx(idx)} onMouseUp={annotate(idx)}>{tag ? getMark(text, idx, tag) : text}</span>
+          <span key={idx} onMouseDown={model.readonly ? undefined : updateStartIdx(idx)} onMouseUp={model.readonly ? undefined : annotate(idx)}>{tag ? getMark(text, idx, tag) : text}</span>
         ))
       }
       </div>

--- a/ui/src/text_annotator.tsx
+++ b/ui/src/text_annotator.tsx
@@ -39,7 +39,7 @@ export interface TextAnnotator {
   items: TextAnnotatorItem[]
   /** True if the form should be submitted when the annotator value changes. */
   trigger?: B
-  /** True to prevent user interaction with annotator component. */
+  /** True to prevent user interaction with the annotator component. */
   readonly?: B
 }
 

--- a/website/widgets/form/text_annotator.md
+++ b/website/widgets/form/text_annotator.md
@@ -8,11 +8,36 @@ custom_edit_url: null
 
 Use text annotator when you need to highlight text phrases. Useful for NLP.
 
+## Basic text annotator
+
 ```py
 q.page['example'] = ui.form_card(box='1 1 4 10', items=[
     ui.text_annotator(
         name='annotator',
         title='Select text to annotate',
+        tags=[
+            ui.text_annotator_tag(name='p', label='Person', color='#F1CBCB'),
+            ui.text_annotator_tag(name='o', label='Org', color='#CAEACA'),
+        ],
+        items=[
+            ui.text_annotator_item(text='Killer Mike', tag='p'),
+            ui.text_annotator_item(text=' is a member, of the hip hop supergroup '),  # no tag
+            ui.text_annotator_item(text='Run the Jewels', tag='o'),
+        ],
+    )
+])
+```
+
+## With readonly
+
+If you wish to prevent user interaction with annotator component, set `readonly` attribute to `True`.
+
+```py
+q.page['example'] = ui.form_card(box='1 1 4 10', items=[
+    ui.text_annotator(
+        name='annotator',
+        title='Select text to annotate',
+        readonly=True,
         tags=[
             ui.text_annotator_tag(name='p', label='Person', color='#F1CBCB'),
             ui.text_annotator_tag(name='o', label='Org', color='#CAEACA'),

--- a/website/widgets/form/text_annotator.md
+++ b/website/widgets/form/text_annotator.md
@@ -8,8 +8,6 @@ custom_edit_url: null
 
 Use text annotator when you need to highlight text phrases. Useful for NLP.
 
-## Basic text annotator
-
 ```py
 q.page['example'] = ui.form_card(box='1 1 4 10', items=[
     ui.text_annotator(
@@ -28,7 +26,7 @@ q.page['example'] = ui.form_card(box='1 1 4 10', items=[
 ])
 ```
 
-## With readonly
+## Readonly
 
 If you wish to prevent user interaction with annotator component, set `readonly` attribute to `True`.
 


### PR DESCRIPTION
This PR introduces `readonly` prop for TextAnnotator component. It provides an option to prevent all user interaction with the annotator component.

Updated API looks as follows:
```ts
export interface TextAnnotator {
  /** An identifying name for this component. */
  name: Id
  /** The text annotator's title. */
  title: S
  /** List of tags the user can annotate with. */
  tags: TextAnnotatorTag[]
  /** Pretagged parts of text content. */
  items: TextAnnotatorItem[]
  /** True if the form should be submitted when the annotator value changes. */
  trigger?: B
  /** True to prevent user interaction with the annotator component. */
  readonly?: B
}
```

Closes #1247
