### PR TITLE
fix: Prevent memory leak caused by unclosed file handles during site.upload.

### DIFF
--- a/py/tests/test_python_server.py
+++ b/py/tests/test_python_server.py
@@ -446,6 +446,8 @@ class TestPythonServer(unittest.TestCase):
 
 
     def test_multipart_server(self):
-        p = site.uplink('test_stream', 'image/svg+xml', open('../assets/brand/wave.svg', 'r'))
+        file_handle = open('../assets/brand/wave.svg', 'r')
+        p = site.uplink('test_stream', 'image/svg+xml', file_handle)
         site.unlink('test_stream')
+        file_handle.close()
         assert len(p) > 0


### PR DESCRIPTION
Prevents a memory leak.

HTTPX (our HTTP client) lib accepts `BufferedReader` for multipart (file) uploads, but somehow doesn't close file handles when finished so it's necessary to do it ourselves - this PR.