### PR TITLE
Fix: Success message without file names when ui.file_upload inside ui.dialog

### DIFF
--- a/ui/src/file_upload.tsx
+++ b/ui/src/file_upload.tsx
@@ -138,7 +138,7 @@ export const
           wave.args[name] = files
 
           if (!compact) wave.push()
-          setSuccessMsg(`Successfully uploaded files: ${files.map(({ name }: File) => name).join(',')}.`)
+          setSuccessMsg(`Successfully uploaded files: ${fileNames}.`)
         }
         catch (err: unknown) {
           if (err) setError(err instanceof XMLHttpRequest ? err.responseText : 'There was an error when uploading file.')


### PR DESCRIPTION
Closes #1607 