### PR TITLE
fix: remove scrollbar from stats

### DIFF
--- a/ui/src/stats.tsx
+++ b/ui/src/stats.tsx
@@ -66,7 +66,8 @@ const
       marginRight: '0.5em',
     },
     icon: {
-      fontSize: 45,
+      height: 45,
+      width: 45,
     },
     statCaption: {
       color: cssVar('$text5')
@@ -97,7 +98,7 @@ export const
         <div key={`${i}:${label}`} className={css.stat} style={statStyle}>
           {icon && (
             <div className={css.lhs} style={icon_color ? { color: cssVar(icon_color) } : undefined}>
-              <Icon className={css.icon} iconName={icon} styles={{ root: { '> span': { height: '100%'}}}}/>
+              <Icon className={css.icon} iconName={icon} styles={{ root: { '> span': { height: '100%', width: '100%'}}}}/>
             </div>
           )}
           <div>

--- a/ui/src/stats.tsx
+++ b/ui/src/stats.tsx
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { FontIcon } from '@fluentui/react'
+import { Icon } from '@fluentui/react'
 import { B, Dict, S } from 'h2o-wave'
 import React from 'react'
 import { stylesheet } from 'typestyle'
@@ -97,7 +97,7 @@ export const
         <div key={`${i}:${label}`} className={css.stat} style={statStyle}>
           {icon && (
             <div className={css.lhs} style={icon_color ? { color: cssVar(icon_color) } : undefined}>
-              <FontIcon className={css.icon} iconName={icon} />
+              <Icon className={css.icon} iconName={icon} styles={{ root: { '> span': { height: '100%'}}}}/>
             </div>
           )}
           <div>


### PR DESCRIPTION
Taking into account #795, stats will not overflow horizontally since the label is going to wrap when it's too long.

After removing `overflow-x: auto`:
![image](https://user-images.githubusercontent.com/15820796/166655300-e3f8fe64-ff38-4e89-b760-3dd0113896a0.png)

@mturoci let me know if I'm missing something on this one since you added `overflow-x: auto`.

closes #1376