### PR TITLE
fix: Renders anchor tag for button link

### DIFF
--- a/ui/src/button.test.tsx
+++ b/ui/src/button.test.tsx
@@ -82,14 +82,33 @@ describe('Button.tsx', () => {
       expect(queryByTestId(name)).not.toHaveClass('ms-Link')
     })
 
-    it('Does redirect if path is specified', () => {
-      const
-        windowOpenMock = jest.fn(),
-        { getByTestId } = render(<XButtons model={{ items: [{ button: { name, label: name, path: 'https://h2o.ai/' } }] }} />)
-
-      window.open = windowOpenMock
-      fireEvent.click(getByTestId(name))
-      expect(windowOpenMock).toHaveBeenCalled()
+    describe('Link', () => {
+      it('Opens in new tab when path are specified', () => {
+        const
+          path = 'https://h2o.ai/',
+          { getByTestId } = render(<XButtons model={{ items: [{ button: { name, label: name, link: true, path } }] }} />)
+  
+        expect(getByTestId(name)).toHaveAttribute('href', path)
+        expect(getByTestId(name)).toHaveAttribute('target', '_blank')
+      })
+  
+      it('Updates location hash when name has hash and path is not specified', () => {
+        const
+          nameWithHash = '#mylink',
+          { getByTestId } = render(<XButtons model={{ items: [{ button: { name: nameWithHash, label: name, link: true } }] }} />)
+  
+        fireEvent.click(getByTestId(nameWithHash))
+        expect(window.location.hash).toBe(nameWithHash)
+      })
+  
+      it('Does not update location hash when name has hash and path is specified', () => {
+        const
+          nameWithHash = '#mylink',
+          { getByTestId } = render(<XButtons model={{ items: [{ button: { name: nameWithHash, label: name, link: true, path: 'https://h2o.ai/' } }] }} />)
+  
+        fireEvent.click(getByTestId(nameWithHash))
+        expect(window.location.hash).toBe('')
+      })
     })
   })
 

--- a/ui/src/button.tsx
+++ b/ui/src/button.tsx
@@ -118,8 +118,7 @@ const
     const
       onClick = (ev: any) => {
         ev.stopPropagation()
-        if (path) window.open(path, "_blank")
-        else if (name.startsWith('#')) window.location.hash = name.substr(1)
+        if (!path && name.startsWith('#')) window.location.hash = name.substring(1)
         else {
           wave.args[name] = value === undefined || value
           wave.push()
@@ -143,7 +142,7 @@ const
     React.useEffect(() => { wave.args[name] = false }, [])
 
     if (link) {
-      return <Fluent.Link data-test={name} disabled={disabled} onClick={onClick} styles={styles}>{label}</Fluent.Link>
+      return <Fluent.Link data-test={name} disabled={disabled} onClick={onClick} href={path} target="_blank" styles={styles}>{label}</Fluent.Link>
     }
     const btnProps: Fluent.IButtonProps = { text: label, disabled, onClick, styles, iconProps: { iconName: icon } }
     if (!label && icon) return <Fluent.IconButton {...btnProps} data-test={name} title={caption} />


### PR DESCRIPTION
Link was being rendered as a button, turning it into an anchor tag will provide proper context menu when right clicking.

<img width="324" alt="image" src="https://user-images.githubusercontent.com/15820796/183074498-51591ef7-e1cc-4257-baa9-bc225bdaa5ae.png">

closes #1572