### PR TITLE
feat: add support to align and justify form card items

### DIFF
--- a/py/examples/form_alignment.py
+++ b/py/examples/form_alignment.py
@@ -1,0 +1,65 @@
+from h2o_wave import main, Q, ui, app
+
+
+@app('/demo')
+async def serve(q: Q):
+
+    q.page['form1'] = ui.form_card(box='1 1 3 3', title='justify start (default)', items=[
+        ui.text_xl(content='Text'),
+        ui.button(name='btn', label='click me')
+    ])
+
+    q.page['form2'] = ui.form_card(box='4 1 3 3', justify='center', items=[
+        ui.text_xl(content='Text'),
+        ui.button(name='btn', label='click me')
+    ])
+
+    q.page['form3'] = ui.form_card(box='7 1 3 3', title='justify end', justify='end', items=[
+        ui.text_xl(content='Text'),
+        ui.button(name='btn', label='click me')
+    ])
+
+    q.page['form4'] = ui.form_card(box='1 4 3 3', title='justify start + align center', align='center', items=[
+        ui.text_xl(content='Text'),
+        ui.button(name='btn', label='click me')
+    ])
+
+    q.page['form5'] = ui.form_card(box='4 4 3 3', title='justify center + align center', justify='center', align='center', items=[
+        ui.text_xl(content='Text'),
+        ui.button(name='btn', label='click me')
+    ])
+
+    q.page['form6'] = ui.form_card(box='7 4 3 3', title='justify end + align center', justify='end', align='center', items=[
+        ui.text_xl(content='Text'),
+        ui.button(name='btn', label='click me')
+    ])
+
+    q.page['form7'] = ui.form_card(box='1 7 3 3', title='justify start + align end', align='end', items=[
+        ui.text_xl(content='Text'),
+        ui.button(name='btn', label='click me')
+    ])
+
+    q.page['form8'] = ui.form_card(box='4 7 3 3', title='justify center + align end', justify='center', align='end', items=[
+        ui.text_xl(content='Text'),
+        ui.button(name='btn', label='click me')
+    ])
+
+    q.page['form9'] = ui.form_card(box='7 7 3 3', title='justify end + align end', justify='end', align='end', items=[
+        ui.text_xl(content='Text'),
+        ui.button(name='btn', label='click me')
+    ])
+
+    q.page['form10'] = ui.form_card(box='1 10 3 3', justify='center', items=[
+        ui.inline(justify='center', items=[
+            ui.text_xl(content='Text'),
+        ]),
+        ui.column(justify='end', items=[
+            ui.inline(justify='around', items=[
+                ui.button(name='btn1', label='click me'),
+                ui.button(name='btn2', label='click me'),
+                ui.button(name='btn3', label='click me'),
+            ]),
+        ]),
+    ])
+
+    await q.page.save()

--- a/py/h2o_wave/types.py
+++ b/py/h2o_wave/types.py
@@ -5867,6 +5867,66 @@ class Inline:
         )
 
 
