### PR TITLE
feat: add oidc-post-logout-redirect-url config options

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -433,6 +433,8 @@ func (h *LogoutHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *LogoutHandler) redirect(w http.ResponseWriter, r *http.Request, idToken string) {
+	var post_logout_redirect_url string
+
 	if h.auth.conf.EndSessionURL == "" {
 		http.Redirect(w, r, h.auth.baseURL, http.StatusFound)
 		return
@@ -444,8 +446,12 @@ func (h *LogoutHandler) redirect(w http.ResponseWriter, r *http.Request, idToken
 		return
 	}
 
+	post_logout_redirect_url = h.auth.conf.PostLogoutRedirectURL
+	if len(post_logout_redirect_url) == 0 {
+		post_logout_redirect_url = r.Host
+	}
 	query := redirectURL.Query()
-	query.Set("post_logout_redirect_uri", r.Host)
+	query.Set("post_logout_redirect_uri", post_logout_redirect_url)
 	if len(idToken) > 0 {
 		// required by Okta
 		// https://developer.okta.com/docs/reference/api/oidc/#logout

--- a/auth.go
+++ b/auth.go
@@ -433,8 +433,6 @@ func (h *LogoutHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *LogoutHandler) redirect(w http.ResponseWriter, r *http.Request, idToken string) {
-	var post_logout_redirect_url string
-
 	if h.auth.conf.EndSessionURL == "" {
 		http.Redirect(w, r, h.auth.baseURL, http.StatusFound)
 		return
@@ -446,8 +444,8 @@ func (h *LogoutHandler) redirect(w http.ResponseWriter, r *http.Request, idToken
 		return
 	}
 
-	post_logout_redirect_url = h.auth.conf.PostLogoutRedirectURL
-	if len(post_logout_redirect_url) == 0 {
+	post_logout_redirect_url := h.auth.conf.PostLogoutRedirectURL
+	if post_logout_redirect_url != "" {
 		post_logout_redirect_url = r.Host
 	}
 	query := redirectURL.Query()

--- a/cmd/wave/main.go
+++ b/cmd/wave/main.go
@@ -116,6 +116,7 @@ func main() {
 	stringVar(&auth.ProviderURL, "oidc-provider-url", "", "OIDC provider URL")
 	stringVar(&auth.RedirectURL, "oidc-redirect-url", "", "OIDC redirect URL")
 	stringVar(&auth.EndSessionURL, "oidc-end-session-url", "", "OIDC end session URL")
+	stringVar(&auth.PostLogoutRedirectURL, "oidc-post-logout-redirect-url", "", "OIDC post logout redirect URL")
 	stringVar(&rawAuthScopes, "oidc-scopes", "", "OIDC scopes, comma-separated (default \"openid,profile\")")
 	stringVar(&rawAuthURLParams, "oidc-auth-url-params", "", "additional URL parameters to pass during OIDC authorization, in the format \"key:value\", comma-separated, e.g. \"foo:bar,qux:42\"")
 	boolVar(&auth.SkipLogin, "oidc-skip-login", false, "do not display the login form during OIDC authorization")

--- a/conf.go
+++ b/conf.go
@@ -69,6 +69,7 @@ type AuthConf struct {
 	ProviderURL       string
 	RedirectURL       string
 	EndSessionURL     string
+	PostLogoutRedirectURL string	
 	Scopes            []string
 	URLParameters     [][]string
 	SkipLogin         bool

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -61,6 +61,8 @@ Usage of ./waved:
         OIDC provider URL
   -oidc-redirect-url string
         OIDC redirect URL
+  -oidc-post-logout-redirect-url string
+        OIDC post logout redirect URL
   -oidc-scopes
         OIDC scopes separated by comma (default "openid,profile")
   -oidc-skip-login
@@ -114,6 +116,7 @@ H2O_WAVE_OIDC_CLIENT_SECRET
 H2O_WAVE_OIDC_END_SESSION_URL
 H2O_WAVE_OIDC_PROVIDER_URL
 H2O_WAVE_OIDC_REDIRECT_URL
+H2O_WAVE_OIDC_POST_LOGOUT_REDIRECT_URL
 H2O_WAVE_OIDC_SCOPES
 H2O_WAVE_OIDC_SKIP_LOGIN [1]
 H2O_WAVE_SESSION_EXPIRY


### PR DESCRIPTION
use the value of oidc-post-logout-redirect-url if set, otherwise follow the previous behavior.

fix/feature: see https://github.com/h2oai/wave/issues/1448 for detailed information

add oidc-post-logout-redirect-url (server param) and H2O_WAVE_OIDC_POST_LOGOUT_REDIRECT_URL (env var) server config options for the highest flexibility

tested with Keycloak 10.0.2

original discussion: https://github.com/h2oai/wave/discussions/1439

Closes #1448 