### PR TITLE
Feat: Make ui.text_annotator to respect \n and \r in text

### DIFF
--- a/py/examples/text_annotator.py
+++ b/py/examples/text_annotator.py
@@ -23,7 +23,7 @@ async def serve(q: Q):
                 ],
                 items=[
                     ui.text_annotator_item(text='Killer Mike', tag='p'),
-                    ui.text_annotator_item(text=' is a member, of the hip hop supergroup '),  # no tag
+                    ui.text_annotator_item(text=' is a member of the hip hop supergroup '),  # no tag
                     ui.text_annotator_item(text='Run the Jewels', tag='o'),
                 ],
             ),

--- a/py/examples/text_annotator.py
+++ b/py/examples/text_annotator.py
@@ -25,7 +25,9 @@ async def serve(q: Q):
                     ui.text_annotator_item(text='Killer Mike', tag='p'),
                     ui.text_annotator_item(text=' is a member of the hip hop supergroup '),  # no tag
                     ui.text_annotator_item(text='Run the Jewels', tag='o'),
-                    ui.text_annotator_item(text='.\nIt is also known by the initials RTJ.')
+                    ui.text_annotator_item(text='.\nIt is also known by the initials '),
+                    ui.text_annotator_item(text='RTJ', tag='o'),
+                    ui.text_annotator_item(text='.')
                 ],
             ),
             ui.button(name='submit', label='Submit', primary=True)

--- a/py/examples/text_annotator.py
+++ b/py/examples/text_annotator.py
@@ -25,6 +25,7 @@ async def serve(q: Q):
                     ui.text_annotator_item(text='Killer Mike', tag='p'),
                     ui.text_annotator_item(text=' is a member of the hip hop supergroup '),  # no tag
                     ui.text_annotator_item(text='Run the Jewels', tag='o'),
+                    ui.text_annotator_item(text='.\nIt is also known by the initials RTJ.')
                 ],
             ),
             ui.button(name='submit', label='Submit', primary=True)

--- a/ui/src/text_annotator.test.tsx
+++ b/ui/src/text_annotator.test.tsx
@@ -252,5 +252,35 @@ describe('TextAnnotator.tsx', () => {
         { text: 'ood', tag: 'tag1' },
         { text: ' day' }])
     })
+
+    it('Sets correct args on annotate when escape characters are included - single line selection', () => {
+      const customItems = [{ text: 'I am\nmultiline\ntext.' }]
+      const { getByText } = render(<XTextAnnotator model={{ ...annotatorProps, items: customItems }} />)
+
+      fireEvent.click(getByText('Tag 1'))
+      fireEvent.mouseDown(getByText('u'))
+      fireEvent.mouseUp(getByText('n'))
+
+      expect(wave.args[name]).toMatchObject([
+        { text: 'I am\n' },
+        { text: 'multiline', tag: 'tag1' },
+        { text: '\ntext.' },
+      ])
+    })
+
+    it('Sets correct args on annotate when escape characters are included - multiline selection', () => {
+      const customItems = [{ text: 'I am\nmultiline\ntext.' }]
+      const { getByText } = render(<XTextAnnotator model={{ ...annotatorProps, items: customItems }} />)
+
+      fireEvent.click(getByText('Tag 1'))
+      fireEvent.mouseDown(getByText('u'))
+      fireEvent.mouseUp(getByText('x'))
+
+      expect(wave.args[name]).toMatchObject([
+        { text: 'I am\n' },
+        { text: 'multiline\ntext', tag: 'tag1' },
+        { text: '.' },
+      ])
+    })
   })
 })

--- a/ui/src/text_annotator.tsx
+++ b/ui/src/text_annotator.tsx
@@ -324,17 +324,21 @@ export
             const activeColor = activeTag ? tagColorMap.get(activeTag) : undefined
             return (
               // Use paragraph instead of span to support text highlight.
-              <p
-                key={idx}
-                // data-keys keeps state in DOM to access it via window.getSelection() API in case mouse up event is fired when cursor is not above <p/> element
-                data-keys={`{ "key": ${idx}, "start": ${start}, "end": ${end} }`}
-                onMouseDown={handleMouseDown({ key: idx, start, end })}
-                onMouseUp={handleMouseUp({ key: idx, start, end })}
-                style={{ display: 'inline', padding: '4px 0px' }}
-                className={activeColor ? style({ $nest: { '&::selection': { background: activeColor, color: getContrast(activeColor) } } }) : undefined}
-              >
-                {tag ? getMark(text, idx, tag) : text}
-              </p>
+              text === '\n' || text === '\r'
+                // Handle newline escape characters
+                ? <br key={idx}></br>
+                // Use paragraph instead of span to support text highlight.
+                : <p
+                  key={idx}
+                  // data-keys keeps state in DOM to access it via window.getSelection() API in case mouse up event is fired when cursor is not above <p/> element
+                  data-keys={`{ "key": ${idx}, "start": ${start}, "end": ${end} }`}
+                  onMouseDown={handleMouseDown({ key: idx, start, end })}
+                  onMouseUp={handleMouseUp({ key: idx, start, end })}
+                  style={{ display: 'inline', padding: '4px 0px' }}
+                  className={activeColor ? style({ $nest: { '&::selection': { background: activeColor, color: getContrast(activeColor) } } }) : undefined}
+                >
+                  {tag ? getMark(text, idx, tag) : text}
+                </p>
             )
           })
         }</div>