+_ColumnJustify = ['start', 'end', 'center', 'between', 'around']
+
+
+class ColumnJustify:
+    START = 'start'
+    END = 'end'
+    CENTER = 'center'
+    BETWEEN = 'between'
+    AROUND = 'around'
+
+
+class Column:
+    """Creates a container to lay out components in the vertical.
+    """
+    def __init__(
+            self,
+            items: List['Component'],
+            justify: Optional[str] = None,
+            inset: Optional[bool] = None,
+    ):
+        _guard_vector('Column.items', items, (Component,), False, False, False)
+        _guard_enum('Column.justify', justify, _ColumnJustify, True)
+        _guard_scalar('Column.inset', inset, (bool,), False, True, False)
+        self.items = items
+        """The components laid out inline."""
+        self.justify = justify
+        """Specifies how to lay out the individual components. Defaults to 'start'. One of 'start', 'end', 'center', 'between', 'around'. See enum h2o_wave.ui.ColumnJustify."""
+        self.inset = inset
+        """Whether to display the components inset from the parent form, with a contrasting background."""
+
+    def dump(self) -> Dict:
+        """Returns the contents of this object as a dict."""
+        _guard_vector('Column.items', self.items, (Component,), False, False, False)
+        _guard_enum('Column.justify', self.justify, _ColumnJustify, True)
+        _guard_scalar('Column.inset', self.inset, (bool,), False, True, False)
+        return _dump(
+            items=[__e.dump() for __e in self.items],
+            justify=self.justify,
+            inset=self.inset,
+        )
+
+    @staticmethod
+    def load(__d: Dict) -> 'Column':
+        """Creates an instance of this class using the contents of a dict."""
+        __d_items: Any = __d.get('items')
+        _guard_vector('Column.items', __d_items, (dict,), False, False, False)
+        __d_justify: Any = __d.get('justify')
+        _guard_enum('Column.justify', __d_justify, _ColumnJustify, True)
+        __d_inset: Any = __d.get('inset')
+        _guard_scalar('Column.inset', __d_inset, (bool,), False, True, False)
+        items: List['Component'] = [Component.load(__e) for __e in __d_items]
+        justify: Optional[str] = __d_justify
+        inset: Optional[bool] = __d_inset
+        return Column(
+            items,
+            justify,
+            inset,
+        )
+
+
 class Image:
     """Create an image.
     """
@@ -6480,6 +6540,7 @@ class Component:
             vega_visualization: Optional[VegaVisualization] = None,
             stats: Optional[Stats] = None,
             inline: Optional[Inline] = None,
+            column: Optional[Column] = None,
             image: Optional[Image] = None,
             persona: Optional[Persona] = None,
             text_annotator: Optional[TextAnnotator] = None,
@@ -6529,6 +6590,7 @@ class Component:
         _guard_scalar('Component.vega_visualization', vega_visualization, (VegaVisualization,), False, True, False)
         _guard_scalar('Component.stats', stats, (Stats,), False, True, False)
         _guard_scalar('Component.inline', inline, (Inline,), False, True, False)
+        _guard_scalar('Component.column', column, (Column,), False, True, False)
         _guard_scalar('Component.image', image, (Image,), False, True, False)
         _guard_scalar('Component.persona', persona, (Persona,), False, True, False)
         _guard_scalar('Component.text_annotator', text_annotator, (TextAnnotator,), False, True, False)
@@ -6618,6 +6680,8 @@ class Component:
         """Stats."""
         self.inline = inline
         """Inline components."""
+        self.column = column
+        """Vertical."""
         self.image = image
         """Image"""
         self.persona = persona
@@ -6676,6 +6740,7 @@ class Component:
         _guard_scalar('Component.vega_visualization', self.vega_visualization, (VegaVisualization,), False, True, False)
         _guard_scalar('Component.stats', self.stats, (Stats,), False, True, False)
         _guard_scalar('Component.inline', self.inline, (Inline,), False, True, False)
+        _guard_scalar('Component.column', self.column, (Column,), False, True, False)
         _guard_scalar('Component.image', self.image, (Image,), False, True, False)
         _guard_scalar('Component.persona', self.persona, (Persona,), False, True, False)
         _guard_scalar('Component.text_annotator', self.text_annotator, (TextAnnotator,), False, True, False)
@@ -6725,6 +6790,7 @@ class Component:
             vega_visualization=None if self.vega_visualization is None else self.vega_visualization.dump(),
             stats=None if self.stats is None else self.stats.dump(),
             inline=None if self.inline is None else self.inline.dump(),
+            column=None if self.column is None else self.column.dump(),
             image=None if self.image is None else self.image.dump(),
             persona=None if self.persona is None else self.persona.dump(),
             text_annotator=None if self.text_annotator is None else self.text_annotator.dump(),
@@ -6819,6 +6885,8 @@ class Component:
         _guard_scalar('Component.stats', __d_stats, (dict,), False, True, False)
         __d_inline: Any = __d.get('inline')
         _guard_scalar('Component.inline', __d_inline, (dict,), False, True, False)
