### PR TITLE
fix: Add support to dynamically change Dropdown value

### DIFF
--- a/ui/src/dropdown.test.tsx
+++ b/ui/src/dropdown.test.tsx
@@ -97,11 +97,6 @@ describe('Dropdown.tsx', () => {
       expect(wave.args[name]).toMatchObject(['A', 'B'])
     })
 
-    it('Returns null when value not specified - init', () => {
-      render(<XDropdown model={defaultProps} />)
-      expect(wave.args[name]).toBeNull()
-    })
-
     it('Shows correct selection in UI on select', () => {
       const { getByTestId, getByText, getAllByText } = render(<XDropdown model={{ ...defaultProps, values: ['A'] }} />)
 

--- a/ui/src/dropdown.test.tsx
+++ b/ui/src/dropdown.test.tsx
@@ -36,7 +36,7 @@ describe('Dropdown.tsx', () => {
         { name: 'D', label: 'Choice D' },
       ]
     },
-    pushMock.mockReset()
+      pushMock.mockReset()
   })
 
   describe('Base dropdown', () => {
@@ -150,29 +150,29 @@ describe('Dropdown.tsx', () => {
       expect(wave.args[name]).toMatchObject([])
       expect(pushMock).toHaveBeenCalled()
     })
-    
+
     describe('Prop changes', () => {
       describe('Single-valued', () => {
         it('Displays new value when "value" prop is updated', () => {
           const { getByRole, rerender } = render(<XDropdown model={{ ...defaultProps, value: 'A' }} />)
           expect(getByRole('combobox')).toHaveTextContent('Choice A')
-    
+
           rerender(<XDropdown model={{ ...defaultProps, value: 'B' }} />)
           expect(getByRole('combobox')).toHaveTextContent('Choice B')
         })
 
         it('Sets wave args when "value" prop is updated ', () => {
-          const { rerender } = render(<XDropdown model={{...defaultProps, value: 'A'}} />)
+          const { rerender } = render(<XDropdown model={{ ...defaultProps, value: 'A' }} />)
           expect(wave.args[name]).toBe('A')
-    
+
           rerender(<XDropdown model={{ ...defaultProps, value: 'B' }} />)
           expect(wave.args[name]).toBe('B')
         })
-  
+
         it('Clears input when "value" prop is updated to empty string', () => {
           const { getByRole, rerender } = render(<XDropdown model={{ ...defaultProps, value: 'A' }} />)
           expect(getByRole('combobox').children[0]).toHaveTextContent('Choice A')
-    
+
           rerender(<XDropdown model={{ ...defaultProps, value: '' }} />)
           expect(getByRole('combobox').children[0]).toBeEmptyDOMElement()
         })
@@ -180,15 +180,15 @@ describe('Dropdown.tsx', () => {
         it('Sets wave args to empty string when "value" prop is updated to an empty string', () => {
           const { rerender } = render(<XDropdown model={{ ...defaultProps, value: 'A' }} />)
           expect(wave.args[name]).toBe('A')
-    
+
           rerender(<XDropdown model={{ ...defaultProps, value: '' }} />)
           expect(wave.args[name]).toBe('')
         })
-    
+
         it('Clears input when "value" prop is updated to undefined (None)', () => {
           const { getByRole, rerender } = render(<XDropdown model={{ ...defaultProps, value: 'A' }} />)
           expect(getByRole('combobox').children[0]).toHaveTextContent('Choice A')
-    
+
           rerender(<XDropdown model={{ ...defaultProps }} />)
           expect(getByRole('combobox').children[0]).toBeEmptyDOMElement()
         })
@@ -196,29 +196,29 @@ describe('Dropdown.tsx', () => {
         it('Sets wave args to null when "value" prop is updated to undefined (None)', () => {
           const { rerender } = render(<XDropdown model={{ ...defaultProps, value: 'A' }} />)
           expect(wave.args[name]).toBe('A')
-    
+
           rerender(<XDropdown model={{ ...defaultProps }} />)
           expect(wave.args[name]).toBeNull()
         })
-    
+
         it('Displays new value when option is selected and "value" prop is updated', () => {
           const { getByRole, getByText, rerender } = render(<XDropdown model={defaultProps} />)
-    
+
           fireEvent.click(getByRole('combobox'))
           fireEvent.click(getByText('Choice A'))
           expect(getByRole('combobox')).toHaveTextContent('Choice A')
-    
+
           rerender(<XDropdown model={{ ...defaultProps, value: 'B' }} />)
           expect(getByRole('combobox')).toHaveTextContent('Choice B')
         })
 
         it('Sets wave args when an option is selected and "value" prop updated', () => {
-          const { getByRole, getByText, rerender } = render(<XDropdown model={{ ...defaultProps}} />)
+          const { getByRole, getByText, rerender } = render(<XDropdown model={{ ...defaultProps }} />)
           fireEvent.click(getByRole('combobox'))
           fireEvent.click(getByText('Choice A'))
           expect(getByRole('combobox')).toHaveTextContent('Choice A')
           expect(wave.args[name]).toBe('A')
-    
+
           rerender(<XDropdown model={{ ...defaultProps, value: 'B' }} />)
           expect(wave.args[name]).toBe('B')
         })
@@ -227,17 +227,17 @@ describe('Dropdown.tsx', () => {
         // For more info, read the comment in "onChange" function. 
         it('Sets wave args when same option is selected twice and "value" prop is updated', () => {
           const { getByRole, getAllByText, rerender } = render(<XDropdown model={{ ...defaultProps, value: 'A' }} />)
-          
+
           fireEvent.click(getByRole('combobox'))
           fireEvent.click(getAllByText('Choice C')[0])
           expect(getByRole('combobox')).toHaveTextContent('Choice C')
           expect(wave.args[name]).toEqual('C')
-    
+
           fireEvent.click(getByRole('combobox'))
           fireEvent.click(getAllByText('Choice C')[1])
           expect(getByRole('combobox')).toHaveTextContent('Choice C')
           expect(wave.args[name]).toEqual('C')
-    
+
           rerender(<XDropdown model={{ ...defaultProps, value: 'B' }} />)
           expect(wave.args[name]).toEqual('B')
         })
@@ -247,63 +247,49 @@ describe('Dropdown.tsx', () => {
         it('Displays new value when "values" prop is updated', () => {
           const { getByRole, rerender } = render(<XDropdown model={{ ...defaultProps, values: ['A'] }} />)
           expect(getByRole('combobox')).toHaveTextContent('Choice A')
-    
+
           rerender(<XDropdown model={{ ...defaultProps, values: ['B'] }} />)
           expect(getByRole('combobox')).toHaveTextContent('Choice B')
         })
 
         it('Sets wave args when "values" prop is updated', () => {
-          const { rerender } = render(<XDropdown model={{...defaultProps, values: ['A']}} />)
-          expect(wave.args[name]).toEqual(['A'])
-    
-          rerender(<XDropdown model={{ ...defaultProps, values: ['B'] }} />)
-          expect(wave.args[name]).toEqual(['B'])
-        })
-    
-        it('Displays new values when "values" prop is updated to array with 2 items', () => {
-          const { getByRole, rerender } = render(<XDropdown model={{ ...defaultProps, values: ['A'] }} />)
-          expect(getByRole('combobox')).toHaveTextContent('Choice A')
-    
-          rerender(<XDropdown model={{ ...defaultProps, values: ['B', 'C'] }} />)
-          expect(getByRole('combobox')).toHaveTextContent('Choice B, Choice C')
-        })
-    
-        it('Displays new value when option is selected and "values" prop is updated', () => {
-          const { getByRole, getByText, rerender } = render(<XDropdown model={defaultProps} />)
-    
-          fireEvent.click(getByRole('combobox'))
-          fireEvent.click(getByText('Choice A'))
-          expect(getByRole('combobox')).toHaveTextContent('Choice A')
-    
-          rerender(<XDropdown model={{ ...defaultProps, values: ['B', 'C'] }} />)
-          expect(getByRole('combobox')).toHaveTextContent('Choice B, Choice C')
-        })
-    
-        it('Sets wave args when option is selected and "values" prop is updated', () => {
-          const { getByRole, getByText, rerender } = render(<XDropdown model={{ ...defaultProps, values: []}} />)
-          fireEvent.click(getByRole('combobox'))
-          fireEvent.click(getByText('Choice A'))
-          expect(getByRole('combobox')).toHaveTextContent('Choice A')
-          expect(wave.args[name]).toEqual(['A'])
-    
-          rerender(<XDropdown model={{ ...defaultProps, values: ['B'] }} />)
-          expect(wave.args[name]).toEqual(['B'])
-        })
-
-        // Because two arrays with same content are not equal, we need to check if it sets Wave args only once and only if values are different
-        it('Sets wave args only when "values" is updated to different "values"', () => {
           const { rerender } = render(<XDropdown model={{ ...defaultProps, values: ['A'] }} />)
           expect(wave.args[name]).toEqual(['A'])
 
-          rerender(<XDropdown model={{ ...defaultProps, values: ['B', 'C'] }} />)
-          expect(wave.args[name]).toEqual(['B', 'C'])
-
-          // Simulates a button submit, wave.push clear the args
-          delete wave.args[name]
-
-          rerender(<XDropdown model={{ ...defaultProps, values: ['B', 'C'] }} />)
-          expect(wave.args[name]).toBeUndefined()
+          rerender(<XDropdown model={{ ...defaultProps, values: ['B'] }} />)
+          expect(wave.args[name]).toEqual(['B'])
         })
+
+        it('Displays new values when "values" prop is updated to array with 2 items', () => {
+          const { getByRole, rerender } = render(<XDropdown model={{ ...defaultProps, values: ['A'] }} />)
+          expect(getByRole('combobox')).toHaveTextContent('Choice A')
+
+          rerender(<XDropdown model={{ ...defaultProps, values: ['B', 'C'] }} />)
+          expect(getByRole('combobox')).toHaveTextContent('Choice B, Choice C')
+        })
+
+        it('Displays new value when option is selected and "values" prop is updated', () => {
+          const { getByRole, getByText, rerender } = render(<XDropdown model={defaultProps} />)
+
+          fireEvent.click(getByRole('combobox'))
+          fireEvent.click(getByText('Choice A'))
+          expect(getByRole('combobox')).toHaveTextContent('Choice A')
+
+          rerender(<XDropdown model={{ ...defaultProps, values: ['B', 'C'] }} />)
+          expect(getByRole('combobox')).toHaveTextContent('Choice B, Choice C')
+        })
+
+        it('Sets wave args when option is selected and "values" prop is updated', () => {
+          const { getByRole, getByText, rerender } = render(<XDropdown model={{ ...defaultProps, values: [] }} />)
+          fireEvent.click(getByRole('combobox'))
+          fireEvent.click(getByText('Choice A'))
+          expect(getByRole('combobox')).toHaveTextContent('Choice A')
+          expect(wave.args[name]).toEqual(['A'])
+
+          rerender(<XDropdown model={{ ...defaultProps, values: ['B'] }} />)
+          expect(wave.args[name]).toEqual(['B'])
+        })
+
       })
     })
   })
@@ -440,7 +426,7 @@ describe('Dropdown.tsx', () => {
 
       fireEvent.click(getByTestId(name))
 
-      expect(getAllByRole('checkbox', { checked: true})).toHaveLength(1)
+      expect(getAllByRole('checkbox', { checked: true })).toHaveLength(1)
     })
 
     it('Has correct number of checked checkboxes - check and cancel', () => {
@@ -475,7 +461,7 @@ describe('Dropdown.tsx', () => {
       const { getByTestId, getAllByRole } = render(<XDropdown model={{ ...dialogProps, values: [] }} />)
 
       fireEvent.click(getByTestId(name))
-      expect(getAllByRole('listitem')).toHaveLength(10) 
+      expect(getAllByRole('listitem')).toHaveLength(10)
       fireEvent.change(getByTestId(`${name}-search`), { target: { value: '9' } })
       expect(getAllByRole('listitem')).toHaveLength(1)
     })
@@ -485,7 +471,7 @@ describe('Dropdown.tsx', () => {
 
       fireEvent.click(getByTestId(name))
       // Only displays 40 options
-      expect(getAllByRole('listitem')).toHaveLength(40) 
+      expect(getAllByRole('listitem')).toHaveLength(40)
     })
 
     it('Shows correct number of selected items even during filtering', () => {
@@ -572,7 +558,7 @@ describe('Dropdown.tsx', () => {
     })
 
     it(`Does not displays dialog when choices > 100 and 'popup' prop is set as 'never'`, () => {
-      const { getByTestId, queryByRole } = render(<XDropdown model={{...dialogProps, choices: overOneHundredChoices, popup: 'never'}} />)
+      const { getByTestId, queryByRole } = render(<XDropdown model={{ ...dialogProps, choices: overOneHundredChoices, popup: 'never' }} />)
 
       fireEvent.click(getByTestId(name))
 
@@ -584,36 +570,36 @@ describe('Dropdown.tsx', () => {
         it('Displays new value when "value" prop is updated', () => {
           const { getByTestId, rerender } = render(<XDropdown model={{ ...dialogProps, popup: 'always', value: '1' }} />)
           expect(getByTestId(name)).toHaveValue('Choice 1')
-    
+
           rerender(<XDropdown model={{ ...dialogProps, value: '2' }} />)
           expect(getByTestId(name)).toHaveValue('Choice 2')
         })
-    
+
         it('Selects option and updates "value"', () => {
           const { getByTestId, getByText, rerender } = render(<XDropdown model={dialogProps} />)
-    
+
           fireEvent.click(getByTestId(name))
           fireEvent.click(getByText('Choice 1'))
           expect(getByTestId(name)).toHaveValue('Choice 1')
-    
+
           rerender(<XDropdown model={{ ...dialogProps, value: '2' }} />)
           expect(getByTestId(name)).toHaveValue('Choice 2')
         })
 
         it('Sets wave args when "value" prop changes', () => {
-          const { rerender } = render(<XDropdown model={{...dialogProps, value: 'A'}} />)
+          const { rerender } = render(<XDropdown model={{ ...dialogProps, value: 'A' }} />)
           expect(wave.args[name]).toBe('A')
-    
+
           rerender(<XDropdown model={{ ...dialogProps, value: 'B' }} />)
           expect(wave.args[name]).toBe('B')
         })
 
         it('Sets wave args when selecting a value and "value" prop changes', () => {
-          const { getByTestId, getByText, rerender } = render(<XDropdown model={{ ...dialogProps}} />)
+          const { getByTestId, getByText, rerender } = render(<XDropdown model={{ ...dialogProps }} />)
           fireEvent.click(getByTestId(name))
           fireEvent.click(getByText('Choice 1'))
           expect(wave.args[name]).toBe('1')
-    
+
           rerender(<XDropdown model={{ ...dialogProps, value: '2' }} />)
           expect(wave.args[name]).toBe('2')
         })
@@ -623,62 +609,47 @@ describe('Dropdown.tsx', () => {
         it('Displays new value when "values" prop is updated', () => {
           const { getByTestId, rerender } = render(<XDropdown model={{ ...dialogProps, values: ['1'] }} />)
           expect(getByTestId(name)).toHaveValue('Choice 1')
-    
+
           rerender(<XDropdown model={{ ...dialogProps, values: ['2'] }} />)
           expect(getByTestId(name)).toHaveValue('Choice 2')
         })
-    
+
         it('Displays new values when "values" prop is updated to array with 2 items', () => {
           const { getByTestId, rerender } = render(<XDropdown model={{ ...dialogProps, values: ['1'] }} />)
           expect(getByTestId(name)).toHaveValue('Choice 1')
-    
+
           rerender(<XDropdown model={{ ...dialogProps, values: ['2', '3'] }} />)
           expect(getByTestId(name)).toHaveValue('Choice 2, Choice 3')
         })
-    
+
         it('Displayes new values when option is selected and "values" prop is updated', () => {
           const { getByTestId, getByText, rerender } = render(<XDropdown model={dialogProps} />)
-    
+
           fireEvent.click(getByTestId(name))
           fireEvent.click(getByText('Choice 1'))
           expect(getByTestId(name)).toHaveValue('Choice 1')
-    
+
           rerender(<XDropdown model={{ ...dialogProps, values: ['2', '3'] }} />)
           expect(getByTestId(name)).toHaveValue('Choice 2, Choice 3')
         })
 
         it('Sets wave args when "values" prop is updated', () => {
-          const { rerender } = render(<XDropdown model={{...dialogProps, values: ['1']}} />)
+          const { rerender } = render(<XDropdown model={{ ...dialogProps, values: ['1'] }} />)
           expect(wave.args[name]).toEqual(['1'])
-    
+
           rerender(<XDropdown model={{ ...dialogProps, values: ['2'] }} />)
           expect(wave.args[name]).toEqual(['2'])
         })
 
         it('Sets wave args when option is selected and "values" prop is updated', () => {
-          const { getByTestId, getByText, rerender } = render(<XDropdown model={{ ...dialogProps, values: []}} />)
+          const { getByTestId, getByText, rerender } = render(<XDropdown model={{ ...dialogProps, values: [] }} />)
           fireEvent.click(getByTestId(name))
           fireEvent.click(getByText('Choice 1'))
           fireEvent.click(getByText('Select'))
           expect(wave.args[name]).toEqual(['1'])
-    
+
           rerender(<XDropdown model={{ ...dialogProps, values: ['2'] }} />)
           expect(wave.args[name]).toEqual(['2'])
-        })
-
-        // Because two arrays with same content are not equal, we need to check if it sets Wave args only once and only if values are different
-        it('Sets wave args only when "values" is updated to different "values"', () => {
-          const { rerender } = render(<XDropdown model={{ ...dialogProps, values: ['1'] }} />)
-          expect(wave.args[name]).toEqual(['1'])
-
-          rerender(<XDropdown model={{ ...dialogProps, values: ['2', '3'] }} />)
-          expect(wave.args[name]).toEqual(['2', '3'])
-
-          // Simulates a button submit, wave.push clear the args
-          delete wave.args[name]
-
-          rerender(<XDropdown model={{ ...dialogProps, values: ['2', '3'] }} />)
-          expect(wave.args[name]).toBeUndefined()
         })
 
         it('Display all selected values in input when "value" prop is update and select all is clicked', () => {
@@ -696,11 +667,11 @@ describe('Dropdown.tsx', () => {
         })
 
         it('Display all selected values in input when "value" prop is updated, searchbox is used, and select all is clicked', () => {
-          const choices = [{ name: 'aa', label: 'Choice aa'}, { name: 'ab', label: 'Choice ab'}, { name: 'c', label: 'Choice c'}]
+          const choices = [{ name: 'aa', label: 'Choice aa' }, { name: 'ab', label: 'Choice ab' }, { name: 'c', label: 'Choice c' }]
           const { getByRole, getByText, getByTestId, rerender } = render(<XDropdown model={{ ...dialogProps, values: ['1'], choices }} />)
           expect(wave.args[name]).toEqual(['1'])
 
-          rerender(<XDropdown model={{ ...dialogProps, values: ['2'] }} />)
+          rerender(<XDropdown model={{ ...dialogProps, values: ['2'], choices }} />)
           expect(wave.args[name]).toEqual(['2'])
 
           fireEvent.click(getByTestId(name))

--- a/ui/src/dropdown.test.tsx
+++ b/ui/src/dropdown.test.tsx
@@ -13,27 +13,31 @@
 // limitations under the License.
 
 import { fireEvent, render } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import React from 'react'
 import { Dropdown, XDropdown } from './dropdown'
 import { wave } from './ui'
 
-const
-  name = 'dropdown-test',
-  defaultProps: Dropdown = {
-    name,
-    label: name,
-    choices: [
-      { name: 'A', label: 'Choice A' },
-      { name: 'B', label: 'Choice B' },
-      { name: 'C', label: 'Choice C' },
-      { name: 'D', label: 'Choice D' },
-    ]
-  },
-  pushMock = jest.fn()
-
 describe('Dropdown.tsx', () => {
+  const
+    name = 'dropdown-test',
+    pushMock = jest.fn()
+
+  let defaultProps: Dropdown
   beforeAll(() => { wave.push = pushMock })
-  beforeEach(() => pushMock.mockReset())
+  beforeEach(() => {
+    // Because the component mutates props "value" and "values" it can affect the next test so we need to reset it for every test
+    defaultProps = {
+      name,
+      choices: [
+        { name: 'A', label: 'Choice A' },
+        { name: 'B', label: 'Choice B' },
+        { name: 'C', label: 'Choice C' },
+        { name: 'D', label: 'Choice D' },
+      ]
+    },
+    pushMock.mockReset()
+  })
 
   describe('Base dropdown', () => {
     it('Renders data-test attr', () => {
@@ -146,14 +150,178 @@ describe('Dropdown.tsx', () => {
       expect(wave.args[name]).toMatchObject([])
       expect(pushMock).toHaveBeenCalled()
     })
+    
+    describe('Prop changes', () => {
+      describe('Single-valued', () => {
+        it('Displays new value when "value" prop is updated', () => {
+          const { getByRole, rerender } = render(<XDropdown model={{ ...defaultProps, value: 'A' }} />)
+          expect(getByRole('combobox')).toHaveTextContent('Choice A')
+    
+          rerender(<XDropdown model={{ ...defaultProps, value: 'B' }} />)
+          expect(getByRole('combobox')).toHaveTextContent('Choice B')
+        })
+
+        it('Sets wave args when "value" prop is updated ', () => {
+          const { rerender } = render(<XDropdown model={{...defaultProps, value: 'A'}} />)
+          expect(wave.args[name]).toBe('A')
+    
+          rerender(<XDropdown model={{ ...defaultProps, value: 'B' }} />)
+          expect(wave.args[name]).toBe('B')
+        })
+  
+        it('Clears input when "value" prop is updated to empty string', () => {
+          const { getByRole, rerender } = render(<XDropdown model={{ ...defaultProps, value: 'A' }} />)
+          expect(getByRole('combobox').children[0]).toHaveTextContent('Choice A')
+    
+          rerender(<XDropdown model={{ ...defaultProps, value: '' }} />)
+          expect(getByRole('combobox').children[0]).toBeEmptyDOMElement()
+        })
+
+        it('Sets wave args to empty string when "value" prop is updated to an empty string', () => {
+          const { rerender } = render(<XDropdown model={{ ...defaultProps, value: 'A' }} />)
+          expect(wave.args[name]).toBe('A')
+    
+          rerender(<XDropdown model={{ ...defaultProps, value: '' }} />)
+          expect(wave.args[name]).toBe('')
+        })
+    
+        it('Clears input when "value" prop is updated to undefined (None)', () => {
+          const { getByRole, rerender } = render(<XDropdown model={{ ...defaultProps, value: 'A' }} />)
+          expect(getByRole('combobox').children[0]).toHaveTextContent('Choice A')
+    
+          rerender(<XDropdown model={{ ...defaultProps }} />)
+          expect(getByRole('combobox').children[0]).toBeEmptyDOMElement()
+        })
+
+        it('Sets wave args to null when "value" prop is updated to undefined (None)', () => {
+          const { rerender } = render(<XDropdown model={{ ...defaultProps, value: 'A' }} />)
+          expect(wave.args[name]).toBe('A')
+    
+          rerender(<XDropdown model={{ ...defaultProps }} />)
+          expect(wave.args[name]).toBeNull()
+        })
+    
+        it('Displays new value when option is selected and "value" prop is updated', () => {
+          const { getByRole, getByText, rerender } = render(<XDropdown model={defaultProps} />)
+    
+          fireEvent.click(getByRole('combobox'))
+          fireEvent.click(getByText('Choice A'))
+          expect(getByRole('combobox')).toHaveTextContent('Choice A')
+    
+          rerender(<XDropdown model={{ ...defaultProps, value: 'B' }} />)
+          expect(getByRole('combobox')).toHaveTextContent('Choice B')
+        })
+
+        it('Sets wave args when an option is selected and "value" prop updated', () => {
+          const { getByRole, getByText, rerender } = render(<XDropdown model={{ ...defaultProps}} />)
+          fireEvent.click(getByRole('combobox'))
+          fireEvent.click(getByText('Choice A'))
+          expect(getByRole('combobox')).toHaveTextContent('Choice A')
+          expect(wave.args[name]).toBe('A')
+    
+          rerender(<XDropdown model={{ ...defaultProps, value: 'B' }} />)
+          expect(wave.args[name]).toBe('B')
+        })
+
+        // Tests bug where user selects same option twice and "value" prop updates don't change dropdown value.
+        // For more info, read the comment in "onChange" function. 
+        it('Sets wave args when same option is selected twice and "value" prop is updated', () => {
+          const { getByRole, getAllByText, rerender } = render(<XDropdown model={{ ...defaultProps, value: 'A' }} />)
+          
+          fireEvent.click(getByRole('combobox'))
+          fireEvent.click(getAllByText('Choice C')[0])
+          expect(getByRole('combobox')).toHaveTextContent('Choice C')
+          expect(wave.args[name]).toEqual('C')
+    
+          fireEvent.click(getByRole('combobox'))
+          fireEvent.click(getAllByText('Choice C')[1])
+          expect(getByRole('combobox')).toHaveTextContent('Choice C')
+          expect(wave.args[name]).toEqual('C')
+    
+          rerender(<XDropdown model={{ ...defaultProps, value: 'B' }} />)
+          expect(wave.args[name]).toEqual('B')
+        })
+      })
+
+      describe('Multi-valued', () => {
+        it('Displays new value when "values" prop is updated', () => {
+          const { getByRole, rerender } = render(<XDropdown model={{ ...defaultProps, values: ['A'] }} />)
+          expect(getByRole('combobox')).toHaveTextContent('Choice A')
+    
+          rerender(<XDropdown model={{ ...defaultProps, values: ['B'] }} />)
+          expect(getByRole('combobox')).toHaveTextContent('Choice B')
+        })
+
+        it('Sets wave args when "values" prop is updated', () => {
+          const { rerender } = render(<XDropdown model={{...defaultProps, values: ['A']}} />)
+          expect(wave.args[name]).toEqual(['A'])
+    
+          rerender(<XDropdown model={{ ...defaultProps, values: ['B'] }} />)
+          expect(wave.args[name]).toEqual(['B'])
+        })
+    
+        it('Displays new values when "values" prop is updated to array with 2 items', () => {
+          const { getByRole, rerender } = render(<XDropdown model={{ ...defaultProps, values: ['A'] }} />)
+          expect(getByRole('combobox')).toHaveTextContent('Choice A')
+    
+          rerender(<XDropdown model={{ ...defaultProps, values: ['B', 'C'] }} />)
+          expect(getByRole('combobox')).toHaveTextContent('Choice B, Choice C')
+        })
+    
+        it('Displays new value when option is selected and "values" prop is updated', () => {
+          const { getByRole, getByText, rerender } = render(<XDropdown model={defaultProps} />)
+    
+          fireEvent.click(getByRole('combobox'))
+          fireEvent.click(getByText('Choice A'))
+          expect(getByRole('combobox')).toHaveTextContent('Choice A')
+    
+          rerender(<XDropdown model={{ ...defaultProps, values: ['B', 'C'] }} />)
+          expect(getByRole('combobox')).toHaveTextContent('Choice B, Choice C')
+        })
+    
+        it('Sets wave args when option is selected and "values" prop is updated', () => {
+          const { getByRole, getByText, rerender } = render(<XDropdown model={{ ...defaultProps, values: []}} />)
+          fireEvent.click(getByRole('combobox'))
+          fireEvent.click(getByText('Choice A'))
+          expect(getByRole('combobox')).toHaveTextContent('Choice A')
+          expect(wave.args[name]).toEqual(['A'])
+    
+          rerender(<XDropdown model={{ ...defaultProps, values: ['B'] }} />)
+          expect(wave.args[name]).toEqual(['B'])
+        })
+
+        // Because two arrays with same content are not equal, we need to check if it sets Wave args only once and only if values are different
+        it('Sets wave args only when "values" is updated to different "values"', () => {
+          const { rerender } = render(<XDropdown model={{ ...defaultProps, values: ['A'] }} />)
+          expect(wave.args[name]).toEqual(['A'])
+
+          rerender(<XDropdown model={{ ...defaultProps, values: ['B', 'C'] }} />)
+          expect(wave.args[name]).toEqual(['B', 'C'])
+
+          // Simulates a button submit, wave.push clear the args
+          delete wave.args[name]
+
+          rerender(<XDropdown model={{ ...defaultProps, values: ['B', 'C'] }} />)
+          expect(wave.args[name]).toBeUndefined()
+        })
+      })
+    })
   })
 
-
   describe('Dialog dropdown', () => {
-    const dialogProps: Dropdown = {
-      ...defaultProps,
-      choices: Array.from(Array(101).keys()).map(key => ({ name: String(key), label: `Choice ${key}` }))
-    }
+    let dialogProps: Dropdown
+
+    const createChoices = (size: number) => Array.from(Array(size).keys()).map(key => ({ name: String(key), label: `Choice ${key}` }))
+    const overOneHundredChoices = createChoices(101)
+    const choices = createChoices(10)
+
+    beforeEach(() => {
+      dialogProps = {
+        ...defaultProps,
+        popup: 'always',
+        choices
+      }
+    })
 
     it('Renders data-test attr', () => {
       const { queryByTestId } = render(<XDropdown model={dialogProps} />)
@@ -188,11 +356,11 @@ describe('Dropdown.tsx', () => {
       const { getByText, getByTestId, getAllByRole } = render(<XDropdown model={{ ...dialogProps, values: ['1'] }} />)
 
       fireEvent.click(getByTestId(name))
-      fireEvent.change(getByTestId(`${name}-search`), { target: { value: '22' } })
+      fireEvent.change(getByTestId(`${name}-search`), { target: { value: '9' } })
       fireEvent.click(getAllByRole('checkbox')[0])
       fireEvent.click(getByText('Select'))
 
-      expect(wave.args[name]).toMatchObject(['1', '22'])
+      expect(wave.args[name]).toMatchObject(['1', '9'])
     })
 
     it('Shows correct selection in UI - init single value', () => {
@@ -272,45 +440,52 @@ describe('Dropdown.tsx', () => {
 
       fireEvent.click(getByTestId(name))
 
-      expect(getAllByRole('checkbox').filter(i => (i as HTMLInputElement).checked)).toHaveLength(1)
+      expect(getAllByRole('checkbox', { checked: true})).toHaveLength(1)
     })
 
     it('Has correct number of checked checkboxes - check and cancel', () => {
-      const { getByText, getByTestId, getAllByRole } = render(<XDropdown model={{ ...dialogProps, values: [] }} />)
+      const { getByText, getByTestId, queryAllByRole } = render(<XDropdown model={{ ...dialogProps, values: [] }} />)
 
       fireEvent.click(getByTestId(name))
-      expect(getAllByRole('checkbox').filter(i => (i as HTMLInputElement).checked)).toHaveLength(0)
+      expect(queryAllByRole('checkbox', { checked: true })).toHaveLength(0)
 
-      fireEvent.click(getAllByRole('checkbox')[2])
-      fireEvent.click(getAllByRole('checkbox')[3])
-      fireEvent.click(getAllByRole('checkbox')[4])
+      fireEvent.click(getByText('Choice 3'))
+      fireEvent.click(getByText('Choice 4'))
+      fireEvent.click(getByText('Choice 5'))
       fireEvent.click(getByText('Cancel'))
       fireEvent.click(getByTestId(name))
 
-      expect(getAllByRole('checkbox').filter(i => (i as HTMLInputElement).checked)).toHaveLength(0)
+      expect(queryAllByRole('checkbox', { checked: true })).toHaveLength(0)
     })
 
     it('Has correct number of checked checkboxes - check and submit', () => {
       const { getByText, getByTestId, getAllByRole } = render(<XDropdown model={{ ...dialogProps, values: [] }} />)
 
       fireEvent.click(getByTestId(name))
-      fireEvent.click(getAllByRole('checkbox')[2])
-      fireEvent.click(getAllByRole('checkbox')[3])
-      fireEvent.click(getAllByRole('checkbox')[4])
+      fireEvent.click(getByText('Choice 3'))
+      fireEvent.click(getByText('Choice 4'))
+      fireEvent.click(getByText('Choice 5'))
       fireEvent.click(getByText('Select'))
       fireEvent.click(getByTestId(name))
 
-
-      expect(getAllByRole('checkbox').filter(i => (i as HTMLInputElement).checked)).toHaveLength(3)
+      expect(getAllByRole('checkbox', { checked: true })).toHaveLength(3)
     })
 
     it('Filters correctly', () => {
       const { getByTestId, getAllByRole } = render(<XDropdown model={{ ...dialogProps, values: [] }} />)
 
       fireEvent.click(getByTestId(name))
-      expect(getAllByRole('listitem')).toHaveLength(40) // Fluent Detaillist uses virtualization, so only first 40 listitems are rendered.
-      fireEvent.change(getByTestId(`${name}-search`), { target: { value: '22' } })
+      expect(getAllByRole('listitem')).toHaveLength(10) 
+      fireEvent.change(getByTestId(`${name}-search`), { target: { value: '9' } })
       expect(getAllByRole('listitem')).toHaveLength(1)
+    })
+
+    it('Virtualizes combobox when over 100 choices', () => {
+      const { getByTestId, getAllByRole } = render(<XDropdown model={{ ...dialogProps, values: [], choices: overOneHundredChoices }} />)
+
+      fireEvent.click(getByTestId(name))
+      // Only displays 40 options
+      expect(getAllByRole('listitem')).toHaveLength(40) 
     })
 
     it('Shows correct number of selected items even during filtering', () => {
@@ -320,7 +495,7 @@ describe('Dropdown.tsx', () => {
       expect(getByText('Selected: 0')).toBeInTheDocument()
       fireEvent.click(getAllByRole('checkbox')[2])
       expect(getByText('Selected: 1')).toBeInTheDocument()
-      fireEvent.change(getByTestId(`${name}-search`), { target: { value: '22' } })
+      fireEvent.change(getByTestId(`${name}-search`), { target: { value: '9' } })
       expect(getByText('Selected: 1')).toBeInTheDocument()
     })
 
@@ -328,52 +503,52 @@ describe('Dropdown.tsx', () => {
       const { getByTestId, getAllByRole } = render(<XDropdown model={{ ...dialogProps, values: [] }} />)
 
       fireEvent.click(getByTestId(name))
-      expect(getAllByRole('listitem')).toHaveLength(40) // Fluent Detaillist uses virtualization, so only first 40 listitems are rendered.
-      fireEvent.change(getByTestId(`${name}-search`), { target: { value: '22' } })
+      expect(getAllByRole('listitem')).toHaveLength(10)
+      fireEvent.change(getByTestId(`${name}-search`), { target: { value: '9' } })
       expect(getAllByRole('listitem')).toHaveLength(1)
 
       fireEvent.change(getByTestId(`${name}-search`), { target: { value: '' } })
-      expect(getAllByRole('listitem')).toHaveLength(40) // Fluent Detaillist uses virtualization, so only first 40 listitems are rendered.
+      expect(getAllByRole('listitem')).toHaveLength(10)
     })
 
     it('Resets filtered items on cancel', () => {
       const { getByTestId, getAllByRole, getByText } = render(<XDropdown model={{ ...dialogProps, values: [] }} />)
 
       fireEvent.click(getByTestId(name))
-      expect(getAllByRole('listitem')).toHaveLength(40) // Fluent Detaillist uses virtualization, so only first 40 listitems are rendered.
-      fireEvent.change(getByTestId(`${name}-search`), { target: { value: '22' } })
+      expect(getAllByRole('listitem')).toHaveLength(10)
+      fireEvent.change(getByTestId(`${name}-search`), { target: { value: '9' } })
       expect(getAllByRole('listitem')).toHaveLength(1)
       fireEvent.click(getByText('Cancel'))
       fireEvent.click(getByTestId(name))
-      expect(getAllByRole('listitem')).toHaveLength(40) // Fluent Detaillist uses virtualization, so only first 40 listitems are rendered.
+      expect(getAllByRole('listitem')).toHaveLength(10)
     })
 
     it('Resets filtered items on submit', () => {
       const { getByTestId, getAllByRole, getByText } = render(<XDropdown model={{ ...dialogProps, values: [] }} />)
 
       fireEvent.click(getByTestId(name))
-      expect(getAllByRole('listitem')).toHaveLength(40) // Fluent Detaillist uses virtualization, so only first 40 listitems are rendered.
-      fireEvent.change(getByTestId(`${name}-search`), { target: { value: '22' } })
+      expect(getAllByRole('listitem')).toHaveLength(10)
+      fireEvent.change(getByTestId(`${name}-search`), { target: { value: '9' } })
       expect(getAllByRole('listitem')).toHaveLength(1)
       fireEvent.click(getByText('Select'))
       fireEvent.click(getByTestId(name))
-      expect(getAllByRole('listitem')).toHaveLength(40) // Fluent Detaillist uses virtualization, so only first 40 listitems are rendered.
+      expect(getAllByRole('listitem')).toHaveLength(10)
     })
 
     it('Resets filtered items on single valued submit', () => {
       const { getByTestId, getAllByRole } = render(<XDropdown model={dialogProps} />)
 
       fireEvent.click(getByTestId(name))
-      expect(getAllByRole('listitem')).toHaveLength(40) // Fluent Detaillist uses virtualization, so only first 40 listitems are rendered.
-      fireEvent.change(getByTestId(`${name}-search`), { target: { value: '22' } })
+      expect(getAllByRole('listitem')).toHaveLength(10)
+      fireEvent.change(getByTestId(`${name}-search`), { target: { value: '9' } })
       expect(getAllByRole('listitem')).toHaveLength(1)
       fireEvent.click(getAllByRole('checkbox')[0])
       fireEvent.click(getByTestId(name))
-      expect(getAllByRole('listitem')).toHaveLength(40) // Fluent Detaillist uses virtualization, so only first 40 listitems are rendered.
+      expect(getAllByRole('listitem')).toHaveLength(10)
     })
 
     it(`Displays dialog when choices > 100 and 'popup' prop is not provided`, () => {
-      const { getByTestId, queryByRole } = render(<XDropdown model={dialogProps} />)
+      const { getByTestId, queryByRole } = render(<XDropdown model={{ ...dialogProps, popup: undefined, choices: overOneHundredChoices }} />)
 
       expect(queryByRole('dialog')).not.toBeInTheDocument()
       fireEvent.click(getByTestId(name))
@@ -381,7 +556,7 @@ describe('Dropdown.tsx', () => {
     })
 
     it(`Displays dialog when choices > 100 and 'popup' prop is set as 'auto'`, () => {
-      const { getByTestId, queryByRole } = render(<XDropdown model={dialogProps} />)
+      const { getByTestId, queryByRole } = render(<XDropdown model={{ ...dialogProps, choices: overOneHundredChoices, popup: 'auto' }} />)
 
       expect(queryByRole('dialog')).not.toBeInTheDocument()
       fireEvent.click(getByTestId(name))
@@ -389,8 +564,6 @@ describe('Dropdown.tsx', () => {
     })
 
     it(`Displays dialog when choices < 100 and 'popup' prop is set as 'always'`, () => {
-      dialogProps.popup = 'always'
-      dialogProps.choices = [{ name: 'A' }]
       const { getByTestId, queryByRole } = render(<XDropdown model={dialogProps} />)
 
       expect(queryByRole('dialog')).not.toBeInTheDocument()
@@ -399,12 +572,145 @@ describe('Dropdown.tsx', () => {
     })
 
     it(`Does not displays dialog when choices > 100 and 'popup' prop is set as 'never'`, () => {
-      dialogProps.popup = 'never'
-      const { getByTestId, queryByRole } = render(<XDropdown model={dialogProps} />)
+      const { getByTestId, queryByRole } = render(<XDropdown model={{...dialogProps, choices: overOneHundredChoices, popup: 'never'}} />)
 
       fireEvent.click(getByTestId(name))
 
       expect(queryByRole('dialog')).not.toBeInTheDocument()
+    })
+
+    describe('Props changes', () => {
+      describe('Single-valued', () => {
+        it('Displays new value when "value" prop is updated', () => {
+          const { getByTestId, rerender } = render(<XDropdown model={{ ...dialogProps, popup: 'always', value: '1' }} />)
+          expect(getByTestId(name)).toHaveValue('Choice 1')
+    
+          rerender(<XDropdown model={{ ...dialogProps, value: '2' }} />)
+          expect(getByTestId(name)).toHaveValue('Choice 2')
+        })
+    
+        it('Selects option and updates "value"', () => {
+          const { getByTestId, getByText, rerender } = render(<XDropdown model={dialogProps} />)
+    
+          fireEvent.click(getByTestId(name))
+          fireEvent.click(getByText('Choice 1'))
+          expect(getByTestId(name)).toHaveValue('Choice 1')
+    
+          rerender(<XDropdown model={{ ...dialogProps, value: '2' }} />)
+          expect(getByTestId(name)).toHaveValue('Choice 2')
+        })
+
+        it('Sets wave args when "value" prop changes', () => {
+          const { rerender } = render(<XDropdown model={{...dialogProps, value: 'A'}} />)
+          expect(wave.args[name]).toBe('A')
+    
+          rerender(<XDropdown model={{ ...dialogProps, value: 'B' }} />)
+          expect(wave.args[name]).toBe('B')
+        })
+
+        it('Sets wave args when selecting a value and "value" prop changes', () => {
+          const { getByTestId, getByText, rerender } = render(<XDropdown model={{ ...dialogProps}} />)
+          fireEvent.click(getByTestId(name))
+          fireEvent.click(getByText('Choice 1'))
+          expect(wave.args[name]).toBe('1')
+    
+          rerender(<XDropdown model={{ ...dialogProps, value: '2' }} />)
+          expect(wave.args[name]).toBe('2')
+        })
+      })
+
+      describe('Multi-valued', () => {
+        it('Displays new value when "values" prop is updated', () => {
+          const { getByTestId, rerender } = render(<XDropdown model={{ ...dialogProps, values: ['1'] }} />)
+          expect(getByTestId(name)).toHaveValue('Choice 1')
+    
+          rerender(<XDropdown model={{ ...dialogProps, values: ['2'] }} />)
+          expect(getByTestId(name)).toHaveValue('Choice 2')
+        })
+    
+        it('Displays new values when "values" prop is updated to array with 2 items', () => {
+          const { getByTestId, rerender } = render(<XDropdown model={{ ...dialogProps, values: ['1'] }} />)
+          expect(getByTestId(name)).toHaveValue('Choice 1')
+    
+          rerender(<XDropdown model={{ ...dialogProps, values: ['2', '3'] }} />)
+          expect(getByTestId(name)).toHaveValue('Choice 2, Choice 3')
+        })
+    
+        it('Displayes new values when option is selected and "values" prop is updated', () => {
+          const { getByTestId, getByText, rerender } = render(<XDropdown model={dialogProps} />)
+    
+          fireEvent.click(getByTestId(name))
+          fireEvent.click(getByText('Choice 1'))
+          expect(getByTestId(name)).toHaveValue('Choice 1')
+    
+          rerender(<XDropdown model={{ ...dialogProps, values: ['2', '3'] }} />)
+          expect(getByTestId(name)).toHaveValue('Choice 2, Choice 3')
+        })
+
+        it('Sets wave args when "values" prop is updated', () => {
+          const { rerender } = render(<XDropdown model={{...dialogProps, values: ['1']}} />)
+          expect(wave.args[name]).toEqual(['1'])
+    
+          rerender(<XDropdown model={{ ...dialogProps, values: ['2'] }} />)
+          expect(wave.args[name]).toEqual(['2'])
+        })
+
+        it('Sets wave args when option is selected and "values" prop is updated', () => {
+          const { getByTestId, getByText, rerender } = render(<XDropdown model={{ ...dialogProps, values: []}} />)
+          fireEvent.click(getByTestId(name))
+          fireEvent.click(getByText('Choice 1'))
+          fireEvent.click(getByText('Select'))
+          expect(wave.args[name]).toEqual(['1'])
+    
+          rerender(<XDropdown model={{ ...dialogProps, values: ['2'] }} />)
+          expect(wave.args[name]).toEqual(['2'])
+        })
+
+        // Because two arrays with same content are not equal, we need to check if it sets Wave args only once and only if values are different
+        it('Sets wave args only when "values" is updated to different "values"', () => {
+          const { rerender } = render(<XDropdown model={{ ...dialogProps, values: ['1'] }} />)
+          expect(wave.args[name]).toEqual(['1'])
+
+          rerender(<XDropdown model={{ ...dialogProps, values: ['2', '3'] }} />)
+          expect(wave.args[name]).toEqual(['2', '3'])
+
+          // Simulates a button submit, wave.push clear the args
+          delete wave.args[name]
+
+          rerender(<XDropdown model={{ ...dialogProps, values: ['2', '3'] }} />)
+          expect(wave.args[name]).toBeUndefined()
+        })
+
+        it('Display all selected values in input when "value" prop is update and select all is clicked', () => {
+          const { getByText, getByTestId, rerender } = render(<XDropdown model={{ ...dialogProps, values: ['1'] }} />)
+          expect(wave.args[name]).toEqual(['1'])
+
+          rerender(<XDropdown model={{ ...dialogProps, values: ['2'] }} />)
+          expect(wave.args[name]).toEqual(['2'])
+
+          fireEvent.click(getByTestId(name))
+          fireEvent.click(getByText('Select All'))
+          fireEvent.click(getByText('Select'))
+
+          expect(getByTestId(name)).toHaveValue(choices.map(c => c.label).join(', '))
+        })
+
+        it('Display all selected values in input when "value" prop is updated, searchbox is used, and select all is clicked', () => {
+          const choices = [{ name: 'aa', label: 'Choice aa'}, { name: 'ab', label: 'Choice ab'}, { name: 'c', label: 'Choice c'}]
+          const { getByRole, getByText, getByTestId, rerender } = render(<XDropdown model={{ ...dialogProps, values: ['1'], choices }} />)
+          expect(wave.args[name]).toEqual(['1'])
+
+          rerender(<XDropdown model={{ ...dialogProps, values: ['2'] }} />)
+          expect(wave.args[name]).toEqual(['2'])
+
+          fireEvent.click(getByTestId(name))
+          userEvent.type(getByRole('searchbox'), 'a')
+          fireEvent.click(getByText('Select All'))
+          fireEvent.click(getByText('Select'))
+
+          expect(getByTestId(name)).toHaveValue('Choice aa, Choice ab')
+        })
+      })
     })
   })
 })

--- a/ui/src/dropdown.tsx
+++ b/ui/src/dropdown.tsx
@@ -133,13 +133,13 @@ const
       if (!isMultivalued) return
       setMultiValues(values || [])
       wave.args[name] = values ?? null
-    }, [name, values])
+    }, [name, values, isMultivalued])
 
     React.useEffect(() => {
       if (isMultivalued) return
       setSingleValue(value || '')
       wave.args[name] = value ?? null
-    }, [name, value])
+    }, [name, value, isMultivalued])
 
     return (
       <>
@@ -246,17 +246,17 @@ const
     const
       [isDialogHidden, setIsDialogHidden] = React.useState(true),
       [items, setItems, onSearchChange] = useItems(choices, values),
-      auxItems = React.useRef([...items]),
+      itemsBackup = React.useRef([...items]),
       openDialog = () => {
         setIsDialogHidden(false)
-        auxItems.current = [...items]
+        itemsBackup.current = [...items]
       },
       closeDialog = () => {
         setItems(items => items.map(i => ({ ...i, show: true })))
         setIsDialogHidden(true)
       },
       cancelDialog = () => {
-        setItems(auxItems.current)
+        setItems(itemsBackup.current)
         closeDialog()
       },
       submit = (items: DropdownItem[]) => {

--- a/ui/src/dropdown.tsx
+++ b/ui/src/dropdown.tsx
@@ -81,16 +81,13 @@ const
       marginTop: 16
     }
   }),
-  BaseDropdown = ({ model: m}: { model: Dropdown}) => {
-  const
-      { name, label, required, disabled, choices, trigger, placeholder } = m,
-      isMultivalued = !!m.values,
-      [stateValue, setStateValue] = React.useState(m.value ?? null),
-      selection = React.useMemo(() => isMultivalued ? new Set<S>(m.values) : null, [isMultivalued, m.values]),
-      [selectedOptions, setSelectedOptions] = React.useState(Array.from(selection || [])),
+  BaseDropdown = ({ name, label, required, disabled, value, values, choices, trigger, placeholder }: Dropdown) => {
+    const
+      isMultivalued = !!values,
+      selection = React.useMemo(() => isMultivalued ? new Set<S>(values) : null, [isMultivalued, values]),
+      [singleValue, setSingleValue] = React.useState(value),
+      [multiValues, setMultiValues] = React.useState(values),
       options = (choices || []).map(({ name, label, disabled }): Fluent.IDropdownOption => ({ key: name, text: label || name, disabled })),
-      previousValues = React.useRef<S[] | undefined>(),
-      skipUseEffect = React.useRef(false),
       onChange = (_e?: React.FormEvent<HTMLElement>, option?: Fluent.IDropdownOption) => {
         if (option) {
           const optionKey = option.key as S
@@ -98,18 +95,10 @@ const
             option.selected ? selection.add(optionKey) : selection.delete(optionKey)
 
             const selectedOpts = Array.from(selection)
-            previousValues.current = selectedOpts
             wave.args[name] = selectedOpts
-            setSelectedOptions(selectedOpts)
+            setMultiValues(selectedOpts)
           } else {
-            setStateValue(optionKey)
-            // HACK: The useEffect is only triggered if the above setter sets a different value and "m.value" changed.
-            // The next line does two things: 
-            // 1. Skip the useEffect so that it doesn't set wave args to same value if trigger is provided
-            // 2. m.value !== optionKey prevents the bug where user selects the same value twice and then the wave app tries to change the "value" prop
-            // e.g. choices = ['a', 'b', 'c'], selects 'c', selects 'c', wave app changes "value" to 'b'
-            skipUseEffect.current = m.value !== optionKey
-            m.value = optionKey
+            setSingleValue(optionKey)
             wave.args[name] = optionKey
           }
         }
@@ -122,41 +111,30 @@ const
         options.forEach(o => { if (!o.disabled) selection.add(o.key as S) })
 
         const selectionArr = Array.from(selection)
-        setSelectedOptions(selectionArr)
-        previousValues.current = selectionArr
+        setMultiValues(selectionArr)
         wave.args[name] = selectionArr
 
-        if (trigger) wave.push()
+        onChange()
       },
       deselectAll = () => {
         if (!selection) return
 
         selection.clear()
-        setSelectedOptions([])
-        previousValues.current = []
+        setMultiValues([])
         wave.args[name] = []
 
-        if (trigger) wave.push()
+        onChange()
       }
 
     React.useEffect(() => {
-      if (!isMultivalued && !skipUseEffect.current) {
-        setStateValue(m.value ?? null)
-        wave.args[name] = m.value ?? null
-      }
-      skipUseEffect.current = false
-    }, [m.value, isMultivalued, name])
+      setMultiValues(values || [])
+      wave.args[name] = values ?? null
+    }, [name, values])
 
-    // Since "m.values" is an array, every time it's set from Wave App we create a new array reference and the useEffect bellow is triggered.
-    // Because of that we don't have to use the hack where "m.values" is set in "onChange" like we do for "m.value".
     React.useEffect(() => {
-      if (isMultivalued ) {
-        setSelectedOptions(Array.from(m.values || []))
-        const isDifferent = previousValues.current?.toString() !== m.values?.toString()
-        if (isDifferent) wave.args[name] = m.values ?? []
-        previousValues.current = m.values
-      }
-    }, [m.values, isMultivalued, name])
+      setSingleValue(value || '')
+      wave.args[name] = value ?? null
+    }, [name, value])
 
     return (
       <>
@@ -169,8 +147,8 @@ const
           required={required}
           disabled={disabled}
           multiSelect={isMultivalued || undefined}
-          selectedKey={!isMultivalued ? stateValue : undefined}
-          selectedKeys={isMultivalued ? selectedOptions : undefined}
+          selectedKey={!isMultivalued ? singleValue : undefined}
+          selectedKeys={isMultivalued ? multiValues : undefined}
           onChange={onChange}
         />
         {
@@ -186,70 +164,55 @@ const
   },
   ROW_HEIGHT = 44,
   PAGE_SIZE = 40,
-  DialogDropdown = ({ model: m}: { model: Dropdown}) => {
+  DialogDropdown = ({ name, choices, values, value, disabled, required, trigger, placeholder, label }: Dropdown) => {
     const
-      { name, choices = [], disabled, required, trigger, placeholder, label } = m,
-      isMultivalued = !!m.values,
+      isMultivalued = !!values,
       [isDialogHidden, setIsDialogHidden] = React.useState(true),
-      [searchValue, setSearchValue] = React.useState(''),
-      selectedMap = React.useMemo<Map<S, B>>(() => {
-        if (m.values?.length) return new Map(m.values.map(v => [v, true]))
-        if (m.value) return new Map([[m.value, true]])
+      initialSelectedMap = React.useMemo(() => {
+        if (values?.length) return new Map(values.map(v => [v, true]))
+        if (value) return new Map([[value, true]])
         return new Map()
-      }, [m.value, m.values]),
-      [items, setItems] = React.useState<DropdownItem[]>(choices.map(({ name, label }, idx) => ({ name, text: label || name, idx, checked: selectedMap.has(name) })) || []),
+      }, [value, values]),
+      items = React.useMemo<DropdownItem[]>(() => choices?.map(({ name, label }, idx) => ({ name, text: label || name, idx, checked: initialSelectedMap.has(name) })) || [], [initialSelectedMap, choices]),
       [filteredItems, setFilteredItems] = React.useState(items),
-      previousValues = React.useRef<S[] | undefined>(),
       [textValue, setTextValue] = React.useState(() => {
-        if (!m.values?.length && !m.value) return
+        if (!values?.length && !value) return
 
         const itemsMap = new Map<S, S>(items.map(({ name, text }) => [name, text]))
 
-        if (m.values?.length) return m.values.map(v => itemsMap.get(v) || '').filter(Boolean).join(', ')
-        if (m.value) return itemsMap.get(m.value)
+        if (values?.length) return values.map(v => itemsMap.get(v) || '').filter(Boolean).join(', ')
+        if (value) return itemsMap.get(value)
       }),
       toggleDialog = React.useCallback(() => setIsDialogHidden(!isDialogHidden), [isDialogHidden]),
       cancelDialog = React.useCallback(() => {
         toggleDialog()
-        setItems(items => items.map(i => ({ ...i, checked: selectedMap.has(i.name) })))
-        setSearchValue('')
-      }, [selectedMap, toggleDialog]),
-      skipUseEffect = React.useRef(false),
+        setFilteredItems(items.map(i => { i.checked = initialSelectedMap.has(i.name); return i }))
+      }, [initialSelectedMap, items, toggleDialog]),
       submit = React.useCallback((checkedItem?: DropdownItem) => {
         const result = checkedItem ? [checkedItem] : items.filter(({ checked }) => checked)
-        wave.args[name] = result.length === 1 ? isMultivalued ? [result[0].name] : result[0].name : result.map(({ name }) => name)
+        wave.args[name] = isMultivalued ? result.map(({ name }) => name) : result[0].name
 
-        if (!isMultivalued) {
-          m.value = result[0].name
-          skipUseEffect.current = true
-        }
         if (trigger) wave.push()
         setTextValue(result.length ? result.map(({ text }) => text).join(', ') : '')
-        selectedMap.clear()
-        result.forEach(({ name }) => selectedMap.set(name, true))
+        initialSelectedMap.clear()
+        result.forEach(({ name }) => initialSelectedMap.set(name, true))
         cancelDialog()
-      }, [cancelDialog, selectedMap, items, name, trigger, m, isMultivalued]),
+      }, [cancelDialog, initialSelectedMap, isMultivalued, items, name, trigger]),
       selectAll = (checked = true) => () => {
-          setItems(items => {
-            const newItems = items.map(i => ({
-              ...i,
-              // In order to select only the filtered values we could use "filteredItems.map(f => f.name).includes(i.name)" but that would be O(n^2)
-              checked: fuzzysearch(i.text, searchValue) ? checked : i.checked
-            }))
-            previousValues.current = newItems.filter(i => i.checked).map(i => i.name)
-            return newItems
-          })
+        const checkedFilteredItems = filteredItems.map(i => { i.checked = checked; return i })
+        const checkedMap = new Map(checkedFilteredItems.map(i => [i.name, i.checked]))
+        setFilteredItems(checkedFilteredItems)
+        items.forEach(i => { if (checkedMap.has(i.name)) i.checked = checkedMap.get(i.name)! })
+        setTextValue(choices?.map(c => c.label).join(', '))
       },
-      onSearchChange = (_e?: React.ChangeEvent<HTMLInputElement>, newVal = '') => setSearchValue(newVal),
+      onSearchChange = (_e?: React.ChangeEvent<HTMLInputElement>, newVal = '') => setFilteredItems(newVal ? items.filter(({ text }) => fuzzysearch(text, newVal)) : items),
       onChecked = React.useCallback((idx: U) => (_ev?: React.FormEvent<HTMLElement | HTMLInputElement>, checked = false) => {
         items[idx].checked = checked
 
-        previousValues.current = items.filter(i => i.checked).map(i => i.name)
-
         isMultivalued
-          ? setItems(items => items.map(i => ({ ...i, checked: items[idx].name === i.name ? checked : i.checked}) ))
+          ? setFilteredItems(filteredItems.map(i => { if (items[idx].name === i.name) i.checked = checked; return i }))
           : submit(items[idx])
-      }, [isMultivalued, items, submit]),
+      }, [filteredItems, isMultivalued, items, submit]),
       onRenderCell = React.useCallback((item?: DropdownItem) => item
         ? <Fluent.Checkbox
           label={item.text}
@@ -265,33 +228,18 @@ const
       getPageSpecification = React.useCallback(() => ({ itemCount: PAGE_SIZE, height: ROW_HEIGHT * PAGE_SIZE, } as Fluent.IPageSpecification), [])
 
     React.useEffect(() => {
-      if (!isMultivalued && !skipUseEffect.current) {
-        setTextValue(new Map<S, S>(items.map(({ name, text }) => [name, text])).get(m.value || ''))
-        setItems(items => items.map(i => ({ ...i, checked: i.name === m.value })))
-        wave.args[name] = m.value ?? null
+      let textVal = ''
+      if (isMultivalued) {
+        const valuesMap = new Map(values.map(v => [v, true]))
+        textVal = items?.filter(i => valuesMap.has(i.name)).map(i => i.text).join(', ') || ''
+      } else {
+        textVal = items?.find(i => i.name === value)?.text || ''
       }
-      skipUseEffect.current = false
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [name, m.value])
+      setTextValue(textVal)
+    }, [isMultivalued, items, value, values])
 
-    React.useEffect(() => {
-      if (!isMultivalued) return
-
-      setItems(items => {
-        const newItems = items.map(i => ({ ...i, checked: m.values?.includes(i.name) ?? false }))
-        setTextValue(newItems.filter(i => i.checked).map(i => i.text).join(', '))
-        return newItems
-      })
-      const isDifferent = previousValues.current?.toString() !== m.values?.toString()
-      if (isDifferent) wave.args[name] = m.values ?? []
-      previousValues.current = m.values
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [name, m.values])
-
-    // sync filtered items
-    React.useEffect(() => {
-      setFilteredItems(searchValue ? items.filter(({ text }) => fuzzysearch(text, searchValue)) : items)
-    }, [items, searchValue])
+    React.useEffect(() => { if (values) wave.args[name] = values ?? null }, [name, values])
+    React.useEffect(() => { if (value !== undefined) wave.args[name] = value ?? null }, [name, value])
 
     return (
       <>
@@ -341,11 +289,14 @@ const
   }
 
 export const XDropdown = ({ model: m }: { model: Dropdown }) => {
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  React.useEffect(() => { wave.args[m.name] = m.values ? (m.values || []) : (m.value || null) }, [])
+
   return m.popup === 'always'
-    ? <DialogDropdown model={m} />
+    ? <DialogDropdown {...m} />
     : m.popup === 'never'
-      ? <BaseDropdown model={m} />
+      ? <BaseDropdown {...m} />
       : (m.choices?.length || 0) > 100
-        ? <DialogDropdown model={m} />
-        : <BaseDropdown model={m} />
+        ? <DialogDropdown {...m} />
+        : <BaseDropdown {...m} />
 }

--- a/ui/src/dropdown.tsx
+++ b/ui/src/dropdown.tsx
@@ -68,6 +68,7 @@ type DropdownItem = {
   text: S
   idx: U
   checked: B
+  show: B
 }
 
 const
@@ -81,8 +82,9 @@ const
       marginTop: 16
     }
   }),
-  BaseDropdown = ({ name, label, required, disabled, value, values, choices, trigger, placeholder }: Dropdown) => {
+  BaseDropdown = ({ model: m }: { model: Dropdown }) => {
     const
+      { name, label, required, disabled, value, values, choices, trigger, placeholder } = m,
       isMultivalued = !!values,
       selection = React.useMemo(() => isMultivalued ? new Set<S>(values) : null, [isMultivalued, values]),
       [singleValue, setSingleValue] = React.useState(value),
@@ -100,6 +102,7 @@ const
           } else {
             setSingleValue(optionKey)
             wave.args[name] = optionKey
+            m.value = optionKey
           }
         }
         if (trigger) wave.push()
@@ -127,11 +130,13 @@ const
       }
 
     React.useEffect(() => {
+      if (!isMultivalued) return
       setMultiValues(values || [])
       wave.args[name] = values ?? null
     }, [name, values])
 
     React.useEffect(() => {
+      if (isMultivalued) return
       setSingleValue(value || '')
       wave.args[name] = value ?? null
     }, [name, value])
@@ -164,82 +169,114 @@ const
   },
   ROW_HEIGHT = 44,
   PAGE_SIZE = 40,
-  DialogDropdown = ({ name, choices, values, value, disabled, required, trigger, placeholder, label }: Dropdown) => {
+  getPageSpecification = () => ({ itemCount: PAGE_SIZE, height: ROW_HEIGHT * PAGE_SIZE } as Fluent.IPageSpecification),
+  useItems = (choices: Choice[], v?: S | S[]) => {
     const
-      isMultivalued = !!values,
+      [items, setItems] = React.useState<DropdownItem[]>(choices.map(({ name, label }, idx) =>
+        ({ name, text: label || name, idx, checked: Array.isArray(v) ? v.includes(name) : v === name, show: true }))),
+      onSearchChange = (_e?: React.ChangeEvent<HTMLInputElement>, newVal = '') => setItems(items => items.map(i => ({ ...i, show: fuzzysearch(i.text, newVal) })))
+    
+    return [items, setItems, onSearchChange] as const
+  },
+  onRenderCell = (onChecked: any) => (item?: DropdownItem) => item
+    ? <Fluent.Checkbox
+      label={item.text}
+      styles={{
+        root: { minHeight: ROW_HEIGHT, alignItems: 'center' },
+        label: { width: pc(100), padding: 12, wordBreak: 'break-word' },
+        checkmark: { display: 'flex' }
+      }}
+      onChange={onChecked(item.name)}
+      className={item.checked ? css.dialogCheckedRow : ''}
+      checked={item.checked} />
+      : null,
+
+  DialogDropdownSingle = ({ model }: { model: Dropdown}) => {
+    const
+      { name, choices = [], disabled, required, trigger, placeholder, label } = model,
       [isDialogHidden, setIsDialogHidden] = React.useState(true),
-      initialSelectedMap = React.useMemo(() => {
-        if (values?.length) return new Map(values.map(v => [v, true]))
-        if (value) return new Map([[value, true]])
-        return new Map()
-      }, [value, values]),
-      items = React.useMemo<DropdownItem[]>(() => choices?.map(({ name, label }, idx) => ({ name, text: label || name, idx, checked: initialSelectedMap.has(name) })) || [], [initialSelectedMap, choices]),
-      [filteredItems, setFilteredItems] = React.useState(items),
-      [textValue, setTextValue] = React.useState(() => {
-        if (!values?.length && !value) return
-
-        const itemsMap = new Map<S, S>(items.map(({ name, text }) => [name, text]))
-
-        if (values?.length) return values.map(v => itemsMap.get(v) || '').filter(Boolean).join(', ')
-        if (value) return itemsMap.get(value)
-      }),
-      toggleDialog = React.useCallback(() => setIsDialogHidden(!isDialogHidden), [isDialogHidden]),
-      cancelDialog = React.useCallback(() => {
-        toggleDialog()
-        setFilteredItems(items.map(i => { i.checked = initialSelectedMap.has(i.name); return i }))
-      }, [initialSelectedMap, items, toggleDialog]),
-      submit = React.useCallback((checkedItem?: DropdownItem) => {
-        const result = checkedItem ? [checkedItem] : items.filter(({ checked }) => checked)
-        wave.args[name] = isMultivalued ? result.map(({ name }) => name) : result[0].name
-
+      [items, setItems, onSearchChange] = useItems(choices, model.value),
+      toggleDialog = () => setIsDialogHidden(v => !v),
+      onChecked = (itemName: S) => (_ev?: React.FormEvent<HTMLElement | HTMLInputElement>, checked = false) => {
+        setItems(items => items.map(item => (({...item, checked: item.name === itemName ? checked : false, show: true}))))
+        wave.args[name] = itemName
+        model.value = itemName
         if (trigger) wave.push()
-        setTextValue(result.length ? result.map(({ text }) => text).join(', ') : '')
-        initialSelectedMap.clear()
-        result.forEach(({ name }) => initialSelectedMap.set(name, true))
-        cancelDialog()
-      }, [cancelDialog, initialSelectedMap, isMultivalued, items, name, trigger]),
-      selectAll = (checked = true) => () => {
-        const checkedFilteredItems = filteredItems.map(i => { i.checked = checked; return i })
-        const checkedMap = new Map(checkedFilteredItems.map(i => [i.name, i.checked]))
-        setFilteredItems(checkedFilteredItems)
-        items.forEach(i => { if (checkedMap.has(i.name)) i.checked = checkedMap.get(i.name)! })
-        setTextValue(choices?.map(c => c.label).join(', '))
+        toggleDialog()
+      }
+    
+      React.useEffect(() => {
+        if (model.value !== undefined) {
+          wave.args[name] = model.value ?? null
+          setItems(items => items.map(i => ({ ...i, checked: model.value === i.name })))
+        }
+      }, [name, model.value, setItems])
+    
+      return (
+        <>
+          <Fluent.TextField
+            data-test={name}
+            iconProps={{ iconName: 'ChevronDown' }}
+            readOnly
+            onClick={toggleDialog}
+            label={label}
+            disabled={disabled}
+            required={required}
+            styles={{ field: { cursor: 'pointer' }, icon: { fontSize: 12, color: cssVar('$neutralSecondary') } }}
+            placeholder={placeholder}
+            value={items.find(i => i.checked)?.text ?? ''} />
+          <Fluent.Dialog hidden={isDialogHidden} dialogContentProps={{ title: label, type: Fluent.DialogType.close }} onDismiss={toggleDialog} minWidth={600} maxWidth='90vw'>
+            <Fluent.DialogContent styles={{ innerContent: { height: '65vh' }, header: { height: 0 } }}>
+              <Fluent.Label>Search</Fluent.Label>
+              <Fluent.SearchBox data-test={`${name}-search`} onChange={onSearchChange} autoFocus />
+              <Fluent.ScrollablePane styles={{ root: { marginTop: 100, boxShadow: `0px 3px 7px ${cssVar('$text3')}` } }}>
+                <Fluent.List
+                  items={items.filter(i => i.show)}
+                  getPageSpecification={getPageSpecification}
+                  renderedWindowsAhead={3}
+                  onRenderCell={onRenderCell(onChecked)}
+                />
+              </Fluent.ScrollablePane>
+            </Fluent.DialogContent>
+          </Fluent.Dialog>
+        </>
+      )
+  },
+  DialogDropdownMulti = ({ name, choices = [], values = [], disabled, required, trigger, placeholder, label }: Dropdown) => {
+    const
+      [isDialogHidden, setIsDialogHidden] = React.useState(true),
+      [items, setItems, onSearchChange] = useItems(choices, values),
+      auxItems = React.useRef([...items]),
+      openDialog = () => {
+        setIsDialogHidden(false)
+        auxItems.current = [...items]
       },
-      onSearchChange = (_e?: React.ChangeEvent<HTMLInputElement>, newVal = '') => setFilteredItems(newVal ? items.filter(({ text }) => fuzzysearch(text, newVal)) : items),
-      onChecked = React.useCallback((idx: U) => (_ev?: React.FormEvent<HTMLElement | HTMLInputElement>, checked = false) => {
-        items[idx].checked = checked
-
-        isMultivalued
-          ? setFilteredItems(filteredItems.map(i => { if (items[idx].name === i.name) i.checked = checked; return i }))
-          : submit(items[idx])
-      }, [filteredItems, isMultivalued, items, submit]),
-      onRenderCell = React.useCallback((item?: DropdownItem) => item
-        ? <Fluent.Checkbox
-          label={item.text}
-          styles={{
-            root: { minHeight: ROW_HEIGHT, alignItems: 'center' },
-            label: { width: pc(100), padding: 12, wordBreak: 'break-word' },
-            checkmark: { display: 'flex' }
-          }}
-          onChange={onChecked(item.idx)}
-          className={item.checked ? css.dialogCheckedRow : ''}
-          checked={item.checked} />
-        : null, [onChecked]),
-      getPageSpecification = React.useCallback(() => ({ itemCount: PAGE_SIZE, height: ROW_HEIGHT * PAGE_SIZE, } as Fluent.IPageSpecification), [])
+      closeDialog = () => {
+        setItems(items => items.map(i => ({ ...i, show: true })))
+        setIsDialogHidden(true)
+      },
+      cancelDialog = () => {
+        setItems(auxItems.current)
+        closeDialog()
+      },
+      submit = (items: DropdownItem[]) => {
+        wave.args[name] = items.filter(i => i.checked).map(i => i.name)
+        if (trigger) wave.push()
+        closeDialog()
+      },
+      onChecked = (name: S) => (_ev?: React.FormEvent<HTMLElement | HTMLInputElement>, checked = false) => {
+        setItems(items => items.map(i => ({ ...i, checked: name === i.name ? checked : i.checked })))
+      },
+      selectAll = (checked = true) => () => {
+        setItems(items => items.map(i => ({ ...i, checked: i.show ? checked : i.checked })))
+      }
 
     React.useEffect(() => {
-      let textVal = ''
-      if (isMultivalued) {
-        const valuesMap = new Map(values.map(v => [v, true]))
-        textVal = items?.filter(i => valuesMap.has(i.name)).map(i => i.text).join(', ') || ''
-      } else {
-        textVal = items?.find(i => i.name === value)?.text || ''
+      if (values) {
+        wave.args[name] = values
+        setItems(items => items.map(i => ({ ...i, checked: values.includes(i.name) })))
       }
-      setTextValue(textVal)
-    }, [isMultivalued, items, value, values])
-
-    React.useEffect(() => { if (values) wave.args[name] = values ?? null }, [name, values])
-    React.useEffect(() => { if (value !== undefined) wave.args[name] = value ?? null }, [name, value])
+    }, [name, values, setItems])
 
     return (
       <>
@@ -247,56 +284,45 @@ const
           data-test={name}
           iconProps={{ iconName: 'ChevronDown' }}
           readOnly
-          onClick={toggleDialog}
+          onClick={openDialog}
           label={label}
           disabled={disabled}
           required={required}
           styles={{ field: { cursor: 'pointer' }, icon: { fontSize: 12, color: cssVar('$neutralSecondary') } }}
           placeholder={placeholder}
-          value={textValue || ''} />
+          value={items.filter(i => i.checked).map(i => i.text).join(', ')} />
         <Fluent.Dialog hidden={isDialogHidden} dialogContentProps={{ title: label, type: Fluent.DialogType.close }} onDismiss={cancelDialog} minWidth={600} maxWidth='90vw'>
           <Fluent.DialogContent styles={{ innerContent: { height: '65vh' }, header: { height: 0 } }}>
             <Fluent.Label>Search</Fluent.Label>
             <Fluent.SearchBox data-test={`${name}-search`} onChange={onSearchChange} autoFocus />
-            {
-              isMultivalued && (
-                <div className={clas('wave-s14', css.dialogControls)}>
-                  <span className='wave-w5'>Selected: {items.filter(({ checked }) => checked).length}</span>
-                  <div><Fluent.Link onClick={selectAll()}>Select All</Fluent.Link> | <Fluent.Link onClick={selectAll(false)}>Deselect All</Fluent.Link></div>
-                </div>
-              )
-            }
+              <div className={clas('wave-s14', css.dialogControls)}>
+                <span className='wave-w5'>Selected: {items.filter(i => i.checked).length}</span>
+                <div><Fluent.Link onClick={selectAll()}>Select All</Fluent.Link> | <Fluent.Link onClick={selectAll(false)}>Deselect All</Fluent.Link></div>
+              </div>
             <Fluent.ScrollablePane styles={{ root: { marginTop: 100, boxShadow: `0px 3px 7px ${cssVar('$text3')}` } }}>
               <Fluent.List
-                items={filteredItems}
+                items={items.filter(i => i.show)}
                 getPageSpecification={getPageSpecification}
                 renderedWindowsAhead={3}
-                onRenderCell={onRenderCell}
+                onRenderCell={onRenderCell(onChecked)}
               />
             </Fluent.ScrollablePane>
           </Fluent.DialogContent>
-          {
-            isMultivalued && (
-              <Fluent.DialogFooter>
-                <Fluent.DefaultButton text='Cancel' onClick={cancelDialog} />
-                <Fluent.PrimaryButton text='Select' onClick={() => submit()} />
-              </Fluent.DialogFooter>
-            )
-          }
+            <Fluent.DialogFooter>
+              <Fluent.DefaultButton text='Cancel' onClick={cancelDialog} />
+              <Fluent.PrimaryButton text='Select' onClick={() => submit(items)} />
+            </Fluent.DialogFooter>
         </Fluent.Dialog>
       </>
     )
-  }
+  },
+  DialogDropdown = (props: Dropdown) => props.values ? <DialogDropdownMulti {...props} /> : <DialogDropdownSingle model={{...props}} />
 
-export const XDropdown = ({ model: m }: { model: Dropdown }) => {
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  React.useEffect(() => { wave.args[m.name] = m.values ? (m.values || []) : (m.value || null) }, [])
-
-  return m.popup === 'always'
+export const XDropdown = ({ model: m }: { model: Dropdown }) => 
+  m.popup === 'always'
     ? <DialogDropdown {...m} />
     : m.popup === 'never'
-      ? <BaseDropdown {...m} />
+      ? <BaseDropdown model={{...m}} />
       : (m.choices?.length || 0) > 100
         ? <DialogDropdown {...m} />
-        : <BaseDropdown {...m} />
-}
+        : <BaseDropdown model={{...m}} />

--- a/ui/src/dropdown.tsx
+++ b/ui/src/dropdown.tsx
@@ -84,10 +84,10 @@ const
   }),
   BaseDropdown = ({ model: m }: { model: Dropdown }) => {
     const
-      { name, label, required, disabled, value, values, choices, trigger, placeholder } = m,
+      { name, label, required, disabled, values, choices, trigger, placeholder } = m,
       isMultivalued = !!values,
       selection = React.useMemo(() => isMultivalued ? new Set<S>(values) : null, [isMultivalued, values]),
-      [singleValue, setSingleValue] = React.useState(value),
+      [singleValue, setSingleValue] = React.useState(m.value),
       [multiValues, setMultiValues] = React.useState(values),
       options = (choices || []).map(({ name, label, disabled }): Fluent.IDropdownOption => ({ key: name, text: label || name, disabled })),
       onChange = (_e?: React.FormEvent<HTMLElement>, option?: Fluent.IDropdownOption) => {
@@ -137,9 +137,9 @@ const
 
     React.useEffect(() => {
       if (isMultivalued) return
-      setSingleValue(value || '')
-      wave.args[name] = value ?? null
-    }, [name, value, isMultivalued])
+      setSingleValue(m.value || '')
+      wave.args[name] = m.value ?? null
+    }, [name, m.value, isMultivalued])
 
     return (
       <>
@@ -246,17 +246,17 @@ const
     const
       [isDialogHidden, setIsDialogHidden] = React.useState(true),
       [items, setItems, onSearchChange] = useItems(choices, values),
-      itemsBackup = React.useRef([...items]),
+      itemsOnDialogOpen = React.useRef(items),
       openDialog = () => {
         setIsDialogHidden(false)
-        itemsBackup.current = [...items]
+        itemsOnDialogOpen.current = items
       },
       closeDialog = () => {
         setItems(items => items.map(i => ({ ...i, show: true })))
         setIsDialogHidden(true)
       },
       cancelDialog = () => {
-        setItems(itemsBackup.current)
+        setItems(itemsOnDialogOpen.current)
         closeDialog()
       },
       submit = (items: DropdownItem[]) => {


### PR DESCRIPTION
## Multi-valued dialog Dropdown Refactor notes

On line 189, since `filteredItems` is intialized with `items`, `setFilteredItems` was mutating `items` when it set `i.checked = checked` which is definitely an antipattern, plus `items` uses `useMemo` which should only change when its dependencies change.
`189: selectAll = (checked = true) => () => setFilteredItems(filteredItems.map(i => { i.checked = checked; return i })),`

`filteredItems` should represent the displayed items and should rely on `items` as single source of truth. The refactoring makes it so that we change `items` and the changes are reflected to `filteredItem` through `useEffect`. Same for searching.

 I believe this is a better mental model.

## Unrelated bugs

I fixed a bug where multi-valued dialog Dropdown was setting wave args to string when it only had a single value selected and it was setting wave args to array for more than one value. Now it's always an array. No one has reported this issue but if they handled this in their code, the fix might break it.

## Performance concerns

We are using `toString()` to compare array content and it can be an expensive computation.

I tested dialog with 100k options and it was fine.

## Updating `choices` prop

This PR solves the issue which was concerned about changing `value` and `values`. Updating `choices` dynamically could be done in a separate PR due to the number of changes and complexity already present in this one.

## Further improvements

The code is still quite complex. We could split each component into single-valued and multi-valued like we did for dropdown. Maybe it would be easier to follow.

Any suggestion is welcomed.

## Handy repro code

```py
from h2o_wave import app, main, Q, ui

combobox_choices = ['A', 'B', 'C']

@app("/demo")
async def serve(q: Q) -> None:
    if not q.client.initialized:
        q.client.initialized = True
        q.page["example"] = ui.form_card(
            box="1 1 4 6",
            items=[
                ui.dropdown(
                    name='dp1',
                    label='base single',
                    choices=[
                        ui.choice(name="a", label="choice a"),
                        ui.choice(name="b", label="choice b"),
                        ui.choice(name="c", label="choice c"),
                    ],
                    value="a",
                ),
                 ui.dropdown(
                    name='dp2',
                    label='base multi',
                    choices=[
                        ui.choice(name="a", label="choice a"),
                        ui.choice(name="b", label="choice b"),
                        ui.choice(name="c", label="choice c"),
                    ],
                    values=["a"],
                ),
                ui.dropdown(
                    name='dp3',
                    label='dialog single',
                    choices=[
                        ui.choice(name="1", label="Choice 1"),
                        ui.choice(name="2", label="Choice 2"),
                        ui.choice(name="3", label="Choice 3"),
                    ],
                    popup="always",
                    value="1"
                ),
                ui.dropdown(
                    name='dp4',
                    label='dialog multi',
                    choices=[ui.choice(name=str(i), label=f'Choice {i}') for i in range(100000)],
                    values=["1"],
                    popup="always",
                ),
                ui.button(name="change", label="change"),
            ],
        )
    if q.args.change:
        q.page["example"].items[0].dropdown.value = 'b'
        q.page["example"].items[1].dropdown.values = ['b']
        q.page["example"].items[2].dropdown.value = '2'
        q.page["example"].items[3].dropdown.values = ['2']
        
    await q.page.save()
```

closes #1574