### PR TITLE
fix: Use correct semantic colors for dark themes

### DIFF
--- a/ui/src/theme.ts
+++ b/ui/src/theme.ts
@@ -588,6 +588,7 @@ const
     const
       theme = themes[themeName] ?? themes[defaultThemeName],
       { palette, fluentPalette } = theme,
+      cardColor = Fluent.getColorFromString(palette.card)!,
       updateTones = (key: S, color: S) => {
         document.body.style.setProperty(`--${key}`, color)
         const [r, g, b] = rgb(color)
@@ -622,7 +623,7 @@ const
     // HACK: Execute as microtask to prevent race condition. Since meta is handled in page.tsx:render,
     // Fluent wants to update all components present (Spinner), but throws warning it cannot update unmounted element (Spinner)
     // because it is replaced by our new component tree in the meanwhile.
-    setTimeout(() => Fluent.loadTheme({ palette: fluentPalette, defaultFontStyle: { fontFamily: 'Inter' } }), 0)
+    setTimeout(() => Fluent.loadTheme({ palette: fluentPalette, defaultFontStyle: { fontFamily: 'Inter' }, isInverted: Fluent.isDark(cardColor) }), 0)
   }
 
 export const


### PR DESCRIPTION
Added `isInverted` prop to `loadTheme` to show correct colors for dark themes.

- **Before**
![Screenshot 2022-09-06 at 13 03 37](https://user-images.githubusercontent.com/23740173/188619820-3877f008-d9d0-4b3f-9bb9-7378097d272b.png)


- **After**
![Screenshot 2022-09-06 at 13 02 40](https://user-images.githubusercontent.com/23740173/188619940-1fc5017d-2107-40a9-99fa-d3d5b1dc0d83.png)


Closes #1608 