### PR TITLE
test: Add test for single-valued Combobox

### DIFF
--- a/ui/src/combobox.test.tsx
+++ b/ui/src/combobox.test.tsx
@@ -85,6 +85,14 @@ describe('Combobox.tsx', () => {
     
         expect(pushMock).toHaveBeenCalled()
       })
+
+      it('Sets wave args as string when a new valued is typed after init', () => {
+        const { getByRole } = render(<XCombobox model={{ ...comboboxProps, value: 'A' }} />)
+    
+        userEvent.type(getByRole('combobox'), '{backspace}D{enter}')
+    
+        expect(wave.args[name]).toBe('D')
+      })
     })
 
     describe('Prop changes - update values dynamically from Wave app', () => {

--- a/ui/src/combobox.test.tsx
+++ b/ui/src/combobox.test.tsx
@@ -86,11 +86,36 @@ describe('Combobox.tsx', () => {
         expect(pushMock).toHaveBeenCalled()
       })
 
-      it('Sets wave args as string when a new valued is typed after init', () => {
+      it('Sets wave args as string when a new valued is typed and enter is pressed - after init', () => {
+        const { getByRole } = render(<XCombobox model={{ ...comboboxProps, value: 'A' }} />)
+        expect(wave.args[name]).toBe('A')
+        userEvent.type(getByRole('combobox'), '{backspace}D{enter}')
+        expect(wave.args[name]).toBe('D')
+      })
+
+      it('Sets wave args as string when a new valued is typed and user clicks away - after init', () => {
         const { getByRole } = render(<XCombobox model={{ ...comboboxProps, value: 'A' }} />)
     
-        userEvent.type(getByRole('combobox'), '{backspace}D{enter}')
+        expect(wave.args[name]).toBe('A')
+
+        userEvent.type(getByRole('combobox'), '{backspace}D')
+        // fireEvent.blur(getByRole('combobox')) doesn't trigger blur. Might be related to https://github.com/testing-library/user-event/issues/592
+        getByRole('combobox').blur()
+        fireEvent.focusOut(getByRole('combobox'))
+
+        expect(getByRole('combobox')).not.toHaveFocus()
+        expect(wave.args[name]).toBe('D')
+      })
+
+      it('Sets wave args as string when a new valued is typed and tab is pressed - after init', () => {
+        const { getByRole } = render(<XCombobox model={{ ...comboboxProps, value: 'A' }} />)
     
+        expect(wave.args[name]).toBe('A')
+
+        userEvent.type(getByRole('combobox'), '{backspace}D')
+        userEvent.tab()
+
+        expect(getByRole('combobox')).not.toHaveFocus()
         expect(wave.args[name]).toBe('D')
       })
     })

--- a/ui/src/combobox.test.tsx
+++ b/ui/src/combobox.test.tsx
@@ -18,11 +18,13 @@ import React from 'react'
 import { Combobox, XCombobox } from './combobox'
 import { wave } from './ui'
 
-const name = 'combobox'
-const comboboxProps: Combobox = { name, choices: ['A', 'B', 'C'] }
-describe('Combobox.tsx', () => {
-  beforeEach(() => { wave.args[name] = null })
+const
+  name = 'combobox',
+  comboboxProps: Combobox = { name, choices: ['A', 'B', 'C'] },
+  pushMock = jest.fn()
+  wave.push = pushMock
 
+describe('Combobox.tsx', () => {
   it('Renders data-test attr', () => {
     const { queryByTestId } = render(<XCombobox model={comboboxProps} />)
     expect(queryByTestId(name)).toBeInTheDocument()
@@ -76,8 +78,6 @@ describe('Combobox.tsx', () => {
       })
 
       it('Calls sync when trigger is on', () => {
-        const pushMock = jest.fn()
-        wave.push = pushMock
         const { getByRole, getByText } = render(<XCombobox model={{ ...comboboxProps, trigger: true }} />)
     
         fireEvent.click(getByRole('presentation', { hidden: true }))
@@ -231,8 +231,6 @@ describe('Combobox.tsx', () => {
       })
 
       it('Calls sync when trigger is on', () => {
-        const pushMock = jest.fn()
-        wave.push = pushMock
         const { getByRole, getByText } = render(<XCombobox model={{ ...comboboxProps, values: [], trigger: true }} />)
     
         fireEvent.click(getByRole('presentation', { hidden: true }))


### PR DESCRIPTION
Add test to ensure a new typed value is a string instead of an array like in Wave 0.22.

closes #1615 