### PR TITLE
feat: Allow specifying path for button

### DIFF
--- a/py/examples/button.py
+++ b/py/examples/button.py
@@ -21,6 +21,7 @@ async def serve(q: Q):
             ui.text(f'primary_caption_disabled_button={q.args.primary_caption_disabled_button}'),
             ui.text(f'button_with_icon={q.args.button_with_icon}'),
             ui.text(f'icon_button={q.args.icon_button}'),
+            ui.text(f'external_path_button={q.args.external_path_button}'),
             ui.button(name='show_form', label='Back', primary=True),
         ]
     else:
@@ -39,5 +40,6 @@ async def serve(q: Q):
                       primary=True, disabled=True),
             ui.button(name='button_with_icon', label='Button with an icon', icon='Search'),
             ui.button(name='icon_button', icon='Heart', caption='Tooltip text'),
+            ui.button(name='external_path_button', label='External', path='https://h2o.ai/'),
         ])
     await q.page.save()

--- a/py/h2o_wave/types.py
+++ b/py/h2o_wave/types.py
@@ -2564,6 +2564,7 @@ class Button:
             width: Optional[str] = None,
             visible: Optional[bool] = None,
             tooltip: Optional[str] = None,
+            path: Optional[str] = None,
     ):
         _guard_scalar('Button.name', name, (str,), True, False, False)
         _guard_scalar('Button.label', label, (str,), False, True, False)
@@ -2576,6 +2577,7 @@ class Button:
         _guard_scalar('Button.width', width, (str,), False, True, False)
         _guard_scalar('Button.visible', visible, (bool,), False, True, False)
         _guard_scalar('Button.tooltip', tooltip, (str,), False, True, False)
+        _guard_scalar('Button.path', path, (str,), False, True, False)
         self.name = name
         """An identifying name for this component. If the name is prefixed with a '#', the button sets the location hash to the name when clicked."""
         self.label = label
@@ -2598,6 +2600,8 @@ class Button:
         """True if the component should be visible. Defaults to True."""
         self.tooltip = tooltip
         """An optional tooltip message displayed when a user clicks the help icon to the right of the component."""
+        self.path = path
+        """The path or URL to link to."""
 
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""
@@ -2612,6 +2616,7 @@ class Button:
         _guard_scalar('Button.width', self.width, (str,), False, True, False)
         _guard_scalar('Button.visible', self.visible, (bool,), False, True, False)
         _guard_scalar('Button.tooltip', self.tooltip, (str,), False, True, False)
+        _guard_scalar('Button.path', self.path, (str,), False, True, False)
         return _dump(
             name=self.name,
             label=self.label,
@@ -2624,6 +2629,7 @@ class Button:
             width=self.width,
             visible=self.visible,
             tooltip=self.tooltip,
+            path=self.path,
         )
 
     @staticmethod
@@ -2651,6 +2657,8 @@ class Button:
         _guard_scalar('Button.visible', __d_visible, (bool,), False, True, False)
         __d_tooltip: Any = __d.get('tooltip')
         _guard_scalar('Button.tooltip', __d_tooltip, (str,), False, True, False)
+        __d_path: Any = __d.get('path')
+        _guard_scalar('Button.path', __d_path, (str,), False, True, False)
         name: str = __d_name
         label: Optional[str] = __d_label
         caption: Optional[str] = __d_caption
@@ -2662,6 +2670,7 @@ class Button:
         width: Optional[str] = __d_width
         visible: Optional[bool] = __d_visible
         tooltip: Optional[str] = __d_tooltip
+        path: Optional[str] = __d_path
         return Button(
             name,
             label,
@@ -2674,6 +2683,7 @@ class Button:
             width,
             visible,
             tooltip,
+            path,
         )
 
 

--- a/py/h2o_wave/types.py
+++ b/py/h2o_wave/types.py
@@ -2601,7 +2601,7 @@ class Button:
         self.tooltip = tooltip
         """An optional tooltip message displayed when a user clicks the help icon to the right of the component."""
         self.path = path
-        """The path or URL to link to."""
+        """The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab."""
 
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""

--- a/py/h2o_wave/ui.py
+++ b/py/h2o_wave/ui.py
@@ -988,6 +988,7 @@ def button(
         width: Optional[str] = None,
         visible: Optional[bool] = None,
         tooltip: Optional[str] = None,
+        path: Optional[str] = None,
 ) -> Component:
     """Create a button.
 
@@ -1018,6 +1019,7 @@ def button(
         width: The width of the button, e.g. '100px'.
         visible: True if the component should be visible. Defaults to True.
         tooltip: An optional tooltip message displayed when a user clicks the help icon to the right of the component.
+        path: The path or URL to link to.
     Returns:
         A `h2o_wave.types.Button` instance.
     """
@@ -1033,6 +1035,7 @@ def button(
         width,
         visible,
         tooltip,
+        path,
     ))
 
 

