### PR TITLE
feat: Add explicit refresh token callable. #1230

### DIFF
--- a/app.go
+++ b/app.go
@@ -86,6 +86,7 @@ func (app *App) send(clientID string, session *Session, data []byte) error {
 	if session.subject != anon {
 		req.Header.Set("Wave-Access-Token", session.token.AccessToken)
 		req.Header.Set("Wave-Refresh-Token", session.token.RefreshToken)
+		req.Header.Set("Wave-Session-ID", session.id)
 	}
 
 	resp, err := app.client.Do(req)

--- a/auth.go
+++ b/auth.go
@@ -494,6 +494,8 @@ func (h *RefreshHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	session.token = token
+	h.auth.set(session)
+
 	w.WriteHeader(http.StatusOK)
 	w.Header().Set("Wave-Access-Token", token.AccessToken)
 	w.Header().Set("Wave-Refresh-Token", token.RefreshToken)

--- a/auth.go
+++ b/auth.go
@@ -489,7 +489,7 @@ func (h *RefreshHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		// Purge session and reload clients if refresh not successful?
 		echo(Log{"t": "refresh_session", "error": err.Error()})
-		http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
 

--- a/auth.go
+++ b/auth.go
@@ -487,6 +487,7 @@ func (h *RefreshHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	token, err := h.auth.ensureValidOAuth2Token(r.Context(), session.token)
 	if err != nil {
+		// Purge session and reload clients if refresh not successful?
 		echo(Log{"t": "refresh_session", "error": err.Error()})
 		http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 		return

--- a/py/examples/wizard.py
+++ b/py/examples/wizard.py
@@ -1,12 +1,60 @@
-from h2o_wave import main, app, Q, ui
+# Wizard
+# Create a multi-step #wizard using #form cards.
+# ---
+from h2o_wave import Q, ui, main, app, cypress, Cypress
 
 
-@app('/')
+@app('/demo')
 async def serve(q: Q):
-    print(f'Access: \n{q.auth.access_token}')
-    print(f'Refresh: \n{q.auth.refresh_token}')
-    await q.sleep(70)
-    await q.auth.force_token_refresh()
-    print(f'Access: \n{q.auth.access_token}')
-    print(f'Refresh: \n{q.auth.refresh_token}')
+    if not q.client.initialized:  # First visit, create an empty form card for our wizard
+        q.page['wizard'] = ui.form_card(box='1 1 2 4', items=[])
+        q.client.initialized = True
+
+    wizard = q.page['wizard']  # Get a reference to the wizard form
+    if q.args.step1:
+        wizard.items = [
+            ui.text_xl('Wizard - Step 1'),
+            ui.text('What is your name?', name='text'),
+            ui.textbox(name='nickname', label='My name is...', value='Gandalf'),
+            ui.buttons([ui.button(name='step2', label='Next', primary=True)]),
+        ]
+    elif q.args.step2:
+        q.client.nickname = q.args.nickname
+        wizard.items = [
+            ui.text_xl('Wizard - Step 2'),
+            ui.text(f'Hi {q.args.nickname}! How do you feel right now?', name='text'),
+            ui.textbox(name='feeling', label='I feel...', value='magical'),
+            ui.buttons([ui.button(name='step3', label='Next', primary=True)]),
+        ]
+    elif q.args.step3:
+        wizard.items = [
+            ui.text_xl('Wizard - Done'),
+            ui.text(
+                f'What a coincidence, {q.client.nickname}! I feel {q.args.feeling} too!',
+                name='text',
+            ),
+            ui.buttons([ui.button(name='step1', label='Try Again', primary=True)]),
+        ]
+    else:
+        wizard.items = [
+            ui.text_xl('Wizard Example'),
+            ui.text("Let's have a conversation, shall we?"),
+            ui.buttons([ui.button(name='step1', label='Of course!', primary=True)]),
+        ]
+
     await q.page.save()
+
+
+@cypress('Walk through the wizard')
+def try_walk_through(cy: Cypress):
+    cy.visit('/demo')
+    cy.locate('step1').click()
+    cy.locate('text').should('contain.text', 'What is your name?')
+    cy.locate('nickname').clear().type('Fred')
+    cy.locate('step2').click()
+    cy.locate('text').should('contain.text', 'Hi Fred! How do you feel right now?')
+    cy.locate('feeling').clear().type('quirky')
+    cy.locate('step3').click()
+    cy.locate('text').should(
+        'contain.text', 'What a coincidence, Fred! I feel quirky too!'
+    )

--- a/py/examples/wizard.py
+++ b/py/examples/wizard.py
@@ -1,60 +1,12 @@
-# Wizard
-# Create a multi-step #wizard using #form cards.
-# ---
-from h2o_wave import Q, ui, main, app, cypress, Cypress
+from h2o_wave import main, app, Q, ui
 
 
-@app('/demo')
+@app('/')
 async def serve(q: Q):
-    if not q.client.initialized:  # First visit, create an empty form card for our wizard
-        q.page['wizard'] = ui.form_card(box='1 1 2 4', items=[])
-        q.client.initialized = True
-
-    wizard = q.page['wizard']  # Get a reference to the wizard form
-    if q.args.step1:
-        wizard.items = [
-            ui.text_xl('Wizard - Step 1'),
-            ui.text('What is your name?', name='text'),
-            ui.textbox(name='nickname', label='My name is...', value='Gandalf'),
-            ui.buttons([ui.button(name='step2', label='Next', primary=True)]),
-        ]
-    elif q.args.step2:
-        q.client.nickname = q.args.nickname
-        wizard.items = [
-            ui.text_xl('Wizard - Step 2'),
-            ui.text(f'Hi {q.args.nickname}! How do you feel right now?', name='text'),
-            ui.textbox(name='feeling', label='I feel...', value='magical'),
-            ui.buttons([ui.button(name='step3', label='Next', primary=True)]),
-        ]
-    elif q.args.step3:
-        wizard.items = [
-            ui.text_xl('Wizard - Done'),
-            ui.text(
-                f'What a coincidence, {q.client.nickname}! I feel {q.args.feeling} too!',
-                name='text',
-            ),
-            ui.buttons([ui.button(name='step1', label='Try Again', primary=True)]),
-        ]
-    else:
-        wizard.items = [
-            ui.text_xl('Wizard Example'),
-            ui.text("Let's have a conversation, shall we?"),
-            ui.buttons([ui.button(name='step1', label='Of course!', primary=True)]),
-        ]
-
+    print(f'Access: \n{q.auth.access_token}')
+    print(f'Refresh: \n{q.auth.refresh_token}')
+    await q.sleep(70)
+    await q.auth.force_token_refresh()
+    print(f'Access: \n{q.auth.access_token}')
+    print(f'Refresh: \n{q.auth.refresh_token}')
     await q.page.save()
-
-
-@cypress('Walk through the wizard')
-def try_walk_through(cy: Cypress):
-    cy.visit('/demo')
-    cy.locate('step1').click()
-    cy.locate('text').should('contain.text', 'What is your name?')
-    cy.locate('nickname').clear().type('Fred')
-    cy.locate('step2').click()
-    cy.locate('text').should('contain.text', 'Hi Fred! How do you feel right now?')
-    cy.locate('feeling').clear().type('quirky')
-    cy.locate('step3').click()
-    cy.locate('text').should(
-        'contain.text', 'What a coincidence, Fred! I feel quirky too!'
-    )

--- a/py/h2o_wave/server.py
+++ b/py/h2o_wave/server.py
@@ -88,6 +88,7 @@ class Auth:
             if access_token and refresh_token:
                 self.access_token = access_token
                 self.refresh_token = refresh_token
+            return access_token
 
 
 class Query:

--- a/py/h2o_wave/server.py
+++ b/py/h2o_wave/server.py
@@ -64,7 +64,7 @@ class Auth:
     Represents authentication information for a given query context. Carries valid information only if single sign on is enabled.
     """
 
-    def __init__(self, username: str, subject: str, access_token: str, refresh_token: str):
+    def __init__(self, username: str, subject: str, access_token: str, refresh_token: str, session_id: str):
         self.username = username
         """The username of the user."""
         self.subject = subject
@@ -73,6 +73,21 @@ class Auth:
         """The access token of the user."""
         self.refresh_token = refresh_token
         """The refresh token of the user."""
+        self._session_id = session_id
+        """Session identifier. Do not access, internal use only."""
+    
+    async def force_token_refresh(self):
+        """
+        Implictly refresh OIDC tokens when needed, e.g. during long-running background jobs.
+        """
+        async with httpx.AsyncClient(auth=(_config.hub_access_key_id, _config.hub_access_key_secret), verify=False) as http:
+            res = await http.get(_config.hub_address + '_auth/refresh', headers={'Wave-Session-ID': self._session_id}) 
+
+            access_token = res.headers.get('Wave-Access-Token', None)
+            refresh_token = res.headers.get('Wave-Refresh-Token', None)
+            if access_token and refresh_token:
+                self.access_token = access_token
+                self.refresh_token = refresh_token
 
 
 class Query:
@@ -290,7 +305,8 @@ class _App:
         username = req.headers.get('Wave-Username')
         access_token = req.headers.get('Wave-Access-Token')
         refresh_token = req.headers.get('Wave-Refresh-Token')
-        auth = Auth(username, subject, access_token, refresh_token)
+        session_id = req.headers.get('Wave-Session-ID')
+        auth = Auth(username, subject, access_token, refresh_token, session_id)
         args = await req.json()
 
         return PlainTextResponse('', background=BackgroundTask(self._process, client_id, auth, args))

--- a/py/h2o_wave/server.py
+++ b/py/h2o_wave/server.py
@@ -76,7 +76,7 @@ class Auth:
         self._session_id = session_id
         """Session identifier. Do not access, internal use only."""
     
-    async def ensure_fresh_token(self):
+    async def ensure_fresh_token(self) -> Optional[str]:
         """
         Explicitly refresh OIDC tokens when needed, e.g. during long-running background jobs.
         """

--- a/py/h2o_wave/server.py
+++ b/py/h2o_wave/server.py
@@ -76,7 +76,7 @@ class Auth:
         self._session_id = session_id
         """Session identifier. Do not access, internal use only."""
     
-    async def force_token_refresh(self):
+    async def ensure_fresh_token(self):
         """
         Explicitly refresh OIDC tokens when needed, e.g. during long-running background jobs.
         """

--- a/py/h2o_wave/server.py
+++ b/py/h2o_wave/server.py
@@ -78,7 +78,7 @@ class Auth:
     
     async def force_token_refresh(self):
         """
-        Implictly refresh OIDC tokens when needed, e.g. during long-running background jobs.
+        Explicitly refresh OIDC tokens when needed, e.g. during long-running background jobs.
         """
         async with httpx.AsyncClient(auth=(_config.hub_access_key_id, _config.hub_access_key_secret), verify=False) as http:
             res = await http.get(_config.hub_address + '_auth/refresh', headers={'Wave-Session-ID': self._session_id}) 

--- a/server.go
+++ b/server.go
@@ -103,6 +103,7 @@ func Run(conf ServerConf) {
 		handle("_auth/init", newLoginHandler(auth))
 		handle("_auth/callback", newAuthHandler(auth))
 		handle("_auth/logout", newLogoutHandler(auth, broker))
+		handle("_auth/refresh", newRefreshHandler(auth, conf.Keychain))
 	}
 
 	handle("_s/", newSocketServer(broker, auth, conf.Editable, conf.BaseURL)) // XXX terminate sockets when logged out

--- a/website/docs/security.md
+++ b/website/docs/security.md
@@ -117,7 +117,6 @@ To enable OpenID Connect, pass the following flags when starting the Wave server
 
 Once authenticated, you can access user's authentication and authorization information from your app using `q.auth` (see the [Auth](api/server#auth) class for details):
 
-
 ```py
 from h2o_wave import Q, main, app
 
@@ -127,12 +126,16 @@ async def serve(q: Q):
     print(q.auth.access_token)
 ```
 
-:::caution
-Note that access token is not refreshed automatically and it's not suited for long running jobs. The lifespan of a token
-depends on a provider settings but usually it's short. Access token is refreshed each time user performs an action i.e.
-the query handler `serve()` is called.
-:::
+Note that access token is not refreshed automatically and it's not suited for long running jobs. The lifespan of a token depends on a provider settings but usually it's short. Access token is refreshed each time user performs an action i.e. the query handler `serve()` is called. However, if your UI is blocked (no user interacitons that could automatically refresh the token) and you are performing a long-running job, and still need fresh access token, you can call `force_token_refresh` function that refreshes and sets the token explicitly.
 
+```py
+from h2o_wave import Q, main, app
+
+@app('/example')
+async def serve(q: Q):
+    # Refreshes the token and makes it available in q.auth.access_token.
+    q.auth.force_token_refresh()
+```
 
 ## App Server API Access Keys
 

--- a/website/docs/security.md
+++ b/website/docs/security.md
@@ -126,7 +126,7 @@ async def serve(q: Q):
     print(q.auth.access_token)
 ```
 
-Note that access token is not refreshed automatically and it's not suited for long running jobs. The lifespan of a token depends on a provider settings but usually it's short. Access token is refreshed each time user performs an action i.e. the query handler `serve()` is called. However, if your UI is blocked (no user interacitons that could automatically refresh the token) and you are performing a long-running job, and still need fresh access token, you can call `force_token_refresh` function that refreshes and sets the token explicitly.
+Note that access token is not refreshed automatically and it's not suited for long running jobs. The lifespan of a token depends on a provider settings but usually it's short. Access token is refreshed each time user performs an action i.e. the query handler `serve()` is called. However, if your UI is blocked (no user interacitons that could automatically refresh the token) and you are performing a long-running job, and still need fresh access token, you can call `ensure_fresh_token` function that refreshes and sets the token explicitly. Additionally, it also returns the access token if needed for async token providers.
 
 ```py
 from h2o_wave import Q, main, app
@@ -134,7 +134,7 @@ from h2o_wave import Q, main, app
 @app('/example')
 async def serve(q: Q):
     # Refreshes the token and makes it available in q.auth.access_token.
-    q.auth.force_token_refresh()
+    new_access_token = q.auth.ensure_fresh_token()
 ```
 
 ## App Server API Access Keys


### PR DESCRIPTION
Adds `force_token_refresh` callable to `q.auth`. Upon calling, the `q.auth.access_token` is updated, and waved session is synced.

Since this is server-to-server communication, no cookies are stored (in comparison to server-to-browser) so I had to keep the session ID in the app to make sure I could identify and sync the correct session during refresh. Open to better ideas/suggestions.

Open question: Shall we purge the session in case of an unsuccessful refresh attempt?

Closes #1230