+        __d_column: Any = __d.get('column')
+        _guard_scalar('Component.column', __d_column, (dict,), False, True, False)
         __d_image: Any = __d.get('image')
         _guard_scalar('Component.image', __d_image, (dict,), False, True, False)
         __d_persona: Any = __d.get('persona')
@@ -6874,6 +6942,7 @@ class Component:
         vega_visualization: Optional[VegaVisualization] = None if __d_vega_visualization is None else VegaVisualization.load(__d_vega_visualization)
         stats: Optional[Stats] = None if __d_stats is None else Stats.load(__d_stats)
         inline: Optional[Inline] = None if __d_inline is None else Inline.load(__d_inline)
+        column: Optional[Column] = None if __d_column is None else Column.load(__d_column)
         image: Optional[Image] = None if __d_image is None else Image.load(__d_image)
         persona: Optional[Persona] = None if __d_persona is None else Persona.load(__d_persona)
         text_annotator: Optional[TextAnnotator] = None if __d_text_annotator is None else TextAnnotator.load(__d_text_annotator)
@@ -6923,6 +6992,7 @@ class Component:
             vega_visualization,
             stats,
             inline,
+            column,
             image,
             persona,
             text_annotator,
@@ -7518,6 +7588,25 @@ class FooterCard:
         )
 
 
+_FormCardJustify = ['start', 'center', 'end', 'around']
+
+
+class FormCardJustify:
+    START = 'start'
+    CENTER = 'center'
+    END = 'end'
+    AROUND = 'around'
+
+
+_FormCardAlign = ['start', 'center', 'end']
+
+
+class FormCardAlign:
+    START = 'start'
+    CENTER = 'center'
+    END = 'end'
+
+
 class FormCard:
     """Create a form.
     """
@@ -7526,11 +7615,15 @@ class FormCard:
             box: str,
             items: Union[List[Component], str],
             title: Optional[str] = None,
+            justify: Optional[str] = None,
+            align: Optional[str] = None,
             commands: Optional[List[Command]] = None,
     ):
         _guard_scalar('FormCard.box', box, (str,), False, False, False)
         _guard_vector('FormCard.items', items, (Component,), False, False, True)
         _guard_scalar('FormCard.title', title, (str,), False, True, False)
+        _guard_enum('FormCard.justify', justify, _FormCardJustify, True)
+        _guard_enum('FormCard.align', align, _FormCardAlign, True)
         _guard_vector('FormCard.commands', commands, (Command,), False, True, False)
         self.box = box
         """A string indicating how to place this component on the page."""
@@ -7538,6 +7631,10 @@ class FormCard:
         """The components in this form."""
         self.title = title
         """The title for this card."""
+        self.justify = justify
+        """Defines the alignment along the horizontal axis. One of 'start', 'center', 'end', 'around'. See enum h2o_wave.ui.FormCardJustify."""
+        self.align = align
+        """Defines the alignment along the vertical axis. One of 'start', 'center', 'end'. See enum h2o_wave.ui.FormCardAlign."""
         self.commands = commands
         """Contextual menu commands for this component."""
 
@@ -7546,12 +7643,16 @@ class FormCard:
         _guard_scalar('FormCard.box', self.box, (str,), False, False, False)
         _guard_vector('FormCard.items', self.items, (Component,), False, False, True)
         _guard_scalar('FormCard.title', self.title, (str,), False, True, False)
+        _guard_enum('FormCard.justify', self.justify, _FormCardJustify, True)
+        _guard_enum('FormCard.align', self.align, _FormCardAlign, True)
         _guard_vector('FormCard.commands', self.commands, (Command,), False, True, False)
         return _dump(
             view='form',
             box=self.box,
             items=self.items if isinstance(self.items, str) else [__e.dump() for __e in self.items],
             title=self.title,
+            justify=self.justify,
+            align=self.align,
             commands=None if self.commands is None else [__e.dump() for __e in self.commands],
         )
 
