### PR TITLE
fix: Use canvas renderer to avoid subtle G2 bugs. #1562

### DIFF
--- a/py/examples/plot_theme.py
+++ b/py/examples/plot_theme.py
@@ -3,7 +3,7 @@
 # ---
 import random
 
-from .synth import FakeTimeSeries, FakeMultiTimeSeries, FakeCategoricalSeries, FakeMultiCategoricalSeries, FakeScatter
+from synth import FakeTimeSeries, FakeMultiTimeSeries, FakeCategoricalSeries, FakeMultiCategoricalSeries, FakeScatter
 from h2o_wave import main, app, data, Q, ui
 
 
@@ -15,23 +15,18 @@ f_cat = FakeCategoricalSeries()
 f_cat_multi = FakeMultiCategoricalSeries(groups=k)
 f_scat = FakeScatter()
 
+zones = [
+    ui.zone(name='title', size='60px'),
+    ui.zone(name='plots', direction=ui.ZoneDirection.ROW, wrap='start', justify='center'),
+]
 
 @app('/demo')
 async def serve(q: Q):
     if not q.client.initialized:
         q.page['meta'] = ui.meta_card(box='', layouts=[
-            ui.layout(breakpoint='xs', zones=[
-                ui.zone(name='title'),
-                ui.zone(name='plots', direction=ui.ZoneDirection.ROW, wrap='start', justify='center'),
-            ]),
-            ui.layout(breakpoint='m', zones=[
-                ui.zone(name='title'),
-                ui.zone(name='plots', direction=ui.ZoneDirection.ROW, wrap='start', justify='center'),
-            ]),
-            ui.layout(breakpoint='xl', zones=[
-                ui.zone(name='title'),
-                ui.zone(name='plots', direction=ui.ZoneDirection.ROW, wrap='start', justify='center'),
-            ]),
+            ui.layout(breakpoint='xs', zones=zones),
+            ui.layout(breakpoint='m', zones=zones),
+            ui.layout(breakpoint='xl', zones=zones),
         ])
 
         q.client.active_theme = 'default'

--- a/py/examples/plot_theme.py
+++ b/py/examples/plot_theme.py
@@ -3,7 +3,7 @@
 # ---
 import random
 
-from synth import FakeTimeSeries, FakeMultiTimeSeries, FakeCategoricalSeries, FakeMultiCategoricalSeries, FakeScatter
+from .synth import FakeTimeSeries, FakeMultiTimeSeries, FakeCategoricalSeries, FakeMultiCategoricalSeries, FakeScatter
 from h2o_wave import main, app, data, Q, ui
 
 

--- a/tools/showcase/Makefile
+++ b/tools/showcase/Makefile
@@ -15,6 +15,7 @@ generate:
 
 visual-regression:
 	rm -rf test/compare test/diff
+	mkdir -p test/compare test/diff
 	./venv/bin/python showcase.py --test
 
 test-result:


### PR DESCRIPTION
This PR replaces the SVG renderer with the default canvas renderer. The main reason for picking the SVG renderer was the ease of theming via CSS variables unavailable in the canvas. Surprisingly, it seems like G2 is able to update theming plots faster than the browser to repaint the UI on CSS variables change (most probably due to too complex DOM structure, but didn't dive deeper).

Closes #1562
Closes #1581 - Safari render