### PR TITLE
Fix: Font changed to Fluent UI default when changing the theme

### DIFF
--- a/ui/src/theme.ts
+++ b/ui/src/theme.ts
@@ -622,7 +622,7 @@ const
     // HACK: Execute as microtask to prevent race condition. Since meta is handled in page.tsx:render,
     // Fluent wants to update all components present (Spinner), but throws warning it cannot update unmounted element (Spinner)
     // because it is replaced by our new component tree in the meanwhile.
-    setTimeout(() => Fluent.loadTheme({ palette: fluentPalette }), 0)
+    setTimeout(() => Fluent.loadTheme({ palette: fluentPalette, defaultFontStyle: { fontFamily: 'Inter' } }), 0)
   }
 
 export const


### PR DESCRIPTION
In our `ui/src/index.tsx` we are setting the `defaultFontStyle: { fontFamily: 'Inter' }`, but this was not the case when changing the theme.

This PR fixes the issue when changing the Wave meta theme changed the font to Fluent default `Segoe UI`.

https://user-images.githubusercontent.com/23740173/172250845-7d62740b-62b5-46bd-8a81-fbde67490873.mov


