### PR TITLE
feat: Text annotator should handle unknown tags

### DIFF
--- a/ui/src/text_annotator.tsx
+++ b/ui/src/text_annotator.tsx
@@ -207,8 +207,10 @@ export
         return false
       },
       getMark = (text: S, idx: U, tag: S) => {
+        const color = tagColorMap.get(tag)
+        // Handle invalid tags entered by user
+        if (!color) return text
         const
-          color = tagColorMap.get(tag)!,
           removeIconStyle = { visibility: shouldShowRemoveIcon(idx, tag) ? 'visible' : 'hidden' },
           isFirst = tokens[idx - 1]?.tag !== tag,
           isLast = tokens[idx + 1]?.tag !== tag


### PR DESCRIPTION
Prevents blank screen and console errors when invalid tag is entered by user.

Example:
```py
ui.text_annotator(
    name='annotator',
    title='Select text to annotate',
    tags=[
        ui.text_annotator_tag(name='p', label='Person', color='#F1CBCB'),
        ui.text_annotator_tag(name='o', label='Org', color='#CAEACA'),
    ],
    items=[
        ui.text_annotator_item(text='Killer Mike', tag='p'),
        ui.text_annotator_item(text=' is a member, of the hip hop supergroup '),  # no tag
        ui.text_annotator_item(text='Run the Jewels', tag='x'),
    ],
),
```
The above example looks like this:
<img width="528" alt="image" src="https://user-images.githubusercontent.com/23740173/169317273-d548e070-2683-493d-8a15-41a2ff27b442.png">

The `x` tag is invalid and therefore is ignored. However when user submits the form, the tag is present there.
<img width="507" alt="image" src="https://user-images.githubusercontent.com/23740173/169317648-80a43c1f-2368-4795-a839-3121423cad4b.png">


Closes #1427 