### PR TITLE
Fix annotator selection misses characters issue

### DIFF
--- a/ui/src/text_annotator.tsx
+++ b/ui/src/text_annotator.tsx
@@ -140,9 +140,9 @@ export
       }, new Map<S, S>()),
       [tokens, setTokens] = React.useState(model.items.reduce((arr, { text, tag }) => {
         // Split by any non-letter character.
-        text.split(/(?=[^A-Za-z])/g).forEach(textItem => {
-          if (textItem.startsWith(' ')) {
-            arr.push({ text: ' ', tag })
+        text.split(/(?=[^a-z])/ig).forEach(textItem => {
+          if (/[^a-z]/i.test(textItem)) {
+            arr.push({ text: textItem.substring(0, 1), tag })
             arr.push({ text: textItem.substring(1), tag })
           } else {
             arr.push({ text: textItem, tag })


### PR DESCRIPTION
Fixes unintentional highlighting of non-alphabetical characters preceding the word when annotating the word.


https://user-images.githubusercontent.com/23740173/169311346-18a6f529-e7cf-4b10-8bb4-b2f187865370.mov


Closes #1432 