@@ -7564,16 +7665,24 @@ class FormCard:
         _guard_vector('FormCard.items', __d_items, (dict,), False, False, True)
         __d_title: Any = __d.get('title')
         _guard_scalar('FormCard.title', __d_title, (str,), False, True, False)
+        __d_justify: Any = __d.get('justify')
+        _guard_enum('FormCard.justify', __d_justify, _FormCardJustify, True)
+        __d_align: Any = __d.get('align')
+        _guard_enum('FormCard.align', __d_align, _FormCardAlign, True)
         __d_commands: Any = __d.get('commands')
         _guard_vector('FormCard.commands', __d_commands, (dict,), False, True, False)
         box: str = __d_box
         items: Union[List[Component], str] = __d_items if isinstance(__d_items, str) else [Component.load(__e) for __e in __d_items]
         title: Optional[str] = __d_title
+        justify: Optional[str] = __d_justify
+        align: Optional[str] = __d_align
         commands: Optional[List[Command]] = None if __d_commands is None else [Command.load(__e) for __e in __d_commands]
         return FormCard(
             box,
             items,
             title,
+            justify,
+            align,
             commands,
         )
 

--- a/py/h2o_wave/ui.py
+++ b/py/h2o_wave/ui.py
@@ -2184,6 +2184,27 @@ def inline(
     ))
 
 
