### PR TITLE
fix: Allow setting Textbox "value" dynamically

### DIFF
--- a/ui/src/textbox.test.tsx
+++ b/ui/src/textbox.test.tsx
@@ -18,8 +18,11 @@ import React from 'react'
 import { Textbox, XTextbox } from './textbox'
 import { wave } from './ui'
 
-const name = 'textbox'
+const
+  name = 'textbox',
+  pushMock = jest.fn()
 let textboxProps: Textbox = { name }
+wave.push = pushMock
 
 describe('Textbox.tsx', () => {
   beforeEach(() => {
@@ -76,9 +79,6 @@ describe('Textbox.tsx', () => {
   it('Calls sync on change - trigger specified', () => {
     const { getByTestId } = render(<XTextbox model={{ ...textboxProps, trigger: true }} />)
 
-    const pushMock = jest.fn()
-    wave.push = pushMock
-
     fireEvent.change(getByTestId(name), { target: { value: 'aaa' } })
 
     expect(pushMock).not.toBeCalled() // Not called immediately, but after specified timeout.
@@ -90,8 +90,6 @@ describe('Textbox.tsx', () => {
 
   it('Debounces wave push', () => {
     const { getByTestId } = render(<XTextbox model={{...textboxProps, trigger: true}} />)
-    const pushMock = jest.fn()
-    wave.push = pushMock
 
     userEvent.type(getByTestId(name), 'a')
     userEvent.type(getByTestId(name), 'a')
@@ -104,9 +102,6 @@ describe('Textbox.tsx', () => {
 
   it('Does not call sync on change - trigger not specified', () => {
     const { getByTestId } = render(<XTextbox model={textboxProps} />)
-
-    const pushMock = jest.fn()
-    wave.push = pushMock
 
     fireEvent.change(getByTestId(name), { target: { value: 'aaa' } })
 

--- a/ui/src/textbox.test.tsx
+++ b/ui/src/textbox.test.tsx
@@ -81,10 +81,8 @@ describe('Textbox.tsx', () => {
     fireEvent.change(getByTestId(name), { target: { value: 'aaa' } })
 
     expect(pushMock).not.toBeCalled() // Not called immediately, but after specified timeout.
-    jest.advanceTimersByTime(250)
-    expect(pushMock).not.toBeCalled()
-    jest.advanceTimersByTime(250)
-    expect(pushMock).toBeCalled()
+    jest.runOnlyPendingTimers()
+    expect(pushMock).toBeCalledTimes(1)
   })
 
   it('Debounces wave push', () => {

--- a/ui/src/textbox.test.tsx
+++ b/ui/src/textbox.test.tsx
@@ -75,6 +75,25 @@ describe('Textbox.tsx', () => {
     expect(wave.args[name]).toBe('default')
   })
 
+  it('Sets args when "value" prop changes', () => {
+    const { rerender } = render(<XTextbox model={{ ...textboxProps, value: 'a' }} />)
+    expect(wave.args[name]).toBe('a')
+
+    rerender(<XTextbox model={{ ...textboxProps, value: 'b' }} />)
+    expect(wave.args[name]).toBe('b')
+  })
+
+  it('Sets args when typing new text and then "value" prop changes', () => {
+    const { getByTestId, rerender } = render(<XTextbox model={{ ...textboxProps, value: 'a' }} />)
+    expect(wave.args[name]).toBe('a')
+
+    userEvent.type(getByTestId(name), '{backspace}b')
+    expect(wave.args[name]).toBe('b')
+
+    rerender(<XTextbox model={{ ...textboxProps, value: 'c' }} />)
+    expect(wave.args[name]).toBe('c')
+  })
+
   it('Calls sync on change - trigger specified', () => {
     const { getByTestId } = render(<XTextbox model={{ ...textboxProps, trigger: true }} />)
 

--- a/ui/src/textbox.test.tsx
+++ b/ui/src/textbox.test.tsx
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { fireEvent, render, act } from '@testing-library/react'
+import { fireEvent, render } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
 import { Textbox, XTextbox } from './textbox'
@@ -56,7 +56,7 @@ describe('Textbox.tsx', () => {
   it('Sets args on input', () => {
     const { getByTestId } = render(<XTextbox model={textboxProps} />)
     fireEvent.change(getByTestId(name), { target: { value: 'text' } })
-    act(() => { jest.runOnlyPendingTimers() })
+    jest.runOnlyPendingTimers()
 
     expect(wave.args[name]).toBe('text')
   })
@@ -81,9 +81,9 @@ describe('Textbox.tsx', () => {
     fireEvent.change(getByTestId(name), { target: { value: 'aaa' } })
 
     expect(pushMock).not.toBeCalled() // Not called immediately, but after specified timeout.
-    act(() => { jest.advanceTimersByTime(250) })
+    jest.advanceTimersByTime(250)
     expect(pushMock).not.toBeCalled()
-    act(() => { jest.advanceTimersByTime(250) })
+    jest.advanceTimersByTime(250)
     expect(pushMock).toBeCalled()
   })
 
@@ -94,7 +94,7 @@ describe('Textbox.tsx', () => {
     userEvent.type(getByTestId(name), 'a')
     userEvent.type(getByTestId(name), 'a')
     userEvent.type(getByTestId(name), 'a')
-    act(() => { jest.runOnlyPendingTimers() })
+    jest.runOnlyPendingTimers()
 
     expect(pushMock).toBeCalledTimes(1)
   })

--- a/ui/src/textbox.test.tsx
+++ b/ui/src/textbox.test.tsx
@@ -28,7 +28,6 @@ describe('Textbox.tsx', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     jest.useFakeTimers()
-    wave.args[name] = null
     // Because we mutate props to programatically change "value" from Wave app we need to reset it before every test
     textboxProps = { name }
   })

--- a/ui/src/textbox.test.tsx
+++ b/ui/src/textbox.test.tsx
@@ -12,19 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { fireEvent, render } from '@testing-library/react'
+import { fireEvent, render, act } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import React from 'react'
 import { Textbox, XTextbox } from './textbox'
 import { wave } from './ui'
 
 const name = 'textbox'
-const textboxProps: Textbox = { name }
+let textboxProps: Textbox = { name }
 
 describe('Textbox.tsx', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     jest.useFakeTimers()
     wave.args[name] = null
+    textboxProps = { name }
   })
 
   it('Renders data-test attr', () => {
@@ -51,7 +53,7 @@ describe('Textbox.tsx', () => {
   it('Sets args on input', () => {
     const { getByTestId } = render(<XTextbox model={textboxProps} />)
     fireEvent.change(getByTestId(name), { target: { value: 'text' } })
-    jest.runOnlyPendingTimers()
+    act(() => { jest.runOnlyPendingTimers() })
 
     expect(wave.args[name]).toBe('text')
   })
@@ -79,8 +81,24 @@ describe('Textbox.tsx', () => {
     fireEvent.change(getByTestId(name), { target: { value: 'aaa' } })
 
     expect(pushMock).not.toBeCalled() // Not called immediately, but after specified timeout.
-    jest.runOnlyPendingTimers()
+    act(() => { jest.advanceTimersByTime(250) })
+    expect(pushMock).not.toBeCalled()
+    act(() => { jest.advanceTimersByTime(250) })
     expect(pushMock).toBeCalled()
+  })
+
+  it('Debounces wave push', () => {
+    const { getByTestId } = render(<XTextbox model={{...textboxProps, trigger: true}} />)
+    const pushMock = jest.fn()
+    wave.push = pushMock
+
+    userEvent.type(getByTestId(name), 'a')
+    userEvent.type(getByTestId(name), 'a')
+    userEvent.type(getByTestId(name), 'a')
+    userEvent.type(getByTestId(name), 'a')
+    act(() => { jest.runOnlyPendingTimers() })
+
+    expect(pushMock).toBeCalledTimes(1)
   })
 
   it('Does not call sync on change - trigger not specified', () => {
@@ -92,5 +110,39 @@ describe('Textbox.tsx', () => {
     fireEvent.change(getByTestId(name), { target: { value: 'aaa' } })
 
     expect(pushMock).not.toBeCalled()
+  })
+
+  it('Display new value when "value" prop changes', () => {
+    const { getByTestId, rerender } = render(<XTextbox model={{...textboxProps, value: 'A'}} />)
+    expect(getByTestId(name)).toHaveValue('A')
+
+    rerender(<XTextbox model={{...textboxProps, value: 'B'}} />)
+    expect(getByTestId(name)).toHaveValue('B')
+  })
+
+  it('Types value and then display new value when "value" prop changes', () => {
+    const { getByTestId, rerender } = render(<XTextbox model={textboxProps} />)
+    userEvent.type(getByTestId(name), '{backspace}A{Enter}')
+    expect(getByTestId(name)).toHaveValue('A')
+
+    rerender(<XTextbox model={{...textboxProps, value: 'B'}} />)
+    expect(getByTestId(name)).toHaveValue('B')
+  })
+
+  it('Display new value when "value" prop changes (masked)', () => {
+    const { getByTestId, rerender } = render(<XTextbox model={{...textboxProps, value: '123', mask: '(999)'}} />)
+    expect(getByTestId(name)).toHaveValue('(123)')
+
+    rerender(<XTextbox model={{...textboxProps, value: '456', mask: '(999)'}} />)
+    expect(getByTestId(name)).toHaveValue('(456)')
+  })
+
+  it('Types value and then display new value when "value" prop changes (masked)', () => {
+    const { getByTestId, rerender } = render(<XTextbox model={{...textboxProps, mask: '(999)'}} />)
+    userEvent.type(getByTestId(name), '{backspace}123{Enter}')
+    expect(getByTestId(name)).toHaveValue('(123)')
+
+    rerender(<XTextbox model={{...textboxProps, value: '456', mask: '(999)'}} />)
+    expect(getByTestId(name)).toHaveValue('(456)')
   })
 })

--- a/ui/src/textbox.test.tsx
+++ b/ui/src/textbox.test.tsx
@@ -26,6 +26,7 @@ describe('Textbox.tsx', () => {
     jest.clearAllMocks()
     jest.useFakeTimers()
     wave.args[name] = null
+    // Because we mutate props to programatically change "value" from Wave app we need to reset it before every test
     textboxProps = { name }
   })
 

--- a/ui/src/textbox.tsx
+++ b/ui/src/textbox.tsx
@@ -99,9 +99,10 @@ export const
         type: m.password ? 'password' : undefined,
       }
 
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    React.useEffect(() => { wave.args[m.name] = m.value || '' }, [])
-    React.useEffect(() => { setValue(m.value ?? '')}, [m.value])
+    React.useEffect(() => {
+      wave.args[m.name] = m.value ?? ''
+      setValue(m.value ?? '')
+    }, [m.value, m.name])
 
     return m.mask
       ? <Fluent.MaskedTextField mask={m.mask} {...textFieldProps} />

--- a/ui/src/textbox.tsx
+++ b/ui/src/textbox.tsx
@@ -72,7 +72,7 @@ export const
   XTextbox = ({ model: m }: { model: Textbox }) => {
     const
       [value, setValue] = React.useState(m.value ?? ''),
-      debounceRef = React.useRef(debounce(DEBOUNCE_TIMEOUT, () => wave.push())),
+      debounceRef = React.useRef(debounce(DEBOUNCE_TIMEOUT, wave.push)),
       onChange = ({ target }: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, v?: S) => {
         v = v || (target as HTMLInputElement).value
 

--- a/ui/src/textbox.tsx
+++ b/ui/src/textbox.tsx
@@ -71,20 +71,25 @@ const DEBOUNCE_TIMEOUT = 500
 export const
   XTextbox = ({ model: m }: { model: Textbox }) => {
     const
+      [value, setValue] = React.useState(m.value ?? ''),
+      debounceRef = React.useRef(debounce(DEBOUNCE_TIMEOUT, () => wave.push())),
       onChange = ({ target }: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, v?: S) => {
         v = v || (target as HTMLInputElement).value
 
         wave.args[m.name] = v ?? (m.value || '')
-        if (m.trigger) wave.push()
+        if (m.trigger) debounceRef.current()
+        setValue(v)
+        m.value = v
       },
       textFieldProps: Fluent.ITextFieldProps & { 'data-test': S } = {
         'data-test': m.name,
         label: m.label,
+        value,
         errorMessage: m.error,
         required: m.required,
         disabled: m.disabled,
         readOnly: m.readonly,
-        onChange: m.trigger ? debounce(DEBOUNCE_TIMEOUT, onChange) : onChange,
+        onChange,
         iconProps: m.icon ? { iconName: m.icon } : undefined,
         placeholder: m.placeholder,
         prefix: m.prefix,
@@ -96,9 +101,10 @@ export const
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
     React.useEffect(() => { wave.args[m.name] = m.value || '' }, [])
+    React.useEffect(() => { setValue(m.value ?? '')}, [m.value])
 
     return m.mask
-      ? <Fluent.MaskedTextField mask={m.mask} {...textFieldProps} value={m.value} />
+      ? <Fluent.MaskedTextField mask={m.mask} {...textFieldProps} />
       : (
         <Fluent.TextField
           styles={
@@ -107,7 +113,6 @@ export const
               : undefined
           }
           {...textFieldProps}
-          defaultValue={m.value}
         />
       )
   }


### PR DESCRIPTION
* allow Textbox "value" to be set from wave app
* add tests for TextField and MaskedTextField
* fix warning about act() in tests


https://user-images.githubusercontent.com/15820796/186417390-982c280e-4dff-44cb-a056-2d86d76bace6.mov


closes #1578