--- a/py/h2o_wave/ui.py
+++ b/py/h2o_wave/ui.py
@@ -1019,7 +1019,7 @@ def button(
         width: The width of the button, e.g. '100px'.
         visible: True if the component should be visible. Defaults to True.
         tooltip: An optional tooltip message displayed when a user clicks the help icon to the right of the component.
-        path: The path or URL to link to.
+        path: The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab.
     Returns:
         A `h2o_wave.types.Button` instance.
     """

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -1186,7 +1186,7 @@ ui_color_picker <- function(
 #' @param width The width of the button, e.g. '100px'.
 #' @param visible True if the component should be visible. Defaults to True.
 #' @param tooltip An optional tooltip message displayed when a user clicks the help icon to the right of the component.
-#' @param path The path or URL to link to.
+#' @param path The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab.
 #' @return A Button instance.
 #' @export
 ui_button <- function(

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -1186,6 +1186,7 @@ ui_color_picker <- function(
 #' @param width The width of the button, e.g. '100px'.
 #' @param visible True if the component should be visible. Defaults to True.
 #' @param tooltip An optional tooltip message displayed when a user clicks the help icon to the right of the component.
+#' @param path The path or URL to link to.
 #' @return A Button instance.
 #' @export
 ui_button <- function(
@@ -1199,7 +1200,8 @@ ui_button <- function(
   icon = NULL,
   width = NULL,
   visible = NULL,
-  tooltip = NULL) {
+  tooltip = NULL,
+  path = NULL) {
   .guard_scalar("name", "character", name)
   .guard_scalar("label", "character", label)
   .guard_scalar("caption", "character", caption)
@@ -1211,6 +1213,7 @@ ui_button <- function(
   .guard_scalar("width", "character", width)
   .guard_scalar("visible", "logical", visible)
   .guard_scalar("tooltip", "character", tooltip)
+  .guard_scalar("path", "character", path)
   .o <- list(button=list(
     name=name,
     label=label,
@@ -1222,7 +1225,8 @@ ui_button <- function(
     icon=icon,
     width=width,
     visible=visible,
-    tooltip=tooltip))
+    tooltip=tooltip,
+    path=path))
   class(.o) <- append(class(.o), c(.wave_obj, "WaveComponent"))
   return(.o)
 }

--- a/tools/intellij-plugin/src/main/resources/templates/wave-components.xml
+++ b/tools/intellij-plugin/src/main/resources/templates/wave-components.xml
@@ -919,7 +919,7 @@
       <option name="Python" value="true"/>
     </context>
   </template>
-  <template name="w_full_button" value="ui.button(name='$name$',label='$label$',caption='$caption$',value='$value$',primary=$primary$,disabled=$disabled$,link=$link$,icon='$icon$',width='$width$',visible=$visible$,tooltip='$tooltip$'),$END$" description="Create Wave Button with full attributes." toReformat="true" toShortenFQNames="true">
+  <template name="w_full_button" value="ui.button(name='$name$',label='$label$',caption='$caption$',value='$value$',primary=$primary$,disabled=$disabled$,link=$link$,icon='$icon$',width='$width$',visible=$visible$,tooltip='$tooltip$',path='$path$'),$END$" description="Create Wave Button with full attributes." toReformat="true" toShortenFQNames="true">
     <variable name="name" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="label" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="caption" expression="" defaultValue="" alwaysStopAt="true"/>
@@ -931,6 +931,7 @@
     <variable name="width" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="visible" expression="" defaultValue="&quot;True&quot;" alwaysStopAt="true"/>
     <variable name="tooltip" expression="" defaultValue="" alwaysStopAt="true"/>
+    <variable name="path" expression="" defaultValue="" alwaysStopAt="true"/>
     <context>
       <option name="Python" value="true"/>
     </context>

--- a/tools/vscode-extension/component-snippets.json
+++ b/tools/vscode-extension/component-snippets.json
@@ -891,7 +891,7 @@
   "Wave Full Button": {
     "prefix": "w_full_button",
     "body": [
-      "ui.button(name='$1', label='$2', caption='$3', value='$4', primary=${5:False}, disabled=${6:False}, link=${7:False}, icon='$8', width='$9', visible=${10:True}, tooltip='$11'),$0"
+      "ui.button(name='$1', label='$2', caption='$3', value='$4', primary=${5:False}, disabled=${6:False}, link=${7:False}, icon='$8', width='$9', visible=${10:True}, tooltip='$11', path='$12'),$0"
     ],
     "description": "Create a full Wave Button."
   },

--- a/ui/src/button.test.tsx
+++ b/ui/src/button.test.tsx
@@ -85,8 +85,7 @@ describe('Button.tsx', () => {
     it('Does redirect if path is specified', () => {
       const
         windowOpenMock = jest.fn(),
-        btnPathProps: Buttons = { items: [{ button: { name, label: name, path: 'https://h2o.ai/' } }] },
-        { getByTestId } = render(<XButtons model={btnPathProps} />)
+        { getByTestId } = render(<XButtons model={{ items: [{ button: { name, label: name, path: 'https://h2o.ai/' } }] }} />)
 
       window.open = windowOpenMock
       fireEvent.click(getByTestId(name))

--- a/ui/src/button.test.tsx
+++ b/ui/src/button.test.tsx
@@ -15,7 +15,6 @@
 import { fireEvent, render } from '@testing-library/react'
 import React from 'react'
 import { Buttons, MiniButtons, XButtons, XMiniButtons } from './button'
-import { Component } from './form'
 import { wave } from './ui'
 
 const
@@ -81,6 +80,17 @@ describe('Button.tsx', () => {
       const { queryByTestId } = render(<XButtons model={btnProps} />)
 
       expect(queryByTestId(name)).not.toHaveClass('ms-Link')
+    })
+
+    it('Does redirect if path is specified', () => {
+      const
+        windowOpenMock = jest.fn(),
+        btnPathProps: Buttons = { items: [{ button: { name, label: name, path: 'https://h2o.ai/' } }] },
+        { getByTestId } = render(<XButtons model={btnPathProps} />)
+
+      window.open = windowOpenMock
+      fireEvent.click(getByTestId(name))
+      expect(windowOpenMock).toHaveBeenCalled()
     })
   })
 

--- a/ui/src/button.tsx
+++ b/ui/src/button.tsx
@@ -62,6 +62,8 @@ export interface Button {
   visible?: B
   /** An optional tooltip message displayed when a user clicks the help icon to the right of the component. */
   tooltip?: S
+  /** The path or URL to link to. */
+  path?: S
 }
 
 /** Create a set of buttons laid out horizontally. */
@@ -112,16 +114,16 @@ const
   }
 
 const
-  XButton = ({ model: { name, visible = true, link, label, disabled, icon, caption, value, primary, width } }: { model: Button }) => {
+  XButton = ({ model: { name, visible = true, link, label, disabled, icon, caption, value, primary, width, path } }: { model: Button }) => {
     const
       onClick = (ev: any) => {
         ev.stopPropagation()
-        if (name.startsWith('#')) {
-          window.location.hash = name.substr(1)
-          return
+        if (path) window.open(path, "_blank")
+        else if (name.startsWith('#')) window.location.hash = name.substr(1)
+        else {
+          wave.args[name] = value === undefined || value
+          wave.push()
         }
-        wave.args[name] = value === undefined || value
-        wave.push()
       },
       // HACK: Our visibility logic in XComponents doesn't count with nested components, e.g. Butttons > Button.
       styles: Fluent.IButtonStyles = {

--- a/ui/src/button.tsx
+++ b/ui/src/button.tsx
@@ -62,7 +62,7 @@ export interface Button {
   visible?: B
   /** An optional tooltip message displayed when a user clicks the help icon to the right of the component. */
   tooltip?: S
-  /** The path or URL to link to. */
+  /** The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab. */
   path?: S
 }
 

--- a/website/widgets/form/button.md
+++ b/website/widgets/form/button.md
@@ -113,3 +113,16 @@ q.page['form'] = ui.form_card(box='1 1 1 1', items=[
     ui.button(name='button', label='Button', disabled=True)
 ])
 ```
+
+## With path
+
+Use a `path` attribute when you want your button to redirect to internal or external hyperlink.
+
+- Internal hyperlinks have paths that begin with a `/` and point to URLs within the Wave UI
+- All other kinds of paths are treated as external hyperlinks (e.g. <https://h2o.ai/>)
+
+```py
+q.page['form'] = ui.form_card(box='1 1 1 1', items=[
+    ui.button(name='external_path_button', label='External', path='https://h2o.ai/')
+])
+```


### PR DESCRIPTION
Adds optional `path` prop to ui.button component:
```ts
export interface Button {
  /** An identifying name for this component. If the name is prefixed with a '#', the button sets the location hash to the name when clicked. */
  name: Id
  /** The text displayed on the button. */
  label?: S
  /** The caption displayed below the label. */
  caption?: S
  /** A value for this button. If a value is set, it is used for the button's submitted instead of a boolean True. */
  value?: S
  /** True if the button should be rendered as the primary button in the set. */
  primary?: B
  /** True if the button should be disabled. */
  disabled?: B
  /** True if the button should be rendered as link text and not a standard button. */
  link?: B
  /** An optional icon to display next to the button label (not applicable for links). */
  icon?: S
  /** The width of the button, e.g. '100px'. */
  width?: S
  /** True if the component should be visible. Defaults to True. */
  visible?: B
  /** An optional tooltip message displayed when a user clicks the help icon to the right of the component. */
  tooltip?: S
  /** The path or URL to link to. */
  path?: S
}
```

Closes #1329