+def column(
+        items: List[Component],
+        justify: Optional[str] = None,
+        inset: Optional[bool] = None,
+) -> Component:
+    """Creates a container to lay out components in the vertical.
+
+    Args:
+        items: The components laid out inline.
+        justify: Specifies how to lay out the individual components. Defaults to 'start'. One of 'start', 'end', 'center', 'between', 'around'. See enum h2o_wave.ui.ColumnJustify.
+        inset: Whether to display the components inset from the parent form, with a contrasting background.
+    Returns:
+        A `h2o_wave.types.Column` instance.
+    """
+    return Component(column=Column(
+        items,
+        justify,
+        inset,
+    ))
+
+
 def image(
         title: str,
         type: Optional[str] = None,
@@ -2640,6 +2661,8 @@ def form_card(
         box: str,
         items: Union[List[Component], str],
         title: Optional[str] = None,
+        justify: Optional[str] = None,
+        align: Optional[str] = None,
         commands: Optional[List[Command]] = None,
 ) -> FormCard:
     """Create a form.
@@ -2648,6 +2671,8 @@ def form_card(
         box: A string indicating how to place this component on the page.
         items: The components in this form.
         title: The title for this card.
+        justify: Defines the alignment along the horizontal axis. One of 'start', 'center', 'end', 'around'. See enum h2o_wave.ui.FormCardJustify.
+        align: Defines the alignment along the vertical axis. One of 'start', 'center', 'end'. See enum h2o_wave.ui.FormCardAlign.
         commands: Contextual menu commands for this component.
     Returns:
         A `h2o_wave.types.FormCard` instance.
@@ -2656,6 +2681,8 @@ def form_card(
         box,
         items,
         title,
+        justify,
+        align,
         commands,
     )
 

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -2558,6 +2558,29 @@ ui_inline <- function(
   return(.o)
 }
 
+#' Creates a container to lay out components in the vertical.
+#'
+#' @param items The components laid out inline.
+#' @param justify Specifies how to lay out the individual components. Defaults to 'start'.
+#'   One of 'start', 'end', 'center', 'between', 'around'. See enum h2o_wave.ui.ColumnJustify.
+#' @param inset Whether to display the components inset from the parent form, with a contrasting background.
+#' @return A Column instance.
+#' @export
+ui_column <- function(
+  items,
+  justify = NULL,
+  inset = NULL) {
+  .guard_vector("items", "WaveComponent", items)
+  # TODO Validate justify
+  .guard_scalar("inset", "logical", inset)
+  .o <- list(column=list(
+    items=items,
+    justify=justify,
+    inset=inset))
+  class(.o) <- append(class(.o), c(.wave_obj, "WaveComponent"))
+  return(.o)
+}
+
 #' Create an image.
 #'
 #' @param title The image title, typically displayed as a tooltip.
@@ -3062,6 +3085,10 @@ ui_footer_card <- function(
 #' @param box A string indicating how to place this component on the page.
 #' @param items The components in this form.
 #' @param title The title for this card.
+#' @param justify Defines the alignment along the horizontal axis.
+#'   One of 'start', 'center', 'end', 'around'. See enum h2o_wave.ui.FormCardJustify.
+#' @param align Defines the alignment along the vertical axis.
+#'   One of 'start', 'center', 'end'. See enum h2o_wave.ui.FormCardAlign.
 #' @param commands Contextual menu commands for this component.
 #' @return A FormCard instance.
 #' @export
@@ -3069,15 +3096,21 @@ ui_form_card <- function(
   box,
   items,
   title = NULL,
+  justify = NULL,
+  align = NULL,
   commands = NULL) {
   .guard_scalar("box", "character", box)
   .guard_vector("items", "WaveComponent", items)
   .guard_scalar("title", "character", title)
+  # TODO Validate justify
+  # TODO Validate align
   .guard_vector("commands", "WaveCommand", commands)
   .o <- list(
     box=box,
     items=items,
     title=title,
+    justify=justify,
+    align=align,
     commands=commands)
   class(.o) <- append(class(.o), c(.wave_obj, "WaveFormCard"))
   return(.o)

--- a/tools/intellij-plugin/src/main/resources/templates/wave-components.xml
+++ b/tools/intellij-plugin/src/main/resources/templates/wave-components.xml
@@ -172,6 +172,12 @@
       <option name="Python" value="true"/>
     </context>
   </template>
+  <template name="w_column" value="ui.column(items=[&#10;	$items$	&#10;]),$END$" description="Create a minimal Wave Column." toReformat="true" toShortenFQNames="true">
+    <variable name="items" expression="" defaultValue="" alwaysStopAt="true"/>
+    <context>
+      <option name="Python" value="true"/>
+    </context>
+  </template>
   <template name="w_form_card" value="ui.form_card(box='$box$',items=[&#10;	$items$	&#10;])$END$" description="Create a minimal Wave FormCard." toReformat="true" toShortenFQNames="true">
     <variable name="box" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="items" expression="" defaultValue="" alwaysStopAt="true"/>
@@ -1195,7 +1201,7 @@
       <option name="Python" value="true"/>
     </context>
   </template>
-  <template name="w_full_component" value="ui.component(text=$text$,text_xl=$text_xl$,text_l=$text_l$,text_m=$text_m$,text_s=$text_s$,text_xs=$text_xs$,label=$label$,separator=$separator$,progress=$progress$,message_bar=$message_bar$,textbox=$textbox$,checkbox=$checkbox$,toggle=$toggle$,choice_group=$choice_group$,checklist=$checklist$,dropdown=$dropdown$,combobox=$combobox$,slider=$slider$,spinbox=$spinbox$,date_picker=$date_picker$,color_picker=$color_picker$,button=$button$,buttons=$buttons$,mini_button=$mini_button$,mini_buttons=$mini_buttons$,file_upload=$file_upload$,table=$table$,link=$link$,links=$links$,tabs=$tabs$,expander=$expander$,frame=$frame$,markup=$markup$,template=$template$,picker=$picker$,range_slider=$range_slider$,stepper=$stepper$,visualization=$visualization$,vega_visualization=$vega_visualization$,stats=$stats$,inline=$inline$,image=$image$,persona=$persona$,text_annotator=$text_annotator$,facepile=$facepile$,copyable_text=$copyable_text$,menu=$menu$,tags=$tags$),$END$" description="Create Wave Component with full attributes." toReformat="true" toShortenFQNames="true">
+  <template name="w_full_component" value="ui.component(text=$text$,text_xl=$text_xl$,text_l=$text_l$,text_m=$text_m$,text_s=$text_s$,text_xs=$text_xs$,label=$label$,separator=$separator$,progress=$progress$,message_bar=$message_bar$,textbox=$textbox$,checkbox=$checkbox$,toggle=$toggle$,choice_group=$choice_group$,checklist=$checklist$,dropdown=$dropdown$,combobox=$combobox$,slider=$slider$,spinbox=$spinbox$,date_picker=$date_picker$,color_picker=$color_picker$,button=$button$,buttons=$buttons$,mini_button=$mini_button$,mini_buttons=$mini_buttons$,file_upload=$file_upload$,table=$table$,link=$link$,links=$links$,tabs=$tabs$,expander=$expander$,frame=$frame$,markup=$markup$,template=$template$,picker=$picker$,range_slider=$range_slider$,stepper=$stepper$,visualization=$visualization$,vega_visualization=$vega_visualization$,stats=$stats$,inline=$inline$,column=$column$,image=$image$,persona=$persona$,text_annotator=$text_annotator$,facepile=$facepile$,copyable_text=$copyable_text$,menu=$menu$,tags=$tags$),$END$" description="Create Wave Component with full attributes." toReformat="true" toShortenFQNames="true">
     <variable name="text" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="text_xl" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="text_l" expression="" defaultValue="" alwaysStopAt="true"/>
@@ -1237,6 +1243,7 @@
     <variable name="vega_visualization" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="stats" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="inline" expression="" defaultValue="" alwaysStopAt="true"/>
+    <variable name="column" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="image" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="persona" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="text_annotator" expression="" defaultValue="" alwaysStopAt="true"/>
@@ -1256,9 +1263,19 @@
       <option name="Python" value="true"/>
     </context>
   </template>
-  <template name="w_full_form_card" value="ui.form_card(box='$box$',title='$title$',items=[&#10;	$items$	&#10;],commands=[&#10;	$commands$	&#10;])$END$" description="Create Wave FormCard with full attributes." toReformat="true" toShortenFQNames="true">
+  <template name="w_full_column" value="ui.column(justify='$justify$',inset=$inset$,items=[&#10;	$items$	&#10;]),$END$" description="Create Wave Column with full attributes." toReformat="true" toShortenFQNames="true">
+    <variable name="justify" expression="" defaultValue="&quot;start&quot;" alwaysStopAt="true"/>
+    <variable name="inset" expression="" defaultValue="&quot;False&quot;" alwaysStopAt="true"/>
+    <variable name="items" expression="" defaultValue="" alwaysStopAt="true"/>
+    <context>
+      <option name="Python" value="true"/>
+    </context>
+  </template>
+  <template name="w_full_form_card" value="ui.form_card(box='$box$',title='$title$',justify='$justify$',align='$align$',items=[&#10;	$items$	&#10;],commands=[&#10;	$commands$	&#10;])$END$" description="Create Wave FormCard with full attributes." toReformat="true" toShortenFQNames="true">
     <variable name="box" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="title" expression="" defaultValue="" alwaysStopAt="true"/>
+    <variable name="justify" expression="" defaultValue="" alwaysStopAt="true"/>
+    <variable name="align" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="items" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="commands" expression="" defaultValue="" alwaysStopAt="true"/>
     <context>

--- a/tools/vscode-extension/component-snippets.json
+++ b/tools/vscode-extension/component-snippets.json
@@ -181,6 +181,13 @@
     ],
     "description": "Create a minimal Wave Inline."
   },
+  "Wave Column": {
+    "prefix": "w_column",
+    "body": [
+      "ui.column(items=[\n\t\t$1\t\t\n]),$0"
+    ],
+    "description": "Create a minimal Wave Column."
+  },
   "Wave FormCard": {
     "prefix": "w_form_card",
     "body": [
@@ -1052,7 +1059,7 @@
   "Wave Full Component": {
     "prefix": "w_full_component",
     "body": [
-      "ui.component(text=$1, text_xl=$2, text_l=$3, text_m=$4, text_s=$5, text_xs=$6, label=$7, separator=$8, progress=$9, message_bar=$10, textbox=$11, checkbox=$12, toggle=$13, choice_group=$14, checklist=$15, dropdown=$16, combobox=$17, slider=$18, spinbox=$19, date_picker=$20, color_picker=$21, button=$22, buttons=$23, mini_button=$24, mini_buttons=$25, file_upload=$26, table=$27, link=$28, links=$29, tabs=$30, expander=$31, frame=$32, markup=$33, template=$34, picker=$35, range_slider=$36, stepper=$37, visualization=$38, vega_visualization=$39, stats=$40, inline=$41, image=$42, persona=$43, text_annotator=$44, facepile=$45, copyable_text=$46, menu=$47, tags=$48),$0"
+      "ui.component(text=$1, text_xl=$2, text_l=$3, text_m=$4, text_s=$5, text_xs=$6, label=$7, separator=$8, progress=$9, message_bar=$10, textbox=$11, checkbox=$12, toggle=$13, choice_group=$14, checklist=$15, dropdown=$16, combobox=$17, slider=$18, spinbox=$19, date_picker=$20, color_picker=$21, button=$22, buttons=$23, mini_button=$24, mini_buttons=$25, file_upload=$26, table=$27, link=$28, links=$29, tabs=$30, expander=$31, frame=$32, markup=$33, template=$34, picker=$35, range_slider=$36, stepper=$37, visualization=$38, vega_visualization=$39, stats=$40, inline=$41, column=$42, image=$43, persona=$44, text_annotator=$45, facepile=$46, copyable_text=$47, menu=$48, tags=$49),$0"
     ],
     "description": "Create a full Wave Component."
   },
@@ -1063,10 +1070,17 @@
     ],
     "description": "Create a full Wave Inline."
   },
+  "Wave Full Column": {
+    "prefix": "w_full_column",
+    "body": [
+      "ui.column(justify='${1:start'}', inset=${2:False}, items=[\n\t\t$3\t\t\n]),$0"
+    ],
+    "description": "Create a full Wave Column."
+  },
   "Wave Full FormCard": {
     "prefix": "w_full_form_card",
     "body": [
-      "ui.form_card(box='$1', title='$2', items=[\n\t\t$3\t\t\n], commands=[\n\t\t$4\t\t\n])$0"
+      "ui.form_card(box='$1', title='$2', justify='$3', align='$4', items=[\n\t\t$5\t\t\n], commands=[\n\t\t$6\t\t\n])$0"
     ],
     "description": "Create a full Wave FormCard."
   },


### PR DESCRIPTION
This PR adds a new container `Column` that allows wave app developers lay out components vertically within a form.

Same interface as `Inline`. I suppose we have to keep it in order to generate the types in python.
```ts
/** Creates a container to lay out components along the vertical axis. */
interface Column {
  /** The components laid out inline. */
  items: Component[]
  /** Specifies how to lay out the individual components. Defaults to 'start'. */
  justify?: 'start' | 'end' | 'center' | 'between' | 'around'
  /** Whether to display the components inset from the parent form, with a contrasting background. */
  inset?: B
}
```

Also, it adds support to position / align all components (in the flexbox model `justify-content` and `align-items`) using the new parameters `justify` (horizontally) and `align` (vertically).

```ts
/** Create a form. */
interface State {
  ...
  /** Justify all components along the horizontal axis. */
  justify?: 'start' | 'center' | 'end' | 'around'
  /** Defines the alignment along the vertical axis. */
  align?: 'start' | 'center' | 'end'
}
```

## Example
The first 9 cards show the usage of `justify` and `align` for the whole form card and the last one using the `Column` component.
![image](https://user-images.githubusercontent.com/15820796/167139656-8f0467c5-70d5-4253-bc2c-dae126a9e389.png)

Question: Can we deprecate `ui.inline` in favor of `ui.row`? It would make more sense if we introduce `ui.column`?

The code needs some refinements but I would like to validate this approach before proceeding with docs and examples.

closes #556