--- a/website/widgets/form/text_annotator.md
+++ b/website/widgets/form/text_annotator.md
@@ -64,7 +64,7 @@ q.page['example'] = ui.form_card(box='1 1 4 10', items=[
         ],
         items=[
             ui.text_annotator_item(text='Killer Mike', tag='p'),
-            ui.text_annotator_item(text=' is a member, of the hip\rhop super\ngroup '),  # no tag
+            ui.text_annotator_item(text=' is a member, of the hip\rhop super\ngroup '),
             ui.text_annotator_item(text='Run the Jewels', tag='o'),
         ],
     )

--- a/website/widgets/form/text_annotator.md
+++ b/website/widgets/form/text_annotator.md
@@ -57,15 +57,16 @@ Use the `\n` or `\r` escape characters if you wish to force the line breaks with
 q.page['example'] = ui.form_card(box='1 1 4 10', items=[
     ui.text_annotator(
         name='annotator',
-        title='Select text to annotate',
+        title='Select a review to annotate',
         tags=[
-            ui.text_annotator_tag(name='p', label='Person', color='#F1CBCB'),
-            ui.text_annotator_tag(name='o', label='Org', color='#CAEACA'),
+            ui.text_annotator_tag(name='p', label='Positive', color='#CAEACA'),
+            ui.text_annotator_tag(name='0', label='Neutral', color='#BBBBBB'),
+            ui.text_annotator_tag(name='n', label='Negative', color='#F1CBCB'),
         ],
         items=[
-            ui.text_annotator_item(text='Killer Mike', tag='p'),
-            ui.text_annotator_item(text=' is a member, of the hip\rhop super\ngroup '),
-            ui.text_annotator_item(text='Run the Jewels', tag='o'),
+            ui.text_annotator_item(text='Okay.\n', tag='0'),
+            ui.text_annotator_item(text='Excellent work\nMasterpiece!\nA waste of money!!\nCould be a better quality.\n'),
+            ui.text_annotator_item(text='Not recommending', tag='n'),
         ],
     )
 ])

--- a/website/widgets/form/text_annotator.md
+++ b/website/widgets/form/text_annotator.md
@@ -48,3 +48,25 @@ q.page['example'] = ui.form_card(box='1 1 4 10', items=[
     )
 ])
 ```
+
+## With linebreaks
+
+Use the `\n` or `\r` escape characters, if you wish to force the line breaks within the text.
+
+```py
+q.page['example'] = ui.form_card(box='1 1 4 10', items=[
+    ui.text_annotator(
+        name='annotator',
+        title='Select text to annotate',
+        tags=[
+            ui.text_annotator_tag(name='p', label='Person', color='#F1CBCB'),
+            ui.text_annotator_tag(name='o', label='Org', color='#CAEACA'),
+        ],
+        items=[
+            ui.text_annotator_item(text='Killer Mike', tag='p'),
+            ui.text_annotator_item(text=' is a member, of the hip\rhop super\ngroup '),  # no tag
+            ui.text_annotator_item(text='Run the Jewels', tag='o'),
+        ],
+    )
+])
+```

--- a/website/widgets/form/text_annotator.md
+++ b/website/widgets/form/text_annotator.md
@@ -54,19 +54,23 @@ q.page['example'] = ui.form_card(box='1 1 4 10', items=[
 Use the `\n` or `\r` escape characters if you wish to force the line breaks within the text.
 
 ```py
+multiline_text='''
+I am
+multiline
+text
+'''
+
 q.page['example'] = ui.form_card(box='1 1 4 10', items=[
     ui.text_annotator(
         name='annotator',
-        title='Select a review to annotate',
+        title='Select text to annotate',
         tags=[
-            ui.text_annotator_tag(name='p', label='Positive', color='#CAEACA'),
-            ui.text_annotator_tag(name='0', label='Neutral', color='#BBBBBB'),
-            ui.text_annotator_tag(name='n', label='Negative', color='#F1CBCB'),
+            ui.text_annotator_tag(name='p', label='Tag 1', color='#CAEACA'),
+            ui.text_annotator_tag(name='n', label='Tag 2', color='#F1CBCB'),
         ],
         items=[
-            ui.text_annotator_item(text='Okay.\n', tag='0'),
-            ui.text_annotator_item(text='Excellent work\nMasterpiece!\nA waste of money!!\nCould be a better quality.\n'),
-            ui.text_annotator_item(text='Not recommending', tag='n'),
+            ui.text_annotator_item(text='I am\nmultiline\rtext'),
+            ui.text_annotator_item(text=multiline_text),
         ],
     )
 ])

--- a/website/widgets/form/text_annotator.md
+++ b/website/widgets/form/text_annotator.md
@@ -49,9 +49,9 @@ q.page['example'] = ui.form_card(box='1 1 4 10', items=[
 ])
 ```
 
-## With linebreaks
+## With line breaks
 
-Use the `\n` or `\r` escape characters, if you wish to force the line breaks within the text.
+Use the `\n` or `\r` escape characters if you wish to force the line breaks within the text.
 
 ```py
 q.page['example'] = ui.form_card(box='1 1 4 10', items=[


### PR DESCRIPTION
Javascript's newline escape sequences `\n` and `\r` are now transformed into line breaks in **ui.text_annotator**:
```py
ui.text_annotator_item(text=' is a member of the hip\rhop super\ngroup ')
```
<img width="343" alt="image" src="https://user-images.githubusercontent.com/23740173/188190346-5538cb77-c8eb-4fab-943c-119f9ad1969a.png">

These escape characters are only included in selection when user spans the selection through multiple lines.

Closes #1358 