### PR TITLE
✨ feat: add oidc-post-logout-redirect-url config options

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -414,7 +414,8 @@ func (h *LogoutHandler) redirect(w http.ResponseWriter, r *http.Request, idToken
 	}
 
 	query := redirectURL.Query()
-	query.Set("post_logout_redirect_uri", r.Host)
+	// Use server config option instead of r.Host
+	query.Set("post_logout_redirect_uri", h.auth.conf.PostLogoutRedirectURL)
 	if len(idToken) > 0 {
 		// required by Okta
 		// https://developer.okta.com/docs/reference/api/oidc/#logout

--- a/cmd/wave/main.go
+++ b/cmd/wave/main.go
@@ -111,6 +111,8 @@ func main() {
 	stringVar(&auth.ProviderURL, "oidc-provider-url", "", "OIDC provider URL")
 	stringVar(&auth.RedirectURL, "oidc-redirect-url", "", "OIDC redirect URL")
 	stringVar(&auth.EndSessionURL, "oidc-end-session-url", "", "OIDC end session URL")
+	// add post logout redirect url option, work with Keycloak
+	stringVar(&auth.PostLogoutRedirectURL, "oidc-post-logout-redirect-url", "", "OIDC post logout redirect URL")
 	stringVar(&rawAuthScopes, "oidc-scopes", "", "OIDC scopes, comma-separated (default \"openid,profile\")")
 	stringVar(&rawAuthURLParams, "oidc-auth-url-params", "", "additional URL parameters to pass during OIDC authorization, in the format \"key:value\", comma-separated, e.g. \"foo:bar,qux:42\"")
 	boolVar(&auth.SkipLogin, "oidc-skip-login", false, "do not display the login form during OIDC authorization")

--- a/conf.go
+++ b/conf.go
@@ -68,6 +68,7 @@ type AuthConf struct {
 	ProviderURL   string
 	RedirectURL   string
 	EndSessionURL string
+	PostLogoutRedirectURL string
 	Scopes        []string
 	URLParameters [][]string
 	SkipLogin     bool


### PR DESCRIPTION
fix/feature: see https://github.com/h2oai/wave/issues/1448 for detailed information

add oidc-post-logout-redirect-url (server param) and H2O_WAVE_OIDC_POST_LOGOUT_REDIRECT_URL (env var) server config options for the highest flexibility

tested with Keycloak 10.0.2

original discussion: https://github.com/h2oai/wave/discussions/1439