### PR TITLE
Fix: Missing tooltips for histogram with time x_scale

### DIFF
--- a/ui/src/plot.tsx
+++ b/ui/src/plot.tsx
@@ -1097,6 +1097,7 @@ export const
         currentPlot.current = plot
         if (chart) {
           chart.tooltip({
+            title: ' ', // HACK: Ignore tooltip title computation by G2 since we overwrite it anyway.
             showCrosshairs: true,
             crosshairs: { type: 'xy' },
             domStyles: {


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/23740173/185197016-ce06ebaa-46a0-42b1-aac1-40e92c369db3.png)


Closes #1474 