### PR TITLE
Fix: Textbox's scrollbar and text overflow when height is set

### DIFF
--- a/ui/src/textbox.tsx
+++ b/ui/src/textbox.tsx
@@ -100,7 +100,7 @@ export const
           styles={m.multiline && m.height
             ? {
               field: { height: m.height },
-              fieldGroup: { border: 'none', borderRadius: 0, outline: '1px solid' }
+              fieldGroup: { minHeight: m.height }
             }
             : undefined}
           label={m.label}

--- a/ui/src/textbox.tsx
+++ b/ui/src/textbox.tsx
@@ -97,7 +97,12 @@ export const
       : (
         <Fluent.TextField
           data-test={m.name}
-          styles={m.multiline && m.height ? { fieldGroup: { height: m.height } } : undefined}
+          styles={m.multiline && m.height
+            ? {
+              field: { height: m.height },
+              fieldGroup: { border: 'none', borderRadius: 0, outline: '1px solid' }
+            }
+            : undefined}
           label={m.label}
           placeholder={m.placeholder}
           iconProps={{ iconName: m.icon }}

--- a/ui/src/textbox.tsx
+++ b/ui/src/textbox.tsx
@@ -97,12 +97,7 @@ export const
       : (
         <Fluent.TextField
           data-test={m.name}
-          styles={m.multiline && m.height
-            ? {
-              field: { height: m.height },
-              fieldGroup: { minHeight: m.height }
-            }
-            : undefined}
+          styles={m.multiline && m.height ? { field: { height: m.height }, fieldGroup: { minHeight: m.height } } : undefined}
           label={m.label}
           placeholder={m.placeholder}
           iconProps={{ iconName: m.icon }}


### PR DESCRIPTION
Fixes [textbox overflow issue](https://github.com/h2oai/wave/issues/1385) when height is set for multiline **ui.textbox**.

Closes #1385 