### PR TITLE
feat: Add proper err handling to site.download function and allow extensionless file downloads. #1627

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -40,19 +40,6 @@
       ]
     },
     {
-      "name": "Debug PY App",
-      "type": "python",
-      "request": "launch",
-      "program": "${workspaceFolder}/py/venv/bin/wave",
-      "python": "${workspaceFolder}/py/venv/bin/python",
-      "cwd": "${workspaceFolder}/py/examples",
-      "args": [
-        "run",
-        "tour",
-        "--no-reload",
-      ],
-    },
-    {
       "name": "Debug Py Tests",
       "type": "python",
       "cwd": "${workspaceFolder}/py",
@@ -103,6 +90,19 @@
       "outFiles": [
         "${workspaceFolder}/tools/wavegen/build/**/*.js"
       ]
+    },
+    {
+      "name": "Debug Wave App",
+      "type": "python",
+      "request": "launch",
+      "program": "${workspaceFolder}/py/venv/bin/wave",
+      "python": "${workspaceFolder}/py/venv/bin/python",
+      "cwd": "${workspaceFolder}/py/examples",
+      "args": [
+        "run",
+        "tour",
+        "--no-reload",
+      ],
     },
     {
       "name": "Debug Wave Server",

--- a/file_server.go
+++ b/file_server.go
@@ -69,14 +69,16 @@ func (fs *FileServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		if path.Ext(r.URL.Path) == "" { // ignore requests for directories and ext-less files
+		trimmedPrefix := strings.TrimPrefix(r.URL.Path, fs.baseURL)
+		// Ignore requests for directories and non-existent / unaccessible files.
+		if fileInfo, err := os.Stat(filepath.Join(fs.dir, trimmedPrefix)); err != nil || fileInfo.IsDir() {
 			echo(Log{"t": "file_download", "path": r.URL.Path, "error": "not found"})
 			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
 			return
 		}
 
 		echo(Log{"t": "file_download", "path": r.URL.Path})
-		r.URL.Path = strings.TrimPrefix(r.URL.Path, fs.baseURL) // public
+		r.URL.Path = trimmedPrefix // public
 		fs.handler.ServeHTTP(w, r)
 
 	case http.MethodPost:

--- a/file_server.go
+++ b/file_server.go
@@ -70,8 +70,9 @@ func (fs *FileServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 
 		trimmedPrefix := strings.TrimPrefix(r.URL.Path, fs.baseURL)
+		fsDirPath := path.Join(fs.dir, trimmedPrefix)
 		// Ignore requests for directories and non-existent / unaccessible files.
-		if fileInfo, err := os.Stat(filepath.Join(fs.dir, trimmedPrefix)); err != nil || fileInfo.IsDir() {
+		if fileInfo, err := os.Stat(filepath.FromSlash(fsDirPath)); err != nil || fileInfo.IsDir() {
 			echo(Log{"t": "file_download", "path": r.URL.Path, "error": "not found"})
 			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
 			return

--- a/py/h2o_wave/core.py
+++ b/py/h2o_wave/core.py
@@ -719,9 +719,11 @@ class Site:
         # If path is a directory, get basename from url
         filepath = os.path.join(path, os.path.basename(url)) if os.path.isdir(path) else path
 
-        with open(filepath, 'wb') as f:
-            with self._http.stream('GET', f'{_config.hub_host_address}{url}') as r:
-                for chunk in r.iter_bytes():
+        with self._http.stream('GET', f'{_config.hub_host_address}{url}') as res:
+            if res.status_code != 200:
+                raise ServiceError(f'Download failed (code={res.status_code}): {res.text}')
+            with open(filepath, 'wb') as f:
+                for chunk in res.iter_bytes():
                     f.write(chunk)
 
         return filepath

--- a/py/h2o_wave/core.py
+++ b/py/h2o_wave/core.py
@@ -721,6 +721,7 @@ class Site:
 
         with self._http.stream('GET', f'{_config.hub_host_address}{url}') as res:
             if res.status_code != 200:
+                res.read()
                 raise ServiceError(f'Download failed (code={res.status_code}): {res.text}')
             with open(filepath, 'wb') as f:
                 for chunk in res.iter_bytes():

--- a/py/tests/test_python_server.py
+++ b/py/tests/test_python_server.py
@@ -383,7 +383,7 @@ class TestPythonServer(unittest.TestCase):
 
     def test_upload_dir(self):
         upload_path, = site.upload_dir(os.path.join('tests', 'test_folder'))
-        download_path = site.download(f'{base_url}{upload_path}test.txt', 'test.txt')
+        download_path = site.download(f'{upload_path}/test.txt', 'test.txt')
         txt = read_file(download_path)
         os.remove(download_path)
         assert len(txt) > 0

--- a/py/tests/test_python_server.py
+++ b/py/tests/test_python_server.py
@@ -22,6 +22,8 @@ from .utils import (compare, make_card, make_cyc_buf, make_fix_buf,
 
 base_url = os.getenv('H2O_WAVE_BASE_URL', '/')
 
+
+# TODO: Add cleanup (site.unload) to tests that upload files.
 class TestPythonServer(unittest.TestCase):
     def test_new_empty_card(self):
         page = site['/test']

--- a/py/tests/test_python_server_async.py
+++ b/py/tests/test_python_server_async.py
@@ -19,7 +19,7 @@ import httpx
 
 from .utils import read_file
 
-
+# TODO: Add cleanup (site.unload) to tests that upload files.
 class TestPythonServerAsync(unittest.IsolatedAsyncioTestCase):
     def __init__(self, methodName: str = ...) -> None:
         super().__init__(methodName)

--- a/py/tests/test_python_server_async.py
+++ b/py/tests/test_python_server_async.py
@@ -68,8 +68,7 @@ class TestPythonServerAsync(unittest.IsolatedAsyncioTestCase):
 
     async def test_upload_dir(self):
         upload_path, = await self.site.upload_dir(os.path.join('tests', 'test_folder'))
-        base_url = os.getenv('H2O_WAVE_BASE_URL', '/')
-        download_path = await self.site.download(f'{base_url}{upload_path}test.txt', 'test.txt')
+        download_path = await self.site.download(f'{upload_path}/test.txt', 'test.txt')
         txt = read_file(download_path)
         os.remove(download_path)
         assert len(txt) > 0


### PR DESCRIPTION
* Raise an err if there is any - same behavior like the rest of alike functions.
* Create a file for the stream to write into only in case of 200 status code.

Needs discussion: https://github.com/h2oai/wave/issues/1627#issuecomment-1254702592

Closes #1627