### PR TITLE
feat: Polygon support for image annotator

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,6 +12,22 @@
       "webRoot": "${workspaceFolder}/ui"
     },
     {
+      "name": "Debug UI Tests",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "node",
+      "program": "${workspaceRoot}/ui/node_modules/jest/bin/jest.js",
+      "args": [
+        "--no-cache",
+        "--env=jsdom",
+        "${file}"
+      ],
+      "cwd": "${workspaceRoot}/ui",
+      "protocol": "inspector",
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen"
+    },
+    {
       "name": "Debug PY Build",
       "type": "python",
       "request": "launch",
@@ -68,23 +84,6 @@
       "program": "${workspaceFolder}/tools/showcase/showcase.py",
       "python": "${workspaceFolder}/tools/showcase/venv/bin/python",
       "console": "integratedTerminal",
-    },
-    {
-      "name": "Debug UI Tests",
-      "type": "node",
-      "request": "launch",
-      "runtimeExecutable": "node",
-      "program": "${workspaceRoot}/ui/node_modules/jest/bin/jest.js",
-      "args": [
-        "--watch",
-        "--runInBand",
-        "--no-cache",
-        "--env=jsdom"
-      ],
-      "cwd": "${workspaceRoot}/ui",
-      "protocol": "inspector",
-      "console": "integratedTerminal",
-      "internalConsoleOptions": "neverOpen"
     },
     {
       "type": "node",

--- a/py/examples/image_annotator.py
+++ b/py/examples/image_annotator.py
@@ -6,7 +6,7 @@ from h2o_wave import main, app, Q, ui
 
 
 @app('/demo')
-async def serve(q=Q):
+async def serve(q: Q):
     if q.args.annotator is not None:
         q.page['example'].items = [
             ui.text(f'annotator={q.args.annotator}'),

--- a/py/examples/image_annotator.py
+++ b/py/examples/image_annotator.py
@@ -13,12 +13,12 @@ async def serve(q=Q):
             ui.button(name='back', label='Back', primary=True),
         ]
     else:
-        q.page['example'] = ui.form_card(box='1 1 -1 -1', items=[
+        q.page['example'] = ui.form_card(box='1 1 5 8', items=[
             ui.image_annotator(
                 name='annotator',
                 title='Drag to annotate',
                 image='https://images.pexels.com/photos/2696064/pexels-photo-2696064.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1',
-                image_height='280px',
+                image_height='450px',
                 tags=[
                     ui.image_annotator_tag(name='p', label='Person', color='$cyan'),
                     ui.image_annotator_tag(name='f', label='Food', color='$blue'),

--- a/py/examples/image_annotator.py
+++ b/py/examples/image_annotator.py
@@ -6,7 +6,7 @@ from h2o_wave import main, app, Q, ui
 
 
 @app('/demo')
-async def serve(q: Q):
+async def serve(q=Q):
     if q.args.annotator is not None:
         q.page['example'].items = [
             ui.text(f'annotator={q.args.annotator}'),
@@ -25,6 +25,12 @@ async def serve(q: Q):
                 ],
                 items=[
                     ui.image_annotator_item(shape=ui.image_annotator_rect(x1=649, y1=393, x2=383, y2=25), tag='p'),
+                    ui.image_annotator_item(tag='p', shape=ui.image_annotator_polygon([
+                        ui.image_annotator_point(x=828.2142857142857, y=135),
+                        ui.image_annotator_point(x=731.7857142857142, y=212.14285714285714),
+                        ui.image_annotator_point(x=890.3571428571429, y=354.6428571428571),
+                        ui.image_annotator_point(x=950.3571428571429, y=247.5)
+                    ])),
                 ],
             ),
             ui.button(name='submit', label='Submit', primary=True)

--- a/py/h2o_wave/types.py
+++ b/py/h2o_wave/types.py
@@ -6485,27 +6485,27 @@ class ImageAnnotatorPolygon:
     """
     def __init__(
             self,
-            items: List[ImageAnnotatorPoint],
+            vertices: List[ImageAnnotatorPoint],
     ):
-        _guard_vector('ImageAnnotatorPolygon.items', items, (ImageAnnotatorPoint,), False, False, False)
-        self.items = items
+        _guard_vector('ImageAnnotatorPolygon.vertices', vertices, (ImageAnnotatorPoint,), False, False, False)
+        self.vertices = vertices
         """List of points of the polygon."""
 
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""
-        _guard_vector('ImageAnnotatorPolygon.items', self.items, (ImageAnnotatorPoint,), False, False, False)
+        _guard_vector('ImageAnnotatorPolygon.vertices', self.vertices, (ImageAnnotatorPoint,), False, False, False)
         return _dump(
-            items=[__e.dump() for __e in self.items],
+            vertices=[__e.dump() for __e in self.vertices],
         )
 
     @staticmethod
     def load(__d: Dict) -> 'ImageAnnotatorPolygon':
         """Creates an instance of this class using the contents of a dict."""
-        __d_items: Any = __d.get('items')
-        _guard_vector('ImageAnnotatorPolygon.items', __d_items, (dict,), False, False, False)
-        items: List[ImageAnnotatorPoint] = [ImageAnnotatorPoint.load(__e) for __e in __d_items]
+        __d_vertices: Any = __d.get('vertices')
+        _guard_vector('ImageAnnotatorPolygon.vertices', __d_vertices, (dict,), False, False, False)
+        vertices: List[ImageAnnotatorPoint] = [ImageAnnotatorPoint.load(__e) for __e in __d_vertices]
         return ImageAnnotatorPolygon(
-            items,
+            vertices,
         )
 
 

--- a/py/h2o_wave/types.py
+++ b/py/h2o_wave/types.py
@@ -6442,7 +6442,7 @@ class ImageAnnotatorRect:
 
 
 class ImageAnnotatorPoint:
-    """No documentation available.
+    """Create a polygon annotation point with x and y coordinates..
     """
     def __init__(
             self,

--- a/py/h2o_wave/types.py
+++ b/py/h2o_wave/types.py
@@ -6441,22 +6441,96 @@ class ImageAnnotatorRect:
         )
 
 
+class ImageAnnotatorPoint:
+    """No documentation available.
+    """
+    def __init__(
+            self,
+            x: float,
+            y: float,
+    ):
+        _guard_scalar('ImageAnnotatorPoint.x', x, (float, int,), False, False, False)
+        _guard_scalar('ImageAnnotatorPoint.y', y, (float, int,), False, False, False)
+        self.x = x
+        """`x` coordinate of the point."""
+        self.y = y
+        """`y` coordinate of the point."""
+
+    def dump(self) -> Dict:
+        """Returns the contents of this object as a dict."""
+        _guard_scalar('ImageAnnotatorPoint.x', self.x, (float, int,), False, False, False)
+        _guard_scalar('ImageAnnotatorPoint.y', self.y, (float, int,), False, False, False)
+        return _dump(
+            x=self.x,
+            y=self.y,
+        )
+
+    @staticmethod
+    def load(__d: Dict) -> 'ImageAnnotatorPoint':
+        """Creates an instance of this class using the contents of a dict."""
+        __d_x: Any = __d.get('x')
+        _guard_scalar('ImageAnnotatorPoint.x', __d_x, (float, int,), False, False, False)
+        __d_y: Any = __d.get('y')
+        _guard_scalar('ImageAnnotatorPoint.y', __d_y, (float, int,), False, False, False)
+        x: float = __d_x
+        y: float = __d_y
+        return ImageAnnotatorPoint(
+            x,
+            y,
+        )
+
+
+class ImageAnnotatorPolygon:
+    """Create a polygon annotation shape.
+    """
+    def __init__(
+            self,
+            items: List[ImageAnnotatorPoint],
+    ):
+        _guard_vector('ImageAnnotatorPolygon.items', items, (ImageAnnotatorPoint,), False, False, False)
+        self.items = items
+        """List of points of the polygon."""
+
+    def dump(self) -> Dict:
+        """Returns the contents of this object as a dict."""
+        _guard_vector('ImageAnnotatorPolygon.items', self.items, (ImageAnnotatorPoint,), False, False, False)
+        return _dump(
+            items=[__e.dump() for __e in self.items],
+        )
+
+    @staticmethod
+    def load(__d: Dict) -> 'ImageAnnotatorPolygon':
+        """Creates an instance of this class using the contents of a dict."""
+        __d_items: Any = __d.get('items')
+        _guard_vector('ImageAnnotatorPolygon.items', __d_items, (dict,), False, False, False)
+        items: List[ImageAnnotatorPoint] = [ImageAnnotatorPoint.load(__e) for __e in __d_items]
+        return ImageAnnotatorPolygon(
+            items,
+        )
+
+
 class ImageAnnotatorShape:
     """Create a shape to be rendered as an annotation on an image annotator.
     """
     def __init__(
             self,
             rect: Optional[ImageAnnotatorRect] = None,
+            polygon: Optional[ImageAnnotatorPolygon] = None,
     ):
         _guard_scalar('ImageAnnotatorShape.rect', rect, (ImageAnnotatorRect,), False, True, False)
+        _guard_scalar('ImageAnnotatorShape.polygon', polygon, (ImageAnnotatorPolygon,), False, True, False)
         self.rect = rect
+        """No documentation available."""
+        self.polygon = polygon
         """No documentation available."""
 
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""
         _guard_scalar('ImageAnnotatorShape.rect', self.rect, (ImageAnnotatorRect,), False, True, False)
+        _guard_scalar('ImageAnnotatorShape.polygon', self.polygon, (ImageAnnotatorPolygon,), False, True, False)
         return _dump(
             rect=None if self.rect is None else self.rect.dump(),
+            polygon=None if self.polygon is None else self.polygon.dump(),
         )
 
     @staticmethod
@@ -6464,9 +6538,13 @@ class ImageAnnotatorShape:
         """Creates an instance of this class using the contents of a dict."""
         __d_rect: Any = __d.get('rect')
         _guard_scalar('ImageAnnotatorShape.rect', __d_rect, (dict,), False, True, False)
+        __d_polygon: Any = __d.get('polygon')
+        _guard_scalar('ImageAnnotatorShape.polygon', __d_polygon, (dict,), False, True, False)
         rect: Optional[ImageAnnotatorRect] = None if __d_rect is None else ImageAnnotatorRect.load(__d_rect)
+        polygon: Optional[ImageAnnotatorPolygon] = None if __d_polygon is None else ImageAnnotatorPolygon.load(__d_polygon)
         return ImageAnnotatorShape(
             rect,
+            polygon,
         )
 
 

--- a/py/h2o_wave/ui.py
+++ b/py/h2o_wave/ui.py
@@ -2398,6 +2398,39 @@ def image_annotator_rect(
     ))
 
 
+def image_annotator_point(
+        x: float,
+        y: float,
+) -> ImageAnnotatorPoint:
+    """No documentation available.
+
+    Args:
+        x: `x` coordinate of the point.
+        y: `y` coordinate of the point.
+    Returns:
+        A `h2o_wave.types.ImageAnnotatorPoint` instance.
+    """
+    return ImageAnnotatorPoint(
+        x,
+        y,
+    )
+
+
+def image_annotator_polygon(
+        items: List[ImageAnnotatorPoint],
+) -> ImageAnnotatorShape:
+    """Create a polygon annotation shape.
+
+    Args:
+        items: List of points of the polygon.
+    Returns:
+        A `h2o_wave.types.ImageAnnotatorPolygon` instance.
+    """
+    return ImageAnnotatorShape(polygon=ImageAnnotatorPolygon(
+        items,
+    ))
+
+
 def image_annotator_item(
         shape: ImageAnnotatorShape,
         tag: str,

--- a/py/h2o_wave/ui.py
+++ b/py/h2o_wave/ui.py
@@ -2417,17 +2417,17 @@ def image_annotator_point(
 
 
 def image_annotator_polygon(
-        items: List[ImageAnnotatorPoint],
+        vertices: List[ImageAnnotatorPoint],
 ) -> ImageAnnotatorShape:
     """Create a polygon annotation shape.
 
     Args:
-        items: List of points of the polygon.
+        vertices: List of points of the polygon.
     Returns:
         A `h2o_wave.types.ImageAnnotatorPolygon` instance.
     """
     return ImageAnnotatorShape(polygon=ImageAnnotatorPolygon(
-        items,
+        vertices,
     ))
 
 

--- a/py/h2o_wave/ui.py
+++ b/py/h2o_wave/ui.py
@@ -2402,7 +2402,7 @@ def image_annotator_point(
         x: float,
         y: float,
 ) -> ImageAnnotatorPoint:
-    """No documentation available.
+    """Create a polygon annotation point with x and y coordinates..
 
     Args:
         x: `x` coordinate of the point.

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -2797,6 +2797,38 @@ ui_image_annotator_rect <- function(
   return(.o)
 }
 
+#' No documentation available.
+#'
+#' @param x `x` coordinate of the point.
+#' @param y `y` coordinate of the point.
+#' @return A ImageAnnotatorPoint instance.
+#' @export
+ui_image_annotator_point <- function(
+  x,
+  y) {
+  .guard_scalar("x", "numeric", x)
+  .guard_scalar("y", "numeric", y)
+  .o <- list(
+    x=x,
+    y=y)
+  class(.o) <- append(class(.o), c(.wave_obj, "WaveImageAnnotatorPoint"))
+  return(.o)
+}
+
+#' Create a polygon annotation shape.
+#'
+#' @param items List of points of the polygon.
+#' @return A ImageAnnotatorPolygon instance.
+#' @export
+ui_image_annotator_polygon <- function(
+  items) {
+  .guard_vector("items", "WaveImageAnnotatorPoint", items)
+  .o <- list(polygon=list(
+    items=items))
+  class(.o) <- append(class(.o), c(.wave_obj, "WaveImageAnnotatorShape"))
+  return(.o)
+}
+
 #' Create an annotator item with initial selected tags or no tag for plaintext.
 #'
 #' @param shape The annotation shape.

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -2797,7 +2797,7 @@ ui_image_annotator_rect <- function(
   return(.o)
 }
 
-#' No documentation available.
+#' Create a polygon annotation point with x and y coordinates..
 #'
 #' @param x `x` coordinate of the point.
 #' @param y `y` coordinate of the point.

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -2817,14 +2817,14 @@ ui_image_annotator_point <- function(
 
 #' Create a polygon annotation shape.
 #'
-#' @param items List of points of the polygon.
+#' @param vertices List of points of the polygon.
 #' @return A ImageAnnotatorPolygon instance.
 #' @export
 ui_image_annotator_polygon <- function(
-  items) {
-  .guard_vector("items", "WaveImageAnnotatorPoint", items)
+  vertices) {
+  .guard_vector("vertices", "WaveImageAnnotatorPoint", vertices)
   .o <- list(polygon=list(
-    items=items))
+    vertices=vertices))
   class(.o) <- append(class(.o), c(.wave_obj, "WaveImageAnnotatorShape"))
   return(.o)
 }

--- a/tools/intellij-plugin/src/main/resources/templates/wave-components.xml
+++ b/tools/intellij-plugin/src/main/resources/templates/wave-components.xml
@@ -223,6 +223,19 @@
       <option name="Python" value="true"/>
     </context>
   </template>
+  <template name="w_image_annotator_point" value="ui.image_annotator_point(x=$x$,y=$y$),$END$" description="Create a minimal Wave ImageAnnotatorPoint." toReformat="true" toShortenFQNames="true">
+    <variable name="x" expression="" defaultValue="" alwaysStopAt="true"/>
+    <variable name="y" expression="" defaultValue="" alwaysStopAt="true"/>
+    <context>
+      <option name="Python" value="true"/>
+    </context>
+  </template>
+  <template name="w_image_annotator_polygon" value="ui.image_annotator_polygon(items=[&#10;	$items$	&#10;]),$END$" description="Create a minimal Wave ImageAnnotatorPolygon." toReformat="true" toShortenFQNames="true">
+    <variable name="items" expression="" defaultValue="" alwaysStopAt="true"/>
+    <context>
+      <option name="Python" value="true"/>
+    </context>
+  </template>
   <template name="w_image_annotator_rect" value="ui.image_annotator_rect(x1=$x1$,y1=$y1$,x2=$x2$,y2=$y2$),$END$" description="Create a minimal Wave ImageAnnotatorRect." toReformat="true" toShortenFQNames="true">
     <variable name="x1" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="y1" expression="" defaultValue="" alwaysStopAt="true"/>
@@ -1396,6 +1409,19 @@
       <option name="Python" value="true"/>
     </context>
   </template>
+  <template name="w_full_image_annotator_point" value="ui.image_annotator_point(x=$x$,y=$y$),$END$" description="Create Wave ImageAnnotatorPoint with full attributes." toReformat="true" toShortenFQNames="true">
+    <variable name="x" expression="" defaultValue="" alwaysStopAt="true"/>
+    <variable name="y" expression="" defaultValue="" alwaysStopAt="true"/>
+    <context>
+      <option name="Python" value="true"/>
+    </context>
+  </template>
+  <template name="w_full_image_annotator_polygon" value="ui.image_annotator_polygon(items=[&#10;	$items$	&#10;]),$END$" description="Create Wave ImageAnnotatorPolygon with full attributes." toReformat="true" toShortenFQNames="true">
+    <variable name="items" expression="" defaultValue="" alwaysStopAt="true"/>
+    <context>
+      <option name="Python" value="true"/>
+    </context>
+  </template>
   <template name="w_full_image_annotator_rect" value="ui.image_annotator_rect(x1=$x1$,y1=$y1$,x2=$x2$,y2=$y2$),$END$" description="Create Wave ImageAnnotatorRect with full attributes." toReformat="true" toShortenFQNames="true">
     <variable name="x1" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="y1" expression="" defaultValue="" alwaysStopAt="true"/>
@@ -1405,8 +1431,9 @@
       <option name="Python" value="true"/>
     </context>
   </template>
-  <template name="w_full_image_annotator_shape" value="ui.image_annotator_shape(rect=$rect$),$END$" description="Create Wave ImageAnnotatorShape with full attributes." toReformat="true" toShortenFQNames="true">
+  <template name="w_full_image_annotator_shape" value="ui.image_annotator_shape(rect=$rect$,polygon=$polygon$),$END$" description="Create Wave ImageAnnotatorShape with full attributes." toReformat="true" toShortenFQNames="true">
     <variable name="rect" expression="" defaultValue="&quot;None&quot;" alwaysStopAt="true"/>
+    <variable name="polygon" expression="" defaultValue="&quot;None&quot;" alwaysStopAt="true"/>
     <context>
       <option name="Python" value="true"/>
     </context>

--- a/tools/intellij-plugin/src/main/resources/templates/wave-components.xml
+++ b/tools/intellij-plugin/src/main/resources/templates/wave-components.xml
@@ -230,8 +230,8 @@
       <option name="Python" value="true"/>
     </context>
   </template>
-  <template name="w_image_annotator_polygon" value="ui.image_annotator_polygon(items=[&#10;	$items$	&#10;]),$END$" description="Create a minimal Wave ImageAnnotatorPolygon." toReformat="true" toShortenFQNames="true">
-    <variable name="items" expression="" defaultValue="" alwaysStopAt="true"/>
+  <template name="w_image_annotator_polygon" value="ui.image_annotator_polygon(vertices=[&#10;	$vertices$	&#10;]),$END$" description="Create a minimal Wave ImageAnnotatorPolygon." toReformat="true" toShortenFQNames="true">
+    <variable name="vertices" expression="" defaultValue="" alwaysStopAt="true"/>
     <context>
       <option name="Python" value="true"/>
     </context>
@@ -1416,8 +1416,8 @@
       <option name="Python" value="true"/>
     </context>
   </template>
-  <template name="w_full_image_annotator_polygon" value="ui.image_annotator_polygon(items=[&#10;	$items$	&#10;]),$END$" description="Create Wave ImageAnnotatorPolygon with full attributes." toReformat="true" toShortenFQNames="true">
-    <variable name="items" expression="" defaultValue="" alwaysStopAt="true"/>
+  <template name="w_full_image_annotator_polygon" value="ui.image_annotator_polygon(vertices=[&#10;	$vertices$	&#10;]),$END$" description="Create Wave ImageAnnotatorPolygon with full attributes." toReformat="true" toShortenFQNames="true">
+    <variable name="vertices" expression="" defaultValue="" alwaysStopAt="true"/>
     <context>
       <option name="Python" value="true"/>
     </context>

--- a/tools/vscode-extension/component-snippets.json
+++ b/tools/vscode-extension/component-snippets.json
@@ -230,6 +230,20 @@
     ],
     "description": "Create a minimal Wave Image."
   },
+  "Wave ImageAnnotatorPoint": {
+    "prefix": "w_image_annotator_point",
+    "body": [
+      "ui.image_annotator_point(x=$1, y=$2),$0"
+    ],
+    "description": "Create a minimal Wave ImageAnnotatorPoint."
+  },
+  "Wave ImageAnnotatorPolygon": {
+    "prefix": "w_image_annotator_polygon",
+    "body": [
+      "ui.image_annotator_polygon(items=[\n\t\t$1\t\t\n]),$0"
+    ],
+    "description": "Create a minimal Wave ImageAnnotatorPolygon."
+  },
   "Wave ImageAnnotatorRect": {
     "prefix": "w_image_annotator_rect",
     "body": [
@@ -1161,6 +1175,20 @@
     ],
     "description": "Create a full Wave Image."
   },
+  "Wave Full ImageAnnotatorPoint": {
+    "prefix": "w_full_image_annotator_point",
+    "body": [
+      "ui.image_annotator_point(x=$1, y=$2),$0"
+    ],
+    "description": "Create a full Wave ImageAnnotatorPoint."
+  },
+  "Wave Full ImageAnnotatorPolygon": {
+    "prefix": "w_full_image_annotator_polygon",
+    "body": [
+      "ui.image_annotator_polygon(items=[\n\t\t$1\t\t\n]),$0"
+    ],
+    "description": "Create a full Wave ImageAnnotatorPolygon."
+  },
   "Wave Full ImageAnnotatorRect": {
     "prefix": "w_full_image_annotator_rect",
     "body": [
@@ -1171,7 +1199,7 @@
   "Wave Full ImageAnnotatorShape": {
     "prefix": "w_full_image_annotator_shape",
     "body": [
-      "ui.image_annotator_shape(rect=${1:None}),$0"
+      "ui.image_annotator_shape(rect=${1:None}, polygon=${2:None}),$0"
     ],
     "description": "Create a full Wave ImageAnnotatorShape."
   },

--- a/tools/vscode-extension/component-snippets.json
+++ b/tools/vscode-extension/component-snippets.json
@@ -240,7 +240,7 @@
   "Wave ImageAnnotatorPolygon": {
     "prefix": "w_image_annotator_polygon",
     "body": [
-      "ui.image_annotator_polygon(items=[\n\t\t$1\t\t\n]),$0"
+      "ui.image_annotator_polygon(vertices=[\n\t\t$1\t\t\n]),$0"
     ],
     "description": "Create a minimal Wave ImageAnnotatorPolygon."
   },
@@ -1185,7 +1185,7 @@
   "Wave Full ImageAnnotatorPolygon": {
     "prefix": "w_full_image_annotator_polygon",
     "body": [
-      "ui.image_annotator_polygon(items=[\n\t\t$1\t\t\n]),$0"
+      "ui.image_annotator_polygon(vertices=[\n\t\t$1\t\t\n]),$0"
     ],
     "description": "Create a full Wave ImageAnnotatorPolygon."
   },

--- a/ui/src/image_annotator.test.tsx
+++ b/ui/src/image_annotator.test.tsx
@@ -394,7 +394,7 @@ describe('ImageAnnotator.tsx', () => {
       ])
     })
 
-    it.only('Moves polygon by a single point, then moves it whole', async () => {
+    it('Moves polygon by a single point, then moves it whole', async () => {
       const { container } = render(<XImageAnnotator model={model} />)
       await waitForImgLoad()
       const canvasEl = container.querySelectorAll('canvas')[1]

--- a/ui/src/image_annotator.test.tsx
+++ b/ui/src/image_annotator.test.tsx
@@ -36,7 +36,7 @@ class MockedRenderingContext extends window.CanvasRenderingContext2D {
 const
   name = 'image_annotator',
   rect = { shape: { rect: { x1: 10, x2: 100, y1: 10, y2: 100 } }, tag: 'person' },
-  polygon = { shape: { polygon: { items: [{ x: 105, y: 100 }, { x: 240, y: 100 }, { x: 240, y: 220 },] } }, tag: 'person' },
+  polygon = { shape: { polygon: { vertices: [{ x: 105, y: 100 }, { x: 240, y: 100 }, { x: 240, y: 220 },] } }, tag: 'person' },
   items = [rect, polygon],
   model: ImageAnnotator = {
     name,
@@ -291,7 +291,7 @@ describe('ImageAnnotator.tsx', () => {
       fireEvent.click(canvasEl, { clientX: 10, clientY: 10 })
 
       expect(wave.args[name]).toMatchObject([
-        { tag: 'person', shape: { polygon: { items: [{ x: 10, y: 10 }, { x: 20, y: 20 }, { x: 30, y: 30 },] } } },
+        { tag: 'person', shape: { polygon: { vertices: [{ x: 10, y: 10 }, { x: 20, y: 20 }, { x: 30, y: 30 },] } } },
         ...items
       ])
     })
@@ -309,7 +309,7 @@ describe('ImageAnnotator.tsx', () => {
       fireEvent.click(canvasEl, { clientX: 10, clientY: 10 })
 
       expect(wave.args[name]).toMatchObject([
-        { tag: 'object', shape: { polygon: { items: [{ x: 10, y: 10 }, { x: 20, y: 20 }, { x: 30, y: 30 },] } } },
+        { tag: 'object', shape: { polygon: { vertices: [{ x: 10, y: 10 }, { x: 20, y: 20 }, { x: 30, y: 30 },] } } },
         ...items
       ])
     })
@@ -351,7 +351,7 @@ describe('ImageAnnotator.tsx', () => {
       fireEvent.click(canvasEl, { clientX: 240, clientY: 160 })
       expect(wave.args[name]).toMatchObject([
         rect,
-        { shape: { polygon: { items: [{ x: 105, y: 100 }, { x: 240, y: 100 }, { x: 240, y: 160 }, { x: 240, y: 220 },] } }, tag: 'person' }
+        { shape: { polygon: { vertices: [{ x: 105, y: 100 }, { x: 240, y: 100 }, { x: 240, y: 160 }, { x: 240, y: 220 },] } }, tag: 'person' }
       ])
     })
 
@@ -405,7 +405,7 @@ describe('ImageAnnotator.tsx', () => {
 
       expect(wave.args[name]).toMatchObject([
         rect,
-        { shape: { polygon: { items: [{ x: 115, y: 110 }, { x: 250, y: 110 }, { x: 250, y: 230 }] } }, tag: 'person' },
+        { shape: { polygon: { vertices: [{ x: 115, y: 110 }, { x: 250, y: 110 }, { x: 250, y: 230 }] } }, tag: 'person' },
       ])
     })
 
@@ -435,7 +435,7 @@ describe('ImageAnnotator.tsx', () => {
 
       expect(wave.args[name]).toMatchObject([
         rect,
-        { shape: { polygon: { items: [{ x: 100, y: 200 }, { x: 240, y: 100 }, { x: 240, y: 220 },] } }, tag: 'person' },
+        { shape: { polygon: { vertices: [{ x: 100, y: 200 }, { x: 240, y: 100 }, { x: 240, y: 220 },] } }, tag: 'person' },
       ])
     })
 
@@ -452,7 +452,7 @@ describe('ImageAnnotator.tsx', () => {
 
       expect(wave.args[name]).toMatchObject([
         rect,
-        { shape: { polygon: { items: [{ x: 100, y: 200 }, { x: 240, y: 100 }, { x: 240, y: 220 },] } }, tag: 'person' },
+        { shape: { polygon: { vertices: [{ x: 100, y: 200 }, { x: 240, y: 100 }, { x: 240, y: 220 },] } }, tag: 'person' },
       ])
     })
 
@@ -469,7 +469,7 @@ describe('ImageAnnotator.tsx', () => {
 
       expect(wave.args[name]).toMatchObject([
         rect,
-        { shape: { polygon: { items: [{ x: 100, y: 200 }, { x: 240, y: 100 }, { x: 240, y: 220 },] } }, tag: 'person' },
+        { shape: { polygon: { vertices: [{ x: 100, y: 200 }, { x: 240, y: 100 }, { x: 240, y: 220 },] } }, tag: 'person' },
       ])
 
       fireEvent.click(canvasEl, { clientX: 180, clientY: 150 })
@@ -479,7 +479,7 @@ describe('ImageAnnotator.tsx', () => {
 
       expect(wave.args[name]).toMatchObject([
         rect,
-        { shape: { polygon: { items: [{ x: 110, y: 210 }, { x: 250, y: 110 }, { x: 250, y: 230 },] } }, tag: 'person' },
+        { shape: { polygon: { vertices: [{ x: 110, y: 210 }, { x: 250, y: 110 }, { x: 250, y: 230 },] } }, tag: 'person' },
       ])
     })
   })

--- a/ui/src/image_annotator.test.tsx
+++ b/ui/src/image_annotator.test.tsx
@@ -48,7 +48,7 @@ const
     ],
     items
   },
-  waitForImgLoad = async () => act(() => new Promise(res => setTimeout(() => res(), 20)))
+  waitForLoad = async () => act(() => new Promise(res => setTimeout(() => res(), 20)))
 
 
 describe('ImageAnnotator.tsx', () => {
@@ -81,16 +81,24 @@ describe('ImageAnnotator.tsx', () => {
 
   it('Displays the correct cursor when hovering over canvas - no intersection', async () => {
     const { container } = render(<XImageAnnotator model={model} />)
-    await waitForImgLoad()
+    await waitForLoad()
     const canvasEl = container.querySelectorAll('canvas')[1]
     fireEvent.mouseMove(canvasEl, { clientX: 250, clientY: 250 })
     expect(canvasEl.style.cursor).toBe('auto')
   })
 
+  it('Removes all shapes after clicking remove all btn', async () => {
+    const { getByText } = render(<XImageAnnotator model={model} />)
+    await waitForLoad()
+    expect(wave.args[name]).toMatchObject(items)
+    fireEvent.click(getByText('Remove all'))
+    expect(wave.args[name]).toMatchObject([])
+  })
+
   describe('Rect', () => {
     it('Draws a new rect', async () => {
       const { container, getByText } = render(<XImageAnnotator model={model} />)
-      await waitForImgLoad()
+      await waitForLoad()
       const canvasEl = container.querySelectorAll('canvas')[1]
       fireEvent.click(getByText('Rectangle'))
       fireEvent.mouseDown(canvasEl, { clientX: 110, clientY: 110 })
@@ -101,7 +109,7 @@ describe('ImageAnnotator.tsx', () => {
 
     it('Draws a new rect with different tag if selected', async () => {
       const { container, getByText } = render(<XImageAnnotator model={model} />)
-      await waitForImgLoad()
+      await waitForLoad()
       const canvasEl = container.querySelectorAll('canvas')[1]
       fireEvent.click(getByText('Rectangle'))
       fireEvent.click(getByText('Object'))
@@ -113,7 +121,7 @@ describe('ImageAnnotator.tsx', () => {
 
     it('Does not draw a new rect if active shape is select', async () => {
       const { container } = render(<XImageAnnotator model={model} />)
-      await waitForImgLoad()
+      await waitForLoad()
       const canvasEl = container.querySelectorAll('canvas')[1]
       fireEvent.mouseDown(canvasEl, { clientX: 110, clientY: 110 })
       fireEvent.click(canvasEl, { clientX: 150, clientY: 150 })
@@ -121,9 +129,25 @@ describe('ImageAnnotator.tsx', () => {
       expect(wave.args[name]).toMatchObject(items)
     })
 
-    it('Changes tag of when clicked existing rect', async () => {
+    it('Removes rect after clicking remove btn', async () => {
       const { container, getByText } = render(<XImageAnnotator model={model} />)
-      await waitForImgLoad()
+      await waitForLoad()
+      const canvasEl = container.querySelectorAll('canvas')[1]
+      expect(wave.args[name]).toMatchObject(items)
+
+      const removeBtn = getByText('Remove selection').parentElement?.parentElement?.parentElement
+      expect(removeBtn).toHaveAttribute('aria-disabled', 'true')
+      fireEvent.click(canvasEl, { clientX: 50, clientY: 50 })
+      await waitForLoad()
+      expect(removeBtn).not.toHaveAttribute('aria-disabled')
+      fireEvent.click(removeBtn!)
+
+      expect(wave.args[name]).toMatchObject([polygon])
+    })
+
+    it('Changes tag when clicked existing rect', async () => {
+      const { container, getByText } = render(<XImageAnnotator model={model} />)
+      await waitForLoad()
       const canvasEl = container.querySelectorAll('canvas')[1]
       fireEvent.click(canvasEl, { clientX: 50, clientY: 50 })
       fireEvent.click(getByText('Object'))
@@ -133,7 +157,7 @@ describe('ImageAnnotator.tsx', () => {
 
     it('Displays the correct cursor when hovering over rect', async () => {
       const { container } = render(<XImageAnnotator model={model} />)
-      await waitForImgLoad()
+      await waitForLoad()
       const canvasEl = container.querySelectorAll('canvas')[1]
       fireEvent.mouseMove(canvasEl, { clientX: 50, clientY: 50 })
       expect(canvasEl.style.cursor).toBe('pointer')
@@ -141,7 +165,7 @@ describe('ImageAnnotator.tsx', () => {
 
     it('Displays the correct cursor when hovering over focused rect', async () => {
       const { container } = render(<XImageAnnotator model={model} />)
-      await waitForImgLoad()
+      await waitForLoad()
       const canvasEl = container.querySelectorAll('canvas')[1]
       fireEvent.click(canvasEl, { clientX: 50, clientY: 50 })
       expect(canvasEl.style.cursor).toBe('move')
@@ -153,7 +177,7 @@ describe('ImageAnnotator.tsx', () => {
 
     it('Displays the correct cursor when hovering over focused rect corners', async () => {
       const { container } = render(<XImageAnnotator model={model} />)
-      await waitForImgLoad()
+      await waitForLoad()
       const canvasEl = container.querySelectorAll('canvas')[1]
       fireEvent.click(canvasEl, { clientX: 50, clientY: 50 })
 
@@ -173,7 +197,7 @@ describe('ImageAnnotator.tsx', () => {
 
     it('Moves rect correctly', async () => {
       const { container } = render(<XImageAnnotator model={model} />)
-      await waitForImgLoad()
+      await waitForLoad()
       const canvasEl = container.querySelectorAll('canvas')[1]
       fireEvent.click(canvasEl, { clientX: 50, clientY: 50 })
       fireEvent.mouseDown(canvasEl, { clientX: 50, clientY: 50 })
@@ -185,7 +209,7 @@ describe('ImageAnnotator.tsx', () => {
 
     it('Does not move rect if left mouse btn not pressed (dragging)', async () => {
       const { container } = render(<XImageAnnotator model={model} />)
-      await waitForImgLoad()
+      await waitForLoad()
       const canvasEl = container.querySelectorAll('canvas')[1]
       fireEvent.click(canvasEl, { clientX: 50, clientY: 50 })
       fireEvent.mouseDown(canvasEl, { clientX: 50, clientY: 50 })
@@ -197,7 +221,7 @@ describe('ImageAnnotator.tsx', () => {
 
     it('Resizes top left corner properly', async () => {
       const { container } = render(<XImageAnnotator model={model} />)
-      await waitForImgLoad()
+      await waitForLoad()
       const canvasEl = container.querySelectorAll('canvas')[1]
       fireEvent.click(canvasEl, { clientX: 50, clientY: 50 })
       fireEvent.mouseDown(canvasEl, { clientX: 10, clientY: 10 })
@@ -212,7 +236,7 @@ describe('ImageAnnotator.tsx', () => {
 
     it('Resizes top right corner properly', async () => {
       const { container } = render(<XImageAnnotator model={model} />)
-      await waitForImgLoad()
+      await waitForLoad()
       const canvasEl = container.querySelectorAll('canvas')[1]
       fireEvent.click(canvasEl, { clientX: 50, clientY: 50 })
       fireEvent.mouseDown(canvasEl, { clientX: 100, clientY: 10 })
@@ -227,7 +251,7 @@ describe('ImageAnnotator.tsx', () => {
 
     it('Resizes bottom left corner properly', async () => {
       const { container } = render(<XImageAnnotator model={model} />)
-      await waitForImgLoad()
+      await waitForLoad()
       const canvasEl = container.querySelectorAll('canvas')[1]
       fireEvent.click(canvasEl, { clientX: 50, clientY: 50 })
       fireEvent.mouseDown(canvasEl, { clientX: 10, clientY: 100 })
@@ -242,7 +266,7 @@ describe('ImageAnnotator.tsx', () => {
 
     it('Resizes bottom right corner properly', async () => {
       const { container } = render(<XImageAnnotator model={model} />)
-      await waitForImgLoad()
+      await waitForLoad()
       const canvasEl = container.querySelectorAll('canvas')[1]
       fireEvent.click(canvasEl, { clientX: 50, clientY: 50 })
       fireEvent.mouseDown(canvasEl, { clientX: 100, clientY: 100 })
@@ -258,7 +282,7 @@ describe('ImageAnnotator.tsx', () => {
   describe('Polygon', () => {
     it('Draws a new polygon', async () => {
       const { container, getByText } = render(<XImageAnnotator model={model} />)
-      await waitForImgLoad()
+      await waitForLoad()
       const canvasEl = container.querySelectorAll('canvas')[1]
       fireEvent.click(getByText('Polygon'))
       fireEvent.click(canvasEl, { clientX: 10, clientY: 10 })
@@ -274,7 +298,7 @@ describe('ImageAnnotator.tsx', () => {
 
     it('Draws a new polygon with different tag if selected', async () => {
       const { container, getByText } = render(<XImageAnnotator model={model} />)
-      await waitForImgLoad()
+      await waitForLoad()
       const canvasEl = container.querySelectorAll('canvas')[1]
       fireEvent.click(getByText('Polygon'))
       fireEvent.click(getByText('Object'))
@@ -292,7 +316,7 @@ describe('ImageAnnotator.tsx', () => {
 
     it('Does not draw a new polygon if active shape is select', async () => {
       const { container } = render(<XImageAnnotator model={model} />)
-      await waitForImgLoad()
+      await waitForLoad()
       const canvasEl = container.querySelectorAll('canvas')[1]
 
       fireEvent.click(canvasEl, { clientX: 10, clientY: 10 })
@@ -303,9 +327,25 @@ describe('ImageAnnotator.tsx', () => {
       expect(wave.args[name]).toMatchObject(items)
     })
 
+    it('Removes polygon after clicking remove btn', async () => {
+      const { container, getByText } = render(<XImageAnnotator model={model} />)
+      await waitForLoad()
+      const canvasEl = container.querySelectorAll('canvas')[1]
+      expect(wave.args[name]).toMatchObject(items)
+
+      const removeBtn = getByText('Remove selection').parentElement?.parentElement?.parentElement
+      expect(removeBtn).toHaveAttribute('aria-disabled', 'true')
+      fireEvent.click(canvasEl, { clientX: 180, clientY: 120 })
+      await waitForLoad()
+      expect(removeBtn).not.toHaveAttribute('aria-disabled')
+      fireEvent.click(removeBtn!)
+
+      expect(wave.args[name]).toMatchObject([rect])
+    })
+
     it('Changes tag of existing polygon when clicked ', async () => {
       const { container, getByText } = render(<XImageAnnotator model={model} />)
-      await waitForImgLoad()
+      await waitForLoad()
       const canvasEl = container.querySelectorAll('canvas')[1]
       fireEvent.click(canvasEl, { clientX: 180, clientY: 120 })
       fireEvent.click(getByText('Object'))
@@ -315,7 +355,7 @@ describe('ImageAnnotator.tsx', () => {
 
     it('Displays the correct cursor when hovering over polygon', async () => {
       const { container } = render(<XImageAnnotator model={model} />)
-      await waitForImgLoad()
+      await waitForLoad()
       const canvasEl = container.querySelectorAll('canvas')[1]
       fireEvent.mouseMove(canvasEl, { clientX: 180, clientY: 120 })
       expect(canvasEl.style.cursor).toBe('pointer')
@@ -323,7 +363,7 @@ describe('ImageAnnotator.tsx', () => {
 
     it('Displays the correct cursor when hovering over focused polygon', async () => {
       const { container } = render(<XImageAnnotator model={model} />)
-      await waitForImgLoad()
+      await waitForLoad()
       const canvasEl = container.querySelectorAll('canvas')[1]
       fireEvent.click(canvasEl, { clientX: 180, clientY: 120 })
       expect(canvasEl.style.cursor).toBe('move')
@@ -333,7 +373,7 @@ describe('ImageAnnotator.tsx', () => {
 
     it('Moves polygon correctly', async () => {
       const { container } = render(<XImageAnnotator model={model} />)
-      await waitForImgLoad()
+      await waitForLoad()
       const canvasEl = container.querySelectorAll('canvas')[1]
 
       fireEvent.click(canvasEl, { clientX: 180, clientY: 120 })
@@ -349,7 +389,7 @@ describe('ImageAnnotator.tsx', () => {
 
     it('Does not move polygon if left mouse btn not pressed (dragging)', async () => {
       const { container } = render(<XImageAnnotator model={model} />)
-      await waitForImgLoad()
+      await waitForLoad()
       const canvasEl = container.querySelectorAll('canvas')[1]
 
       fireEvent.click(canvasEl, { clientX: 180, clientY: 120 })
@@ -362,7 +402,7 @@ describe('ImageAnnotator.tsx', () => {
 
     it('Moves polygon by a single point correctly', async () => {
       const { container } = render(<XImageAnnotator model={model} />)
-      await waitForImgLoad()
+      await waitForLoad()
       const canvasEl = container.querySelectorAll('canvas')[1]
 
       fireEvent.click(canvasEl, { clientX: 180, clientY: 120 })
@@ -379,7 +419,7 @@ describe('ImageAnnotator.tsx', () => {
 
     it('Moves polygon by a single point correctly', async () => {
       const { container } = render(<XImageAnnotator model={model} />)
-      await waitForImgLoad()
+      await waitForLoad()
       const canvasEl = container.querySelectorAll('canvas')[1]
 
       fireEvent.click(canvasEl, { clientX: 180, clientY: 120 })
@@ -396,7 +436,7 @@ describe('ImageAnnotator.tsx', () => {
 
     it('Moves polygon by a single point, then moves it whole', async () => {
       const { container } = render(<XImageAnnotator model={model} />)
-      await waitForImgLoad()
+      await waitForLoad()
       const canvasEl = container.querySelectorAll('canvas')[1]
 
       fireEvent.click(canvasEl, { clientX: 180, clientY: 120 })

--- a/ui/src/image_annotator.test.tsx
+++ b/ui/src/image_annotator.test.tsx
@@ -343,6 +343,18 @@ describe('ImageAnnotator.tsx', () => {
       expect(wave.args[name]).toMatchObject([rect])
     })
 
+    it('Adds aux point to polygon when clicked', async () => {
+      const { container } = render(<XImageAnnotator model={model} />)
+      await waitForLoad()
+      const canvasEl = container.querySelectorAll('canvas')[1]
+      fireEvent.click(canvasEl, { clientX: 180, clientY: 120 })
+      fireEvent.click(canvasEl, { clientX: 240, clientY: 160 })
+      expect(wave.args[name]).toMatchObject([
+        rect,
+        { shape: { polygon: { items: [{ x: 105, y: 100 }, { x: 240, y: 100 }, { x: 240, y: 160 }, { x: 240, y: 220 },] } }, tag: 'person' }
+      ])
+    })
+
     it('Changes tag of existing polygon when clicked ', async () => {
       const { container, getByText } = render(<XImageAnnotator model={model} />)
       await waitForLoad()
@@ -369,6 +381,16 @@ describe('ImageAnnotator.tsx', () => {
       expect(canvasEl.style.cursor).toBe('move')
       fireEvent.mouseMove(canvasEl, { clientX: 250, clientY: 250 })
       expect(canvasEl.style.cursor).toBe('auto')
+    })
+
+    it('Displays the correct cursor when hovering over polygon aux point', async () => {
+      const { container } = render(<XImageAnnotator model={model} />)
+      await waitForLoad()
+      const canvasEl = container.querySelectorAll('canvas')[1]
+      fireEvent.click(canvasEl, { clientX: 180, clientY: 120 })
+      expect(canvasEl.style.cursor).toBe('move')
+      fireEvent.mouseMove(canvasEl, { clientX: 240, clientY: 160 })
+      expect(canvasEl.style.cursor).toBe('pointer')
     })
 
     it('Moves polygon correctly', async () => {

--- a/ui/src/image_annotator.test.tsx
+++ b/ui/src/image_annotator.test.tsx
@@ -1,0 +1,380 @@
+// Copyright 2020 H2O.ai, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { act, fireEvent, render, waitFor } from '@testing-library/react'
+import { U } from 'h2o-wave'
+import React from 'react'
+import { ImageAnnotator, XImageAnnotator } from './image_annotator'
+import { wave } from './ui'
+
+class MockedImage extends window.Image {
+  constructor() {
+    super()
+    setTimeout(() => { if (this.onload) this.onload(null as any) }, 10)
+  }
+}
+class MockedRenderingContext extends window.CanvasRenderingContext2D {
+  drawImage(image: CanvasImageSource, dx: U, dy: U): void
+  drawImage(image: CanvasImageSource, dx: U, dy: U, dw: U, dh: U): void
+  drawImage(image: CanvasImageSource, sx: U, sy: U, sw: U, sh: U, dx: U, dy: U, dw: U, dh: U): void
+  drawImage(_image: any, _sx: U, _sy: U, _sw?: U, _sh?: U, _dx?: U, _dy?: U, _dw?: U, _dh?: U): void {
+    // Noop.
+  }
+}
+
+const
+  name = 'image_annotator',
+  rect = { shape: { rect: { x1: 10, x2: 100, y1: 10, y2: 100 } }, tag: 'person' },
+  polygon = { shape: { polygon: { items: [{ x: 105, y: 100 }, { x: 240, y: 100 }, { x: 240, y: 220 },] } }, tag: 'person' },
+  items = [rect, polygon],
+  model: ImageAnnotator = {
+    name,
+    image: 'img',
+    title: name,
+    tags: [
+      { name: 'person', label: 'Person', color: 'red' },
+      { name: 'object', label: 'Object', color: 'blue' },
+    ],
+    items
+  },
+  waitForImgLoad = async () => act(() => new Promise(res => setTimeout(() => res(), 20)))
+
+
+describe('ImageAnnotator.tsx', () => {
+  beforeAll(() => {
+    Object.defineProperty(window.HTMLImageElement.prototype, 'naturalHeight', { get: () => 300 })
+    Object.defineProperty(window.HTMLImageElement.prototype, 'naturalWidth', { get: () => 600 })
+    window.Image = MockedImage
+    window.CanvasRenderingContext2D = MockedRenderingContext
+  })
+
+  it('Renders data-test attr', () => {
+    const { queryByTestId } = render(<XImageAnnotator model={model} />)
+    expect(queryByTestId(name)).toBeInTheDocument()
+  })
+
+  it('Sets correct args - empty ', () => {
+    render(<XImageAnnotator model={{ ...model, items: undefined }} />)
+    expect(wave.args[name]).toMatchObject([])
+  })
+
+  it('Sets correct args ', async () => {
+    render(<XImageAnnotator model={model} />)
+    await waitFor(() => expect(wave.args[name]).toMatchObject(items))
+  })
+
+  it('Sets correct args - different aspect ratio ', async () => {
+    render(<XImageAnnotator model={{ ...model, image_height: '150px' }} />)
+    await waitFor(() => expect(wave.args[name]).toMatchObject(items))
+  })
+
+  it('Displays the correct cursor when hovering over canvas - no intersection', async () => {
+    const { container } = render(<XImageAnnotator model={model} />)
+    await waitForImgLoad()
+    const canvasEl = container.querySelectorAll('canvas')[1]
+    fireEvent.mouseMove(canvasEl, { clientX: 250, clientY: 250 })
+    expect(canvasEl.style.cursor).toBe('auto')
+  })
+
+  describe('Rect', () => {
+    it('Draws a new rect', async () => {
+      const { container, getByText } = render(<XImageAnnotator model={model} />)
+      await waitForImgLoad()
+      const canvasEl = container.querySelectorAll('canvas')[1]
+      fireEvent.click(getByText('Rectangle'))
+      fireEvent.mouseDown(canvasEl, { clientX: 110, clientY: 110 })
+      fireEvent.click(canvasEl, { clientX: 150, clientY: 150 })
+
+      expect(wave.args[name]).toMatchObject([{ tag: 'person', shape: { rect: { x1: 110, x2: 150, y1: 110, y2: 150 } } }, ...items])
+    })
+
+    it('Draws a new rect with different tag if selected', async () => {
+      const { container, getByText } = render(<XImageAnnotator model={model} />)
+      await waitForImgLoad()
+      const canvasEl = container.querySelectorAll('canvas')[1]
+      fireEvent.click(getByText('Rectangle'))
+      fireEvent.click(getByText('Object'))
+      fireEvent.mouseDown(canvasEl, { clientX: 110, clientY: 110 })
+      fireEvent.click(canvasEl, { clientX: 150, clientY: 150 })
+
+      expect(wave.args[name]).toMatchObject([{ tag: 'object', shape: { rect: { x1: 110, x2: 150, y1: 110, y2: 150 } } }, ...items])
+    })
+
+    it('Does not draw a new rect if active shape is select', async () => {
+      const { container } = render(<XImageAnnotator model={model} />)
+      await waitForImgLoad()
+      const canvasEl = container.querySelectorAll('canvas')[1]
+      fireEvent.mouseDown(canvasEl, { clientX: 110, clientY: 110 })
+      fireEvent.click(canvasEl, { clientX: 150, clientY: 150 })
+
+      expect(wave.args[name]).toMatchObject(items)
+    })
+
+    it('Changes tag of when clicked existing rect', async () => {
+      const { container, getByText } = render(<XImageAnnotator model={model} />)
+      await waitForImgLoad()
+      const canvasEl = container.querySelectorAll('canvas')[1]
+      fireEvent.click(canvasEl, { clientX: 50, clientY: 50 })
+      fireEvent.click(getByText('Object'))
+
+      expect(wave.args[name]).toMatchObject([{ ...rect, tag: 'object' }, polygon])
+    })
+
+    it('Displays the correct cursor when hovering over rect', async () => {
+      const { container } = render(<XImageAnnotator model={model} />)
+      await waitForImgLoad()
+      const canvasEl = container.querySelectorAll('canvas')[1]
+      fireEvent.mouseMove(canvasEl, { clientX: 50, clientY: 50 })
+      expect(canvasEl.style.cursor).toBe('pointer')
+    })
+
+    it('Displays the correct cursor when hovering over focused rect', async () => {
+      const { container } = render(<XImageAnnotator model={model} />)
+      await waitForImgLoad()
+      const canvasEl = container.querySelectorAll('canvas')[1]
+      fireEvent.click(canvasEl, { clientX: 50, clientY: 50 })
+      expect(canvasEl.style.cursor).toBe('move')
+      fireEvent.mouseMove(canvasEl, { clientX: 100, clientY: 100 })
+      expect(canvasEl.style.cursor).toBe('nwse-resize')
+      fireEvent.mouseMove(canvasEl, { clientX: 250, clientY: 250 })
+      expect(canvasEl.style.cursor).toBe('auto')
+    })
+
+    it('Displays the correct cursor when hovering over focused rect corners', async () => {
+      const { container } = render(<XImageAnnotator model={model} />)
+      await waitForImgLoad()
+      const canvasEl = container.querySelectorAll('canvas')[1]
+      fireEvent.click(canvasEl, { clientX: 50, clientY: 50 })
+
+      // Top left.
+      fireEvent.mouseMove(canvasEl, { clientX: 10, clientY: 10 })
+      expect(canvasEl.style.cursor).toBe('nwse-resize')
+      // Top right.
+      fireEvent.mouseMove(canvasEl, { clientX: 100, clientY: 10 })
+      expect(canvasEl.style.cursor).toBe('nesw-resize')
+      // Bottom left.
+      fireEvent.mouseMove(canvasEl, { clientX: 10, clientY: 100 })
+      expect(canvasEl.style.cursor).toBe('nesw-resize')
+      // Bottom right.
+      fireEvent.mouseMove(canvasEl, { clientX: 100, clientY: 100 })
+      expect(canvasEl.style.cursor).toBe('nwse-resize')
+    })
+
+    it('Moves rect correctly', async () => {
+      const { container } = render(<XImageAnnotator model={model} />)
+      await waitForImgLoad()
+      const canvasEl = container.querySelectorAll('canvas')[1]
+      fireEvent.click(canvasEl, { clientX: 50, clientY: 50 })
+      fireEvent.mouseDown(canvasEl, { clientX: 50, clientY: 50 })
+      fireEvent.mouseMove(canvasEl, { clientX: 60, clientY: 60, buttons: 1 })
+      fireEvent.click(canvasEl, { clientX: 60, clientY: 60 })
+
+      expect(wave.args[name]).toMatchObject([{ tag: 'person', shape: { rect: { x1: 20, x2: 110, y1: 20, y2: 110 } } }, polygon])
+    })
+
+    it('Does not move rect if left mouse btn not pressed (dragging)', async () => {
+      const { container } = render(<XImageAnnotator model={model} />)
+      await waitForImgLoad()
+      const canvasEl = container.querySelectorAll('canvas')[1]
+      fireEvent.click(canvasEl, { clientX: 50, clientY: 50 })
+      fireEvent.mouseDown(canvasEl, { clientX: 50, clientY: 50 })
+      fireEvent.mouseMove(canvasEl, { clientX: 60, clientY: 60 })
+      fireEvent.click(canvasEl, { clientX: 60, clientY: 60 })
+
+      expect(wave.args[name]).toMatchObject(items)
+    })
+
+    it('Resizes top left corner properly', async () => {
+      const { container } = render(<XImageAnnotator model={model} />)
+      await waitForImgLoad()
+      const canvasEl = container.querySelectorAll('canvas')[1]
+      fireEvent.click(canvasEl, { clientX: 50, clientY: 50 })
+      fireEvent.mouseDown(canvasEl, { clientX: 10, clientY: 10 })
+      fireEvent.mouseMove(canvasEl, { clientX: 5, clientY: 5, buttons: 1 })
+      fireEvent.click(canvasEl, { clientX: 5, clientY: 5 })
+
+      expect(wave.args[name]).toMatchObject([
+        { tag: 'person', shape: { rect: { x1: 5, x2: 100, y1: 5, y2: 100 } } },
+        polygon
+      ])
+    })
+
+    it('Resizes top right corner properly', async () => {
+      const { container } = render(<XImageAnnotator model={model} />)
+      await waitForImgLoad()
+      const canvasEl = container.querySelectorAll('canvas')[1]
+      fireEvent.click(canvasEl, { clientX: 50, clientY: 50 })
+      fireEvent.mouseDown(canvasEl, { clientX: 100, clientY: 10 })
+      fireEvent.mouseMove(canvasEl, { clientX: 105, clientY: 5, buttons: 1 })
+      fireEvent.click(canvasEl, { clientX: 5, clientY: 5 })
+
+      expect(wave.args[name]).toMatchObject([
+        { tag: 'person', shape: { rect: { x1: 10, x2: 105, y1: 5, y2: 100 } } },
+        polygon
+      ])
+    })
+
+    it('Resizes bottom left corner properly', async () => {
+      const { container } = render(<XImageAnnotator model={model} />)
+      await waitForImgLoad()
+      const canvasEl = container.querySelectorAll('canvas')[1]
+      fireEvent.click(canvasEl, { clientX: 50, clientY: 50 })
+      fireEvent.mouseDown(canvasEl, { clientX: 10, clientY: 100 })
+      fireEvent.mouseMove(canvasEl, { clientX: 5, clientY: 105, buttons: 1 })
+      fireEvent.click(canvasEl, { clientX: 5, clientY: 5 })
+
+      expect(wave.args[name]).toMatchObject([
+        { tag: 'person', shape: { rect: { x1: 5, x2: 100, y1: 10, y2: 105 } } },
+        polygon
+      ])
+    })
+
+    it('Resizes bottom right corner properly', async () => {
+      const { container } = render(<XImageAnnotator model={model} />)
+      await waitForImgLoad()
+      const canvasEl = container.querySelectorAll('canvas')[1]
+      fireEvent.click(canvasEl, { clientX: 50, clientY: 50 })
+      fireEvent.mouseDown(canvasEl, { clientX: 100, clientY: 100 })
+      fireEvent.mouseMove(canvasEl, { clientX: 105, clientY: 105, buttons: 1 })
+      fireEvent.click(canvasEl, { clientX: 5, clientY: 5 })
+
+      expect(wave.args[name]).toMatchObject([
+        { tag: 'person', shape: { rect: { x1: 10, x2: 105, y1: 10, y2: 105 } } },
+        polygon
+      ])
+    })
+  })
+  describe('Polygon', () => {
+    it('Draws a new polygon', async () => {
+      const { container, getByText } = render(<XImageAnnotator model={model} />)
+      await waitForImgLoad()
+      const canvasEl = container.querySelectorAll('canvas')[1]
+      fireEvent.click(getByText('Polygon'))
+      fireEvent.click(canvasEl, { clientX: 10, clientY: 10 })
+      fireEvent.click(canvasEl, { clientX: 20, clientY: 20 })
+      fireEvent.click(canvasEl, { clientX: 30, clientY: 30 })
+      fireEvent.click(canvasEl, { clientX: 10, clientY: 10 })
+
+      expect(wave.args[name]).toMatchObject([
+        { tag: 'person', shape: { polygon: { items: [{ x: 10, y: 10 }, { x: 20, y: 20 }, { x: 30, y: 30 },] } } },
+        ...items
+      ])
+    })
+
+    it('Draws a new polygon with different tag if selected', async () => {
+      const { container, getByText } = render(<XImageAnnotator model={model} />)
+      await waitForImgLoad()
+      const canvasEl = container.querySelectorAll('canvas')[1]
+      fireEvent.click(getByText('Polygon'))
+      fireEvent.click(getByText('Object'))
+
+      fireEvent.click(canvasEl, { clientX: 10, clientY: 10 })
+      fireEvent.click(canvasEl, { clientX: 20, clientY: 20 })
+      fireEvent.click(canvasEl, { clientX: 30, clientY: 30 })
+      fireEvent.click(canvasEl, { clientX: 10, clientY: 10 })
+
+      expect(wave.args[name]).toMatchObject([
+        { tag: 'object', shape: { polygon: { items: [{ x: 10, y: 10 }, { x: 20, y: 20 }, { x: 30, y: 30 },] } } },
+        ...items
+      ])
+    })
+
+    it('Does not draw a new polygon if active shape is select', async () => {
+      const { container } = render(<XImageAnnotator model={model} />)
+      await waitForImgLoad()
+      const canvasEl = container.querySelectorAll('canvas')[1]
+
+      fireEvent.click(canvasEl, { clientX: 10, clientY: 10 })
+      fireEvent.click(canvasEl, { clientX: 20, clientY: 20 })
+      fireEvent.click(canvasEl, { clientX: 30, clientY: 30 })
+      fireEvent.click(canvasEl, { clientX: 10, clientY: 10 })
+
+      expect(wave.args[name]).toMatchObject(items)
+    })
+
+    it('Changes tag of existing polygon when clicked ', async () => {
+      const { container, getByText } = render(<XImageAnnotator model={model} />)
+      await waitForImgLoad()
+      const canvasEl = container.querySelectorAll('canvas')[1]
+      fireEvent.click(canvasEl, { clientX: 180, clientY: 120 })
+      fireEvent.click(getByText('Object'))
+
+      expect(wave.args[name]).toMatchObject([rect, { ...polygon, tag: 'object' }])
+    })
+
+    it('Displays the correct cursor when hovering over polygon', async () => {
+      const { container } = render(<XImageAnnotator model={model} />)
+      await waitForImgLoad()
+      const canvasEl = container.querySelectorAll('canvas')[1]
+      fireEvent.mouseMove(canvasEl, { clientX: 180, clientY: 120 })
+      expect(canvasEl.style.cursor).toBe('pointer')
+    })
+
+    it('Displays the correct cursor when hovering over focused polygon', async () => {
+      const { container } = render(<XImageAnnotator model={model} />)
+      await waitForImgLoad()
+      const canvasEl = container.querySelectorAll('canvas')[1]
+      fireEvent.click(canvasEl, { clientX: 180, clientY: 120 })
+      expect(canvasEl.style.cursor).toBe('move')
+      fireEvent.mouseMove(canvasEl, { clientX: 250, clientY: 250 })
+      expect(canvasEl.style.cursor).toBe('auto')
+    })
+
+    it('Moves polygon correctly', async () => {
+      const { container } = render(<XImageAnnotator model={model} />)
+      await waitForImgLoad()
+      const canvasEl = container.querySelectorAll('canvas')[1]
+
+      fireEvent.click(canvasEl, { clientX: 180, clientY: 120 })
+      fireEvent.mouseDown(canvasEl, { clientX: 180, clientY: 120 })
+      fireEvent.mouseMove(canvasEl, { clientX: 190, clientY: 130, buttons: 1 })
+      fireEvent.click(canvasEl, { clientX: 190, clientY: 130 })
+
+      expect(wave.args[name]).toMatchObject([
+        rect,
+        { shape: { polygon: { items: [{ x: 115, y: 110 }, { x: 250, y: 110 }, { x: 250, y: 230 }] } }, tag: 'person' },
+      ])
+    })
+
+    it('Does not move polygon if left mouse btn not pressed (dragging)', async () => {
+      const { container } = render(<XImageAnnotator model={model} />)
+      await waitForImgLoad()
+      const canvasEl = container.querySelectorAll('canvas')[1]
+
+      fireEvent.click(canvasEl, { clientX: 180, clientY: 120 })
+      fireEvent.mouseDown(canvasEl, { clientX: 180, clientY: 120 })
+      fireEvent.mouseMove(canvasEl, { clientX: 190, clientY: 130 })
+      fireEvent.click(canvasEl, { clientX: 190, clientY: 130 })
+
+      expect(wave.args[name]).toMatchObject(items)
+    })
+
+    it('Moves polygon by a single point correctly', async () => {
+      const { container } = render(<XImageAnnotator model={model} />)
+      await waitForImgLoad()
+      const canvasEl = container.querySelectorAll('canvas')[1]
+
+      fireEvent.click(canvasEl, { clientX: 180, clientY: 120 })
+      fireEvent.mouseDown(canvasEl, { clientX: 105, clientY: 100 })
+      fireEvent.mouseMove(canvasEl, { clientX: 105, clientY: 100, buttons: 1 })
+      fireEvent.mouseMove(canvasEl, { clientX: 100, clientY: 200, buttons: 1 })
+      fireEvent.click(canvasEl, { clientX: 100, clientY: 200 })
+
+      expect(wave.args[name]).toMatchObject([
+        rect,
+        { shape: { polygon: { items: [{ x: 100, y: 200 }, { x: 240, y: 100 }, { x: 240, y: 220 },] } }, tag: 'person' },
+      ])
+    })
+  })
+})

--- a/ui/src/image_annotator.test.tsx
+++ b/ui/src/image_annotator.test.tsx
@@ -376,5 +376,49 @@ describe('ImageAnnotator.tsx', () => {
         { shape: { polygon: { items: [{ x: 100, y: 200 }, { x: 240, y: 100 }, { x: 240, y: 220 },] } }, tag: 'person' },
       ])
     })
+
+    it('Moves polygon by a single point correctly', async () => {
+      const { container } = render(<XImageAnnotator model={model} />)
+      await waitForImgLoad()
+      const canvasEl = container.querySelectorAll('canvas')[1]
+
+      fireEvent.click(canvasEl, { clientX: 180, clientY: 120 })
+      fireEvent.mouseDown(canvasEl, { clientX: 105, clientY: 100 })
+      fireEvent.mouseMove(canvasEl, { clientX: 105, clientY: 100, buttons: 1 })
+      fireEvent.mouseMove(canvasEl, { clientX: 100, clientY: 200, buttons: 1 })
+      fireEvent.click(canvasEl, { clientX: 100, clientY: 200 })
+
+      expect(wave.args[name]).toMatchObject([
+        rect,
+        { shape: { polygon: { items: [{ x: 100, y: 200 }, { x: 240, y: 100 }, { x: 240, y: 220 },] } }, tag: 'person' },
+      ])
+    })
+
+    it.only('Moves polygon by a single point, then moves it whole', async () => {
+      const { container } = render(<XImageAnnotator model={model} />)
+      await waitForImgLoad()
+      const canvasEl = container.querySelectorAll('canvas')[1]
+
+      fireEvent.click(canvasEl, { clientX: 180, clientY: 120 })
+      fireEvent.mouseDown(canvasEl, { clientX: 105, clientY: 100 })
+      fireEvent.mouseMove(canvasEl, { clientX: 105, clientY: 100, buttons: 1 })
+      fireEvent.mouseMove(canvasEl, { clientX: 100, clientY: 200, buttons: 1 })
+      fireEvent.click(canvasEl, { clientX: 100, clientY: 200 })
+
+      expect(wave.args[name]).toMatchObject([
+        rect,
+        { shape: { polygon: { items: [{ x: 100, y: 200 }, { x: 240, y: 100 }, { x: 240, y: 220 },] } }, tag: 'person' },
+      ])
+
+      fireEvent.click(canvasEl, { clientX: 180, clientY: 150 })
+      fireEvent.mouseDown(canvasEl, { clientX: 180, clientY: 150 })
+      fireEvent.mouseMove(canvasEl, { clientX: 190, clientY: 160, buttons: 1 })
+      fireEvent.click(canvasEl, { clientX: 190, clientY: 160 })
+
+      expect(wave.args[name]).toMatchObject([
+        rect,
+        { shape: { polygon: { items: [{ x: 110, y: 210 }, { x: 250, y: 110 }, { x: 250, y: 230 },] } }, tag: 'person' },
+      ])
+    })
   })
 })

--- a/ui/src/image_annotator.tsx
+++ b/ui/src/image_annotator.tsx
@@ -154,6 +154,7 @@ export const XImageAnnotator = ({ model }: { model: ImageAnnotator }) => {
       })
     }, [getCurrentTagColor]),
     onMouseDown = (e: React.MouseEvent) => {
+      console.log('mousedown')
       if (e.button !== 0) return // Ignore right-click.
       const canvas = canvasRef.current
       if (!canvas) return
@@ -212,8 +213,7 @@ export const XImageAnnotator = ({ model }: { model: ImageAnnotator }) => {
       switch (activeShape) {
         case 'rect': {
           // TODO: Fix rect selection.
-          const newRect = rectRef.current?.onClick(e, cursor_x, cursor_y, drawnShapes, drawnShapes, activeTag, start)
-          if (newRect) setDrawnShapes([newRect, ...drawnShapes])
+          rectRef.current?.onClick(e, cursor_x, cursor_y, setDrawnShapes, activeTag, start)
           break
         }
         case 'polygon': {

--- a/ui/src/image_annotator.tsx
+++ b/ui/src/image_annotator.tsx
@@ -213,6 +213,7 @@ export const XImageAnnotator = ({ model }: { model: ImageAnnotator }) => {
       switch (activeShape) {
         case 'rect': {
           rectRef.current?.onClick(e, cursor_x, cursor_y, setDrawnShapes, activeTag, start)
+          redrawExistingShapes()
           break
         }
         case 'polygon': {
@@ -222,7 +223,6 @@ export const XImageAnnotator = ({ model }: { model: ImageAnnotator }) => {
         }
       }
 
-      redrawExistingShapes()
       if (activeShape !== 'polygon') startPosition.current = undefined
       canvas.style.cursor = getCorrectCursor(drawnShapes, cursor_x, cursor_y, drawnShapes.find(({ isFocused }) => isFocused))
     },

--- a/ui/src/image_annotator.tsx
+++ b/ui/src/image_annotator.tsx
@@ -306,7 +306,7 @@ export const XImageAnnotator = ({ model }: { model: ImageAnnotator }) => {
       canvas.parentElement!.style.height = px(height)
 
       rectRef.current = new RectAnnotator(canvas)
-      polygonRef.current = new PolygonAnnotator(canvas)
+      if (ctxRef.current) polygonRef.current = new PolygonAnnotator(ctxRef.current)
 
       ctx.drawImage(img, 0, 0, img.width, img.height, 0, 0, img.width * aspectRatio, img.height * aspectRatio)
       if (!drawnShapes.length) {

--- a/ui/src/image_annotator.tsx
+++ b/ui/src/image_annotator.tsx
@@ -2,12 +2,13 @@ import * as Fluent from '@fluentui/react'
 import { B, F, Id, Rec, S, U } from 'h2o-wave'
 import React from 'react'
 import { stylesheet } from 'typestyle'
+import { AnnotatorRect, getCorner, isIntersectingRect } from './image_annotator_rect'
 import { AnnotatorTags } from './text_annotator'
 import { clas, cssVar, cssVarValue, px } from './theme'
 import { wave } from './ui'
 
 /** Create a rectangular annotation shape. */
-interface ImageAnnotatorRect {
+export interface ImageAnnotatorRect {
   /** `x` coordinate of the rectangle's corner. */
   x1: F
   /** `y` coordinate of the rectangle's corner. */
@@ -21,6 +22,7 @@ interface ImageAnnotatorRect {
 /** Create a shape to be rendered as an annotation on an image annotator. */
 interface ImageAnnotatorShape {
   rect?: ImageAnnotatorRect
+  polygon?: ImageAnnotatorRect
 }
 
 /** Create a unique tag type for use in an image annotator. */
@@ -63,13 +65,13 @@ export interface ImageAnnotator {
   image_height?: S
 }
 
-type Position = {
+export type Position = {
   x: U
   y: U
   dragging?: B
 }
 
-type DrawnShape = ImageAnnotatorItem & {
+export type DrawnShape = ImageAnnotatorItem & {
   isFocused?: B
 }
 
@@ -94,57 +96,7 @@ const
       margin: 8
     }
   }),
-  ARC_RADIUS = 4,
-  MIN_RECT_WIDTH = 5,
-  MIN_RECT_HEIGHT = 5,
-  isIntersectingRect = (cursor_x: U, cursor_y: U, rect?: ImageAnnotatorRect) => {
-    if (!rect) return false
-    const
-      { x2, x1, y2, y1 } = rect,
-      x_min = Math.min(x1, x2),
-      x_max = Math.max(x1, x2),
-      y_min = Math.min(y1, y2),
-      y_max = Math.max(y1, y2)
-
-    return cursor_x > x_min && cursor_x < x_max && cursor_y > y_min && cursor_y < y_max
-  },
   eventToCursor = (event: React.MouseEvent, rect: DOMRect) => ({ cursor_x: event.clientX - rect.left, cursor_y: event.clientY - rect.top }),
-  drawCircle = (ctx: CanvasRenderingContext2D, x: U, y: U, fillColor: S) => {
-    ctx.beginPath()
-    ctx.fillStyle = fillColor
-    const path = new Path2D()
-    path.arc(x, y, ARC_RADIUS, 0, 2 * Math.PI)
-    ctx.fill(path)
-    ctx.closePath()
-  },
-  drawRect = (ctx: CanvasRenderingContext2D, { x1, x2, y1, y2 }: ImageAnnotatorRect, strokeColor: S, isFocused = false) => {
-    ctx.beginPath()
-    ctx.lineWidth = 3
-    ctx.strokeStyle = strokeColor
-    ctx.strokeRect(x1, y1, x2 - x1, y2 - y1)
-    ctx.closePath()
-    if (isFocused) {
-      ctx.beginPath()
-      ctx.fillStyle = 'rgba(0, 0, 0, 0.3)'
-      ctx.fillRect(x1, y1, x2 - x1, y2 - y1)
-      ctx.closePath()
-      drawCircle(ctx, x1, y1, strokeColor)
-      drawCircle(ctx, x2, y1, strokeColor)
-      drawCircle(ctx, x2, y2, strokeColor)
-      drawCircle(ctx, x1, y2, strokeColor)
-    }
-  },
-  getCorner = (x: U, y: U, { x1, y1, x2, y2 }: ImageAnnotatorRect, ignoreMaxMin = false) => {
-    const
-      x_min = ignoreMaxMin ? x1 : Math.min(x1, x2),
-      x_max = ignoreMaxMin ? x2 : Math.max(x1, x2),
-      y_min = ignoreMaxMin ? y1 : Math.min(y1, y2),
-      y_max = ignoreMaxMin ? y2 : Math.max(y1, y2)
-    if (x > x_min - ARC_RADIUS && x < x_min + ARC_RADIUS && y > y_min - ARC_RADIUS && y < y_min + ARC_RADIUS) return 'topLeft'
-    else if (x > x_min - ARC_RADIUS && x < x_min + ARC_RADIUS && y > y_max - ARC_RADIUS && y < y_max + ARC_RADIUS) return 'topRight'
-    else if (x > x_max - ARC_RADIUS && x < x_max + ARC_RADIUS && y > y_min - ARC_RADIUS && y < y_min + ARC_RADIUS) return 'bottomLeft'
-    else if (x > x_max - ARC_RADIUS && x < x_max + ARC_RADIUS && y > y_max - ARC_RADIUS && y < y_max + ARC_RADIUS) return 'bottomRight'
-  },
   getCornerCursor = (shape: ImageAnnotatorRect, cursor_x: U, cursor_y: U) => {
     const corner = getCorner(cursor_x, cursor_y, shape)
     if (corner === 'topLeft' || corner === 'bottomRight') return 'nwse-resize'
@@ -156,27 +108,20 @@ const
     else if (focused?.shape.rect) return getCornerCursor(focused.shape.rect, cursor_x, cursor_y) || 'crosshair'
     else if (intersected) return 'pointer'
     return 'crosshair'
-  },
-  createRect = (x1: F, x2: F, y1: F, y2: F, { width, height }: HTMLCanvasElement) =>
-    Math.abs(x2 - x1) <= MIN_RECT_WIDTH || Math.abs(y2 - y1) <= MIN_RECT_HEIGHT ? undefined : {
-      x1: x1 > width ? width : x1 < 0 ? 0 : x1,
-      x2: x2 > width ? width : x2 < 0 ? 0 : x2,
-      y1: y1 > height ? height : y1 < 0 ? 0 : y1,
-      y2: y2 > height ? height : y2 < 0 ? 0 : y2,
-    }
+  }
 
 export const XImageAnnotator = ({ model }: { model: ImageAnnotator }) => {
   const
     colorsMap = React.useMemo(() => new Map<S, S>(model.tags.map(tag => [tag.name, cssVarValue(tag.color)])), [model.tags]),
     [activeTag, setActiveTag] = React.useState<S>(model.tags[0]?.name || ''),
+    [activeShape, setActiveShape] = React.useState<keyof ImageAnnotatorShape>('rect'),
     [drawnShapes, setDrawnShapes] = React.useState<DrawnShape[]>([]),
     imgRef = React.useRef<HTMLCanvasElement>(null),
     canvasRef = React.useRef<HTMLCanvasElement>(null),
+    rectRef = React.useRef<AnnotatorRect | null>(null),
     [aspectRatio, setAspectRatio] = React.useState(1),
     startPosition = React.useRef<Position | undefined>(undefined),
     ctxRef = React.useRef<CanvasRenderingContext2D | undefined | null>(undefined),
-    resizedCornerRef = React.useRef<S | undefined>(undefined),
-    movedShapeRef = React.useRef<DrawnShape | undefined>(undefined),
     activateTag = React.useCallback((tagName: S) => () => setActiveTag(tagName), [setActiveTag]),
     redrawExistingShapes = React.useCallback(() => {
       const canvas = canvasRef.current
@@ -186,7 +131,7 @@ export const XImageAnnotator = ({ model }: { model: ImageAnnotator }) => {
       ctx.clearRect(0, 0, canvas.width, canvas.height)
       setDrawnShapes(shapes => {
         shapes.forEach(item => {
-          if (item.shape.rect) drawRect(ctx, item.shape.rect, colorsMap.get(item.tag) || cssVarValue('$red'), item.isFocused)
+          if (item.shape.rect) rectRef.current?.drawRect(item.shape.rect, colorsMap.get(item.tag) || cssVarValue('$red'), item.isFocused)
         })
         return shapes
       })
@@ -200,14 +145,12 @@ export const XImageAnnotator = ({ model }: { model: ImageAnnotator }) => {
         { cursor_x, cursor_y } = eventToCursor(e, canvas.getBoundingClientRect()),
         focused = drawnShapes.find(({ isFocused }) => isFocused)
 
-      if (focused?.shape.rect) resizedCornerRef.current = getCorner(cursor_x, cursor_y, focused.shape.rect, true)
+      if (focused?.shape.rect) rectRef.current?.onMouseDown(cursor_x, cursor_y, focused.shape.rect)
       startPosition.current = { x: cursor_x, y: cursor_y }
     },
     onMouseMove = (e: React.MouseEvent) => {
-      const
-        canvas = canvasRef.current,
-        ctx = ctxRef.current
-      if (!canvas || !ctx) return
+      const canvas = canvasRef.current
+      if (!canvas) return
 
       const
         { cursor_x, cursor_y } = eventToCursor(e, canvas.getBoundingClientRect()),
@@ -215,75 +158,16 @@ export const XImageAnnotator = ({ model }: { model: ImageAnnotator }) => {
         clickStartPosition = startPosition.current
 
       if (clickStartPosition) {
-        const
-          intersected = drawnShapes.find(shape => isIntersectingRect(cursor_x, cursor_y, shape.shape.rect)),
-          x1 = clickStartPosition.x,
-          y1 = clickStartPosition.y
-
+        const intersected = drawnShapes.find(shape => isIntersectingRect(cursor_x, cursor_y, shape.shape.rect))
+        let newShape = null
         clickStartPosition.dragging = true
-        if (focused?.shape.rect && resizedCornerRef.current) {
-          if (resizedCornerRef.current === 'topLeft') {
-            focused.shape.rect.x1 += cursor_x - x1
-            focused.shape.rect.y1 += cursor_y - y1
-          }
-          else if (resizedCornerRef.current === 'topRight') {
-            focused.shape.rect.x1 += cursor_x - x1
-            focused.shape.rect.y2 += cursor_y - y1
-          }
-          else if (resizedCornerRef.current === 'bottomLeft') {
-            focused.shape.rect.x2 += cursor_x - x1
-            focused.shape.rect.y1 += cursor_y - y1
-          }
-          else if (resizedCornerRef.current === 'bottomRight') {
-            focused.shape.rect.x2 += cursor_x - x1
-            focused.shape.rect.y2 += cursor_y - y1
-          }
-          startPosition.current = { x: cursor_x, y: cursor_y }
-          redrawExistingShapes()
-        }
-        else if (movedShapeRef.current || intersected?.isFocused) {
-          movedShapeRef.current = movedShapeRef.current || intersected
-          canvas.style.cursor = 'move'
-          if (!movedShapeRef.current?.shape.rect) return
 
-          const
-            rect = movedShapeRef.current.shape.rect,
-            xIncrement = cursor_x - x1,
-            yIncrement = cursor_y - y1,
-            newX1 = rect.x1 + xIncrement,
-            newX2 = rect.x2 + xIncrement,
-            newY1 = rect.y1 + yIncrement,
-            newY2 = rect.y2 + yIncrement,
-            { width, height } = canvas
+        if (activeShape === 'rect') newShape = rectRef.current?.onMouseMove(clickStartPosition, cursor_x, cursor_y, focused, intersected)
 
-          // Prevent moving behind image boundaries.
-          // FIXME: Hitting boundary repeatedly causes rect to increase in size.
-          if (newX1 < rect.x1 && newX1 < 0) rect.x1 = Math.max(0, newX1)
-          else if (newX2 < rect.x2 && newX2 < 0) rect.x2 = Math.max(0, newX2)
-          else if (newY1 < rect.y1 && newY1 < 0) rect.y1 = Math.max(0, newY1)
-          else if (newY2 < rect.y2 && newY2 < 0) rect.y2 = Math.max(0, newY2)
-          else if (newX1 > rect.x1 && newX1 > width) rect.x1 = Math.min(newX1, width)
-          else if (newX2 > rect.x2 && newX2 > width) rect.x2 = Math.min(newX2, width)
-          else if (newY1 > rect.y1 && newY1 > height) rect.y1 = Math.min(newY1, height)
-          else if (newY2 > rect.y2 && newY2 > height) rect.y2 = Math.min(newY2, height)
-          else {
-            rect.x1 = newX1
-            rect.x2 = newX2
-            rect.y1 = newY1
-            rect.y2 = newY2
-          }
+        if (newShape) setDrawnShapes(shapes => shapes.map(shape => ({ ...shape, isFocused: false })))
 
-          startPosition.current = { x: cursor_x, y: cursor_y }
-          redrawExistingShapes()
-        }
-        else {
-          setDrawnShapes(shapes => shapes.map(shape => ({ ...shape, isFocused: false })))
-          redrawExistingShapes()
-          const newRect = createRect(x1, cursor_x, y1, cursor_y, canvas)
-          if (newRect) {
-            drawRect(ctx, newRect, colorsMap.get(activeTag) || cssVarValue('$red'))
-          }
-        }
+        redrawExistingShapes()
+        if (newShape?.rect) rectRef.current?.drawRect(newShape.rect, colorsMap.get(activeTag) || cssVarValue('$red'))
       }
       else {
         canvas.style.cursor = getCorrectCursor(drawnShapes, cursor_x, cursor_y, focused)
@@ -299,20 +183,11 @@ export const XImageAnnotator = ({ model }: { model: ImageAnnotator }) => {
         { cursor_x, cursor_y } = eventToCursor(e, rect),
         newShapes = [...drawnShapes]
 
-      if (start && !resizedCornerRef.current) {
-        const newRect = createRect(start.x, cursor_x, start.y, cursor_y, canvas)
-        if (newRect) newShapes.unshift({ shape: { rect: newRect }, tag: activeTag })
+      if (activeShape === 'rect') {
+        rectRef.current?.onClick(e, cursor_x, cursor_y, newShapes, drawnShapes, activeTag, start)
+        startPosition.current = undefined
       }
 
-      if (!resizedCornerRef.current && !start?.dragging && e.type !== 'mouseleave') {
-        newShapes.forEach(shape => shape.isFocused = false)
-        const intersecting = drawnShapes.find(shape => isIntersectingRect(cursor_x, cursor_y, shape.shape.rect))
-        if (intersecting) intersecting.isFocused = true
-      }
-
-      startPosition.current = undefined
-      movedShapeRef.current = undefined
-      resizedCornerRef.current = ''
       canvas.style.cursor = getCorrectCursor(newShapes, cursor_x, cursor_y, newShapes.find(({ isFocused }) => isFocused))
       setDrawnShapes(newShapes)
       redrawExistingShapes()
@@ -321,7 +196,8 @@ export const XImageAnnotator = ({ model }: { model: ImageAnnotator }) => {
       if (!item) return
       setDrawnShapes(shapes => item.key === 'remove-selected' ? shapes.filter(s => !s.isFocused) : [])
       redrawExistingShapes()
-    }
+    },
+    chooseShape = (_e?: React.MouseEvent<HTMLElement, MouseEvent> | React.KeyboardEvent<HTMLElement>, i?: Fluent.IContextualMenuItem) => setActiveShape(i?.key as keyof ImageAnnotatorShape)
 
   React.useEffect(() => {
     const img = new Image()
@@ -345,6 +221,8 @@ export const XImageAnnotator = ({ model }: { model: ImageAnnotator }) => {
       canvas.style.zIndex = '1'
       canvas.parentElement!.style.height = px(height)
 
+      rectRef.current = new AnnotatorRect(canvas)
+
       ctx.drawImage(img, 0, 0, img.width, img.height, 0, 0, img.width * aspectRatio, img.height * aspectRatio)
       setDrawnShapes((model.items || []).map(({ tag, shape }) => {
         if (shape.rect) return {
@@ -362,6 +240,7 @@ export const XImageAnnotator = ({ model }: { model: ImageAnnotator }) => {
       }))
       redrawExistingShapes()
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [model.name, model.image, model.image_height, redrawExistingShapes, model.items])
 
   React.useEffect(() => {
@@ -385,22 +264,42 @@ export const XImageAnnotator = ({ model }: { model: ImageAnnotator }) => {
     <div data-test={model.name}>
       <div className={clas('wave-s16 wave-w6', css.title)}>{model.title}</div>
       <AnnotatorTags tags={model.tags} activateTag={activateTag} activeTag={activeTag} />
-      <Fluent.CommandBar styles={{ root: { padding: 0 } }} items={[
-        {
-          key: 'remove-selected',
-          text: 'Remove selection',
-          onClick: remove,
-          disabled: drawnShapes.every(s => !s.isFocused),
-          iconProps: { iconName: 'RemoveContent', styles: { root: { fontSize: 20 } } },
-        },
-        {
-          key: 'remove-all',
-          text: 'Remove all',
-          onClick: remove,
-          disabled: drawnShapes.length === 0,
-          iconProps: { iconName: 'DependencyRemove', styles: { root: { fontSize: 20 } } },
-        },
-      ]} />
+      <Fluent.CommandBar
+        styles={{ root: { padding: 0 } }}
+        items={[
+          {
+            key: 'remove-selected',
+            text: 'Remove selection',
+            onClick: remove,
+            disabled: drawnShapes.every(s => !s.isFocused),
+            iconProps: { iconName: 'RemoveContent', styles: { root: { fontSize: 20 } } },
+          },
+          {
+            key: 'remove-all',
+            text: 'Remove all',
+            onClick: remove,
+            disabled: drawnShapes.length === 0,
+            iconProps: { iconName: 'DependencyRemove', styles: { root: { fontSize: 20 } } },
+          },
+        ]}
+        farItems={[
+          {
+            key: 'rect',
+            text: 'Rectangle',
+            onClick: chooseShape,
+            canCheck: true,
+            checked: activeShape === 'rect',
+            iconProps: { iconName: 'RectangleShape', styles: { root: { fontSize: 20 } } },
+          },
+          {
+            key: 'polygon',
+            text: 'Polygon',
+            onClick: chooseShape,
+            canCheck: true,
+            checked: activeShape === 'polygon',
+            iconProps: { iconName: 'SixPointStar', styles: { root: { fontSize: 20 } } },
+          },
+        ]} />
       <div className={css.canvasContainer}>
         <canvas ref={imgRef} className={css.canvas} />
         <canvas ref={canvasRef} className={css.canvas} onMouseMove={onMouseMove} onMouseDown={onMouseDown} onMouseLeave={onClick} onClick={onClick} />

--- a/ui/src/image_annotator.tsx
+++ b/ui/src/image_annotator.tsx
@@ -212,7 +212,6 @@ export const XImageAnnotator = ({ model }: { model: ImageAnnotator }) => {
 
       switch (activeShape) {
         case 'rect': {
-          // TODO: Fix rect selection.
           rectRef.current?.onClick(e, cursor_x, cursor_y, setDrawnShapes, activeTag, start)
           break
         }

--- a/ui/src/image_annotator.tsx
+++ b/ui/src/image_annotator.tsx
@@ -142,6 +142,14 @@ const
     }
     else if (shape.polygon) return { tag, shape: { polygon: { vertices: shape.polygon.vertices.map(i => ({ x: i.x * aspectRatio, y: i.y * aspectRatio })) } } }
     return { tag, shape }
+  }),
+  getFarItem = (key: S, text: S, onClick: () => void, activeShape: keyof ImageAnnotatorShape | 'select', iconName: S) => ({
+    key,
+    text,
+    onClick,
+    canCheck: true,
+    checked: activeShape === key,
+    iconProps: { iconName, styles: { root: { fontSize: 20 } } },
   })
 
 
@@ -375,31 +383,11 @@ export const XImageAnnotator = ({ model }: { model: ImageAnnotator }) => {
           },
         ]}
         farItems={[
-          {
-            key: 'select',
-            text: 'Select',
-            onClick: chooseShape,
-            canCheck: true,
-            checked: activeShape === 'select',
-            iconProps: { iconName: 'TouchPointer', styles: { root: { fontSize: 20 } } },
-          },
-          {
-            key: 'rect',
-            text: 'Rectangle',
-            onClick: chooseShape,
-            canCheck: true,
-            checked: activeShape === 'rect',
-            iconProps: { iconName: 'RectangleShape', styles: { root: { fontSize: 20 } } },
-          },
-          {
-            key: 'polygon',
-            text: 'Polygon',
-            onClick: chooseShape,
-            canCheck: true,
-            checked: activeShape === 'polygon',
-            iconProps: { iconName: 'SixPointStar', styles: { root: { fontSize: 20 } } },
-          },
-        ]} />
+          getFarItem('select', 'Select', chooseShape, activeShape, 'TouchPointer'),
+          getFarItem('rect', 'Rectangle', chooseShape, activeShape, 'RectangleShape'),
+          getFarItem('polygon', 'Polygon', chooseShape, activeShape, 'SixPointStar'),
+        ]}
+      />
       <div className={css.canvasContainer}>
         <canvas ref={imgRef} className={css.canvas} />
         <canvas ref={canvasRef} className={css.canvas} onMouseMove={onMouseMove} onMouseDown={onMouseDown} onClick={onClick} />

--- a/ui/src/image_annotator.tsx
+++ b/ui/src/image_annotator.tsx
@@ -260,6 +260,7 @@ export const XImageAnnotator = ({ model }: { model: ImageAnnotator }) => {
         }
         case 'select': {
           if (intersected) setActiveTag(intersected.tag)
+          polygonRef.current?.resetDragging()
           setDrawnShapes(drawnShapes => drawnShapes.map(s => { s.isFocused = s === intersected; return s }))
           redrawExistingShapes()
           break

--- a/ui/src/image_annotator.tsx
+++ b/ui/src/image_annotator.tsx
@@ -86,9 +86,8 @@ export type Position = {
   dragging?: B
 }
 
-export type DrawnShape = ImageAnnotatorItem & {
-  isFocused?: B
-}
+export type DrawnShape = ImageAnnotatorItem & { isFocused?: B }
+export type DrawnPoint = ImageAnnotatorPoint & { isAux?: B }
 
 const
   css = stylesheet({
@@ -153,7 +152,8 @@ export const XImageAnnotator = ({ model }: { model: ImageAnnotator }) => {
       return [tag.name, `rgba(${R}, ${G}, ${B}, 1)`]
     })), [model.tags]),
     [activeTag, setActiveTag] = React.useState<S>(model.tags[0]?.name || ''),
-    [activeShape, setActiveShape] = React.useState<keyof ImageAnnotatorShape | 'select'>('rect'),
+    [activeShape, setActiveShape] = React.useState<keyof ImageAnnotatorShape | 'select'>('select'),
+    // TODO: Think about making this a ref instead of state.
     [drawnShapes, setDrawnShapes] = React.useState<DrawnShape[]>([]),
     imgRef = React.useRef<HTMLCanvasElement>(null),
     canvasRef = React.useRef<HTMLCanvasElement>(null),
@@ -223,9 +223,16 @@ export const XImageAnnotator = ({ model }: { model: ImageAnnotator }) => {
           break
         }
         case 'select': {
-          if (focused?.shape.rect) rectRef.current?.onMouseMove(cursor_x, cursor_y, focused, intersected, clickStartPosition)
-          else if (focused?.shape.polygon) polygonRef.current?.onMouseMove(cursor_x, cursor_y, focused, intersected, clickStartPosition)
-          redrawExistingShapes()
+          // If left mouse btn is not held during moving, ignore.
+          if (e.buttons !== 1) break
+          if (focused?.shape.rect) {
+            rectRef.current?.onMouseMove(cursor_x, cursor_y, focused, intersected, clickStartPosition)
+            redrawExistingShapes()
+          }
+          else if (focused?.shape.polygon) {
+            polygonRef.current?.onMouseMove(cursor_x, cursor_y, focused, intersected, clickStartPosition)
+            redrawExistingShapes()
+          }
           break
         }
       }

--- a/ui/src/image_annotator.tsx
+++ b/ui/src/image_annotator.tsx
@@ -129,31 +129,22 @@ const
 
     return cursor
   },
-  mapShapesToWaveArgs = (shapes: DrawnShape[], aspectRatio: F) => {
-    return shapes.map(({ shape, tag }) => {
-      if (shape.rect) return {
-        tag,
-        shape: {
-          rect: {
-            x1: shape.rect.x1 * aspectRatio,
-            x2: shape.rect.x2 * aspectRatio,
-            y1: shape.rect.y1 * aspectRatio,
-            y2: shape.rect.y2 * aspectRatio,
-          }
+  mapShapesToWaveArgs = (shapes: DrawnShape[], aspectRatio: F) => shapes.map(({ shape, tag }) => {
+    if (shape.rect) return {
+      tag,
+      shape: {
+        rect: {
+          x1: shape.rect.x1 * aspectRatio,
+          x2: shape.rect.x2 * aspectRatio,
+          y1: shape.rect.y1 * aspectRatio,
+          y2: shape.rect.y2 * aspectRatio,
         }
       }
-      else if (shape.polygon) return {
-        tag,
-        shape: {
-          polygon: {
-            items: shape.polygon.items.map(i => ({ x: i.x * aspectRatio, y: i.y * aspectRatio }))
-          }
-        }
-      }
-      return { tag, shape }
-    })
+    }
+    else if (shape.polygon) return { tag, shape: { polygon: { items: shape.polygon.items.map(i => ({ x: i.x * aspectRatio, y: i.y * aspectRatio })) } } }
+    return { tag, shape }
+  })
 
-  }
 
 export const XImageAnnotator = ({ model }: { model: ImageAnnotator }) => {
   const

--- a/ui/src/image_annotator.tsx
+++ b/ui/src/image_annotator.tsx
@@ -8,6 +8,7 @@ import { AnnotatorTags } from './text_annotator'
 import { clas, cssVar, cssVarValue, px, rgb } from './theme'
 import { wave } from './ui'
 
+/** Create a polygon annotation point with x and y coordinates.. */
 export interface ImageAnnotatorPoint {
   /** `x` coordinate of the point. */
   x: F

--- a/ui/src/image_annotator_polygon.ts
+++ b/ui/src/image_annotator_polygon.ts
@@ -3,12 +3,11 @@ import { DrawnPoint, DrawnShape, ImageAnnotatorPoint, Position } from "./image_a
 import { ARC_RADIUS } from "./image_annotator_rect"
 
 export class PolygonAnnotator {
-  private ctx: CanvasRenderingContext2D | null
   private currPolygonPoints: ImageAnnotatorPoint[] = []
   private draggedPoint: ImageAnnotatorPoint | null = null
   private draggedShape: DrawnShape | null = null
 
-  constructor(private canvas: HTMLCanvasElement) { this.ctx = canvas.getContext('2d') }
+  constructor(private ctx: CanvasRenderingContext2D) { }
 
   resetDragging() {
     this.draggedPoint = null

--- a/ui/src/image_annotator_polygon.ts
+++ b/ui/src/image_annotator_polygon.ts
@@ -106,13 +106,15 @@ export class PolygonAnnotator {
     this.ctx.beginPath()
     this.ctx.moveTo(points[0].x, points[0].y)
 
-    points.forEach(({ x, y }) => this.drawLine(x, y))
+    const _points = this.draggedPoint ? points.filter(p => !p.isAux) : points
+
+    _points.forEach(({ x, y }) => this.drawLine(x, y))
     if (joinLastPoint) this.drawLine(points[0].x, points[0].y)
 
     if (isFocused) {
       this.ctx.fillStyle = color.substring(0, color.length - 2) + '0.2)'
       this.ctx.fill()
-      points.forEach(({ x, y, isAux }) => this.drawPoint(x, y, isAux))
+      _points.forEach(({ x, y, isAux }) => this.drawPoint(x, y, isAux))
     }
   }
 

--- a/ui/src/image_annotator_polygon.ts
+++ b/ui/src/image_annotator_polygon.ts
@@ -39,6 +39,7 @@ export class PolygonAnnotator {
     if (!points.length || !this.ctx) return
 
     this.ctx.fillStyle = color
+    this.ctx.strokeStyle = color
     this.ctx.beginPath()
     this.ctx.moveTo(points[0].x, points[0].y)
 

--- a/ui/src/image_annotator_polygon.ts
+++ b/ui/src/image_annotator_polygon.ts
@@ -1,4 +1,81 @@
-export const
-  handlePolygonOnClick = () => {
+import { F, S, U } from "h2o-wave"
+import { DrawnShape, ImageAnnotatorPoint } from "./image_annotator"
+import { ARC_RADIUS } from "./image_annotator_rect"
 
+export class PolygonAnnotator {
+  private ctx: CanvasRenderingContext2D | null
+  private currPolygonPoints: ImageAnnotatorPoint[] = []
+
+  constructor(private canvas: HTMLCanvasElement) { this.ctx = canvas.getContext('2d') }
+
+  onClick(cursor_x: U, cursor_y: U, color: S, tag: S): DrawnShape | undefined {
+    if (this.isIntersectingFirstPoint(cursor_x, cursor_y)) {
+      const { x, y } = this.currPolygonPoints.at(-1)!
+      const firstPoint = this.currPolygonPoints[0]
+      this.drawLine(x, y, firstPoint.x, firstPoint.y)
+      // TODO: Reset points for next polygon.
+      const newPolygon = { shape: { polygon: { items: [...this.currPolygonPoints] } }, tag }
+      this.currPolygonPoints = []
+      return newPolygon
+    }
+    if (this.currPolygonPoints.length) {
+      const { x, y } = this.currPolygonPoints.at(-1)!
+      this.drawLine(x, y, cursor_x, cursor_y)
+    }
+    this.drawCircle(cursor_x, cursor_y, color)
+    this.currPolygonPoints.push({ x: cursor_x, y: cursor_y })
   }
+
+  drawLine = (x1: F, y1: F, x2: F, y2: F) => {
+    if (!this.ctx) return
+
+    this.ctx.beginPath()
+    this.ctx.moveTo(x1, y1)
+    this.ctx.lineTo(x2, y2)
+    this.ctx.stroke()
+  }
+
+  drawPolygon = (points: ImageAnnotatorPoint[], color: S, joinLastPoint = true) => {
+    if (!points.length) return
+
+    let prevPoint: ImageAnnotatorPoint | null = null
+    points.forEach(({ x, y }) => {
+      this.drawCircle(x, y, color)
+      if (prevPoint) this.drawLine(prevPoint.x, prevPoint.y, x, y)
+      prevPoint = { x, y }
+    })
+    if (joinLastPoint) this.drawLine(points.at(-1)!.x, points.at(-1)!.y, points[0].x, points[0].y)
+  }
+
+  drawPreviewLine = (cursor_x: F, cursor_y: F, color: S) => {
+    if (!this.ctx || !this.currPolygonPoints.length) return
+
+    this.drawPolygon(this.currPolygonPoints, color, false)
+    const { x, y } = this.currPolygonPoints.at(-1)!
+
+    this.ctx.beginPath()
+    this.ctx.fillStyle = color
+    this.ctx.moveTo(x, y)
+    this.ctx.lineTo(cursor_x, cursor_y)
+    this.ctx.stroke()
+  }
+
+  drawCircle = (x: F, y: F, fillColor: S) => {
+    if (!this.ctx) return
+
+    this.ctx.beginPath()
+    this.ctx.fillStyle = fillColor
+    const path = new Path2D()
+    path.arc(x, y, ARC_RADIUS, 0, 2 * Math.PI)
+    this.ctx.fill(path)
+    this.ctx.closePath()
+  }
+
+
+  isIntersectingFirstPoint = (cursor_x: F, cursor_y: F) => {
+    if (!this.currPolygonPoints.length) return false
+    const { x, y } = this.currPolygonPoints[0]
+    const offset = 2 * ARC_RADIUS
+    return cursor_x >= x - offset && cursor_x <= x + offset && cursor_y >= y - offset && cursor_y < y + offset
+  }
+}

--- a/ui/src/image_annotator_polygon.ts
+++ b/ui/src/image_annotator_polygon.ts
@@ -10,6 +10,11 @@ export class PolygonAnnotator {
 
   constructor(private canvas: HTMLCanvasElement) { this.ctx = canvas.getContext('2d') }
 
+  resetDragging() {
+    this.draggedPoint = null
+    this.draggedShape = null
+  }
+
   onClick(cursor_x: U, cursor_y: U, color: S, tag: S): DrawnShape | undefined {
     if (!this.ctx) return
 

--- a/ui/src/image_annotator_polygon.ts
+++ b/ui/src/image_annotator_polygon.ts
@@ -13,7 +13,6 @@ export class PolygonAnnotator {
       const { x, y } = this.currPolygonPoints.at(-1)!
       const firstPoint = this.currPolygonPoints[0]
       this.drawLine(x, y, firstPoint.x, firstPoint.y)
-      // TODO: Reset points for next polygon.
       const newPolygon = { shape: { polygon: { items: [...this.currPolygonPoints] } }, tag }
       this.currPolygonPoints = []
       return newPolygon

--- a/ui/src/image_annotator_polygon.ts
+++ b/ui/src/image_annotator_polygon.ts
@@ -76,30 +76,36 @@ export class PolygonAnnotator {
     this.ctx.fill(path)
   }
 
-
   isIntersectingFirstPoint = (cursor_x: F, cursor_y: F) => {
     if (!this.currPolygonPoints.length) return false
-    const { x, y } = this.currPolygonPoints[0]
-    const offset = 2 * ARC_RADIUS
-    return cursor_x >= x - offset && cursor_x <= x + offset && cursor_y >= y - offset && cursor_y < y + offset
+    return isIntersectingPoint(this.currPolygonPoints[0], cursor_x, cursor_y)
   }
 }
 
 // Credit: https://gist.github.com/vlasky/d0d1d97af30af3191fc214beaf379acc?permalink_comment_id=3658988#gistcomment-3658988
 const cross = (x: ImageAnnotatorPoint, y: ImageAnnotatorPoint, z: ImageAnnotatorPoint) => (y.x - x.x) * (z.y - x.y) - (z.x - x.x) * (y.y - x.y)
-export const isIntersectingPolygon = (p: ImageAnnotatorPoint, points: ImageAnnotatorPoint[]) => {
-  let windingNumber = 0
+export
+  const isIntersectingPolygon = (p: ImageAnnotatorPoint, points: ImageAnnotatorPoint[]) => {
+    let windingNumber = 0
 
-  points.forEach((point, idx) => {
-    const b = points[(idx + 1) % points.length]
-    if (point.y <= p.y) {
-      if (b.y > p.y && cross(point, b, p) > 0) {
-        windingNumber += 1
+    points.forEach((point, idx) => {
+      const b = points[(idx + 1) % points.length]
+      if (point.y <= p.y) {
+        if (b.y > p.y && cross(point, b, p) > 0) {
+          windingNumber += 1
+        }
+      } else if (b.y <= p.y && cross(point, b, p) < 0) {
+        windingNumber -= 1
       }
-    } else if (b.y <= p.y && cross(point, b, p) < 0) {
-      windingNumber -= 1
-    }
-  })
+    })
 
-  return windingNumber !== 0
-}
+    return windingNumber !== 0
+  },
+  isIntersectingPoint = ({ x, y }: ImageAnnotatorPoint, cursor_x: F, cursor_y: F) => {
+    const offset = 2 * ARC_RADIUS
+    return cursor_x >= x - offset && cursor_x <= x + offset && cursor_y >= y - offset && cursor_y < y + offset
+  },
+  getPolygonPointCursor = (items: ImageAnnotatorPoint[], cursor_x: F, cursor_y: F) => {
+    const isIntersecting = items.some(p => isIntersectingPoint(p, cursor_x, cursor_y))
+    return isIntersecting ? 'move' : ''
+  }

--- a/ui/src/image_annotator_polygon.ts
+++ b/ui/src/image_annotator_polygon.ts
@@ -1,0 +1,4 @@
+export const
+  handlePolygonOnClick = () => {
+
+  }

--- a/ui/src/image_annotator_polygon.ts
+++ b/ui/src/image_annotator_polygon.ts
@@ -44,11 +44,13 @@ export class PolygonAnnotator {
       this.draggedPoint.y += cursor_y - this.draggedPoint.y
     }
     else if (intersected == focused || this.draggedShape) {
-      this.draggedShape = intersected || this.draggedShape
+      this.draggedShape = intersected?.shape.polygon && intersected.isFocused ? intersected : this.draggedShape
       this.draggedShape?.shape.polygon?.items.forEach(p => {
-        p.x += cursor_x - p.x
-        p.y += cursor_y - p.y
+        p.x += cursor_x - clickStartPosition!.x
+        p.y += cursor_y - clickStartPosition!.y
       })
+      clickStartPosition.x = cursor_x
+      clickStartPosition.y = cursor_y
     }
   }
 

--- a/ui/src/image_annotator_polygon.ts
+++ b/ui/src/image_annotator_polygon.ts
@@ -39,7 +39,7 @@ export class PolygonAnnotator {
       return
     }
 
-    const clickedPolygonPoint = focused.shape.polygon.items.find(p => isIntersectingPoint(p, cursor_x, cursor_y))
+    const clickedPolygonPoint = focused.shape.polygon.vertices.find(p => isIntersectingPoint(p, cursor_x, cursor_y))
     this.draggedPoint = clickedPolygonPoint || this.draggedPoint
     if (this.draggedPoint) {
       this.draggedPoint.x += cursor_x - this.draggedPoint.x
@@ -47,7 +47,7 @@ export class PolygonAnnotator {
     }
     else if (intersected == focused || this.draggedShape) {
       this.draggedShape = intersected?.shape.polygon && intersected.isFocused ? intersected : this.draggedShape
-      this.draggedShape?.shape.polygon?.items.forEach(p => {
+      this.draggedShape?.shape.polygon?.vertices.forEach(p => {
         p.x += cursor_x - clickStartPosition!.x
         p.y += cursor_y - clickStartPosition!.y
       })

--- a/ui/src/image_annotator_polygon.ts
+++ b/ui/src/image_annotator_polygon.ts
@@ -23,7 +23,7 @@ export class PolygonAnnotator {
     if (this.isIntersectingFirstPoint(cursor_x, cursor_y)) {
       const { x, y } = this.currPolygonPoints[0]
       this.drawLine(x, y)
-      const newPolygon = { shape: { polygon: { items: [...this.currPolygonPoints] } }, tag }
+      const newPolygon = { shape: { polygon: { vertices: [...this.currPolygonPoints] } }, tag }
       this.currPolygonPoints = []
       return newPolygon
     }

--- a/ui/src/image_annotator_rect.ts
+++ b/ui/src/image_annotator_rect.ts
@@ -73,7 +73,9 @@ export class RectAnnotator {
     this.resizedCorner = getCorner(cursor_x, cursor_y, rect, true)
   }
 
-  onMouseMove(clickStartPosition: Position, cursor_x: U, cursor_y: U, focused?: DrawnShape, intersected?: DrawnShape) {
+  onMouseMove(cursor_x: U, cursor_y: U, focused?: DrawnShape, intersected?: DrawnShape, clickStartPosition?: Position) {
+    if (!clickStartPosition) return
+
     const
       x1 = clickStartPosition.x,
       y1 = clickStartPosition.y
@@ -141,8 +143,9 @@ export class RectAnnotator {
 }
 
 export const
-  isIntersectingRect = (cursor_x: U, cursor_y: U, rect?: ImageAnnotatorRect) => {
+  isIntersectingRect = (cursor_x: U, cursor_y: U, rect?: ImageAnnotatorRect, isFocused = false) => {
     if (!rect) return false
+    if (isFocused && getCorner(cursor_x, cursor_y, rect)) return true
     const
       { x2, x1, y2, y1 } = rect,
       x_min = Math.min(x1, x2),

--- a/ui/src/image_annotator_rect.ts
+++ b/ui/src/image_annotator_rect.ts
@@ -101,7 +101,6 @@ export class RectAnnotator {
     }
     else if (this.movedRect || intersected?.isFocused) {
       this.movedRect = this.movedRect || intersected
-      this.canvas.style.cursor = 'move'
       if (!this.movedRect?.shape.rect) return
 
       const

--- a/ui/src/image_annotator_rect.ts
+++ b/ui/src/image_annotator_rect.ts
@@ -6,6 +6,7 @@ const
   MIN_RECT_HEIGHT = 5
 export const ARC_RADIUS = 4
 
+// Needs some canvas-related refactoring love.
 export class RectAnnotator {
   private resizedCorner?: 'topLeft' | 'topRight' | 'bottomLeft' | 'bottomRight'
   private movedRect?: DrawnShape
@@ -13,32 +14,29 @@ export class RectAnnotator {
 
   constructor(private canvas: HTMLCanvasElement) { this.ctx = canvas.getContext('2d') }
 
-  drawCircle = (x: U, y: U, fillColor: S) => {
+  drawCircle = (x: U, y: U) => {
     if (!this.ctx) return
-    this.ctx.beginPath()
-    this.ctx.fillStyle = fillColor
     const path = new Path2D()
     path.arc(x, y, ARC_RADIUS, 0, 2 * Math.PI)
+    this.ctx.lineWidth = 2
+    this.ctx.strokeStyle = '#000'
+    this.ctx.fillStyle = '#FFF'
     this.ctx.fill(path)
-    this.ctx.closePath()
+    this.ctx.stroke(path)
   }
 
   drawRect = ({ x1, x2, y1, y2 }: ImageAnnotatorRect, strokeColor: S, isFocused = false) => {
     if (!this.ctx) return
-    this.ctx.beginPath()
     this.ctx.lineWidth = 3
     this.ctx.strokeStyle = strokeColor
     this.ctx.strokeRect(x1, y1, x2 - x1, y2 - y1)
-    this.ctx.closePath()
     if (isFocused) {
-      this.ctx.beginPath()
       this.ctx.fillStyle = strokeColor.substring(0, strokeColor.length - 2) + '0.2)'
       this.ctx.fillRect(x1, y1, x2 - x1, y2 - y1)
-      this.ctx.closePath()
-      this.drawCircle(x1, y1, strokeColor)
-      this.drawCircle(x2, y1, strokeColor)
-      this.drawCircle(x2, y2, strokeColor)
-      this.drawCircle(x1, y2, strokeColor)
+      this.drawCircle(x1, y1)
+      this.drawCircle(x2, y1)
+      this.drawCircle(x2, y2)
+      this.drawCircle(x1, y2)
     }
   }
 

--- a/ui/src/image_annotator_rect.ts
+++ b/ui/src/image_annotator_rect.ts
@@ -162,4 +162,9 @@ export const
     else if (x > x_min - ARC_RADIUS && x < x_min + ARC_RADIUS && y > y_max - ARC_RADIUS && y < y_max + ARC_RADIUS) return 'topRight'
     else if (x > x_max - ARC_RADIUS && x < x_max + ARC_RADIUS && y > y_min - ARC_RADIUS && y < y_min + ARC_RADIUS) return 'bottomLeft'
     else if (x > x_max - ARC_RADIUS && x < x_max + ARC_RADIUS && y > y_max - ARC_RADIUS && y < y_max + ARC_RADIUS) return 'bottomRight'
+  },
+  getRectCornerCursor = (shape: ImageAnnotatorRect, cursor_x: U, cursor_y: U) => {
+    const corner = getCorner(cursor_x, cursor_y, shape)
+    if (corner === 'topLeft' || corner === 'bottomRight') return 'nwse-resize'
+    if (corner === 'bottomLeft' || corner === 'topRight') return 'nesw-resize'
   }

--- a/ui/src/image_annotator_rect.ts
+++ b/ui/src/image_annotator_rect.ts
@@ -3,12 +3,12 @@ import { DrawnShape, ImageAnnotatorRect, Position } from './image_annotator'
 
 const
   MIN_RECT_WIDTH = 5,
-  MIN_RECT_HEIGHT = 5,
-  ARC_RADIUS = 4
+  MIN_RECT_HEIGHT = 5
+export const ARC_RADIUS = 4
 
-export class AnnotatorRect {
-  private resizedCorner: 'topLeft' | 'topRight' | 'bottomLeft' | 'bottomRight' | undefined
-  private movedRect: DrawnShape | undefined
+export class RectAnnotator {
+  private resizedCorner?: 'topLeft' | 'topRight' | 'bottomLeft' | 'bottomRight'
+  private movedRect?: DrawnShape
   private ctx: CanvasRenderingContext2D | null
 
   constructor(private canvas: HTMLCanvasElement) { this.ctx = canvas.getContext('2d') }
@@ -22,6 +22,7 @@ export class AnnotatorRect {
     this.ctx.fill(path)
     this.ctx.closePath()
   }
+
   drawRect = ({ x1, x2, y1, y2 }: ImageAnnotatorRect, strokeColor: S, isFocused = false) => {
     if (!this.ctx) return
     this.ctx.beginPath()
@@ -52,9 +53,10 @@ export class AnnotatorRect {
   }
 
   onClick = (e: React.MouseEvent, cursor_x: U, cursor_y: U, newShapes: DrawnShape[], drawnShapes: DrawnShape[], tag: S, start?: Position) => {
+    let newRect = null
     if (start && !this.resizedCorner) {
-      const newRect = this.createRect(start.x, cursor_x, start.y, cursor_y)
-      if (newRect) newShapes.unshift({ shape: { rect: newRect }, tag })
+      const rect = this.createRect(start.x, cursor_x, start.y, cursor_y)
+      if (rect) newRect = ({ shape: { rect: rect }, tag })
     }
 
     if (!this.resizedCorner && !start?.dragging && e.type !== 'mouseleave') {
@@ -65,6 +67,8 @@ export class AnnotatorRect {
 
     this.resizedCorner = undefined
     this.movedRect = undefined
+
+    return newRect
   }
 
   onMouseDown(cursor_x: U, cursor_y: U, rect: ImageAnnotatorRect) {

--- a/ui/src/image_annotator_rect.ts
+++ b/ui/src/image_annotator_rect.ts
@@ -32,7 +32,7 @@ export class RectAnnotator {
     this.ctx.closePath()
     if (isFocused) {
       this.ctx.beginPath()
-      this.ctx.fillStyle = 'rgba(0, 0, 0, 0.3)'
+      this.ctx.fillStyle = strokeColor.substring(0, strokeColor.length - 2) + '0.2)'
       this.ctx.fillRect(x1, y1, x2 - x1, y2 - y1)
       this.ctx.closePath()
       this.drawCircle(x1, y1, strokeColor)

--- a/ui/src/image_annotator_rect.ts
+++ b/ui/src/image_annotator_rect.ts
@@ -53,10 +53,9 @@ export class RectAnnotator {
   }
 
   onClick = (e: React.MouseEvent, cursor_x: U, cursor_y: U, setDrawnShapes: (value: React.SetStateAction<DrawnShape[]>) => void, tag: S, start?: Position) => {
-    let newRect = null
     if (start && !this.resizedCorner) {
       const rect = this.createRect(start.x, cursor_x, start.y, cursor_y)
-      if (rect) newRect = ({ shape: { rect: rect }, tag })
+      if (rect) setDrawnShapes(drawnShapes => [{ shape: { rect }, tag }, ...drawnShapes])
     }
 
     if (!this.resizedCorner && !start?.dragging && e.type !== 'mouseleave') {
@@ -68,8 +67,6 @@ export class RectAnnotator {
 
     this.resizedCorner = undefined
     this.movedRect = undefined
-
-    return newRect
   }
 
   onMouseDown(cursor_x: U, cursor_y: U, rect: ImageAnnotatorRect) {

--- a/ui/src/image_annotator_rect.ts
+++ b/ui/src/image_annotator_rect.ts
@@ -52,7 +52,7 @@ export class RectAnnotator {
     }
   }
 
-  onClick = (e: React.MouseEvent, cursor_x: U, cursor_y: U, newShapes: DrawnShape[], drawnShapes: DrawnShape[], tag: S, start?: Position) => {
+  onClick = (e: React.MouseEvent, cursor_x: U, cursor_y: U, setDrawnShapes: (value: React.SetStateAction<DrawnShape[]>) => void, tag: S, start?: Position) => {
     let newRect = null
     if (start && !this.resizedCorner) {
       const rect = this.createRect(start.x, cursor_x, start.y, cursor_y)
@@ -60,9 +60,10 @@ export class RectAnnotator {
     }
 
     if (!this.resizedCorner && !start?.dragging && e.type !== 'mouseleave') {
-      newShapes.forEach(shape => shape.isFocused = false)
-      const intersecting = drawnShapes.find(shape => isIntersectingRect(cursor_x, cursor_y, shape.shape.rect))
-      if (intersecting) intersecting.isFocused = true
+      setDrawnShapes(drawnShapes => drawnShapes.map(s => {
+        s.isFocused = isIntersectingRect(cursor_x, cursor_y, s.shape.rect)
+        return s
+      }))
     }
 
     this.resizedCorner = undefined

--- a/ui/src/image_annotator_rect.ts
+++ b/ui/src/image_annotator_rect.ts
@@ -1,0 +1,163 @@
+import { F, S, U } from 'h2o-wave'
+import { DrawnShape, ImageAnnotatorRect, Position } from './image_annotator'
+
+const
+  MIN_RECT_WIDTH = 5,
+  MIN_RECT_HEIGHT = 5,
+  ARC_RADIUS = 4
+
+export class AnnotatorRect {
+  private resizedCorner: 'topLeft' | 'topRight' | 'bottomLeft' | 'bottomRight' | undefined
+  private movedRect: DrawnShape | undefined
+  private ctx: CanvasRenderingContext2D | null
+
+  constructor(private canvas: HTMLCanvasElement) { this.ctx = canvas.getContext('2d') }
+
+  drawCircle = (x: U, y: U, fillColor: S) => {
+    if (!this.ctx) return
+    this.ctx.beginPath()
+    this.ctx.fillStyle = fillColor
+    const path = new Path2D()
+    path.arc(x, y, ARC_RADIUS, 0, 2 * Math.PI)
+    this.ctx.fill(path)
+    this.ctx.closePath()
+  }
+  drawRect = ({ x1, x2, y1, y2 }: ImageAnnotatorRect, strokeColor: S, isFocused = false) => {
+    if (!this.ctx) return
+    this.ctx.beginPath()
+    this.ctx.lineWidth = 3
+    this.ctx.strokeStyle = strokeColor
+    this.ctx.strokeRect(x1, y1, x2 - x1, y2 - y1)
+    this.ctx.closePath()
+    if (isFocused) {
+      this.ctx.beginPath()
+      this.ctx.fillStyle = 'rgba(0, 0, 0, 0.3)'
+      this.ctx.fillRect(x1, y1, x2 - x1, y2 - y1)
+      this.ctx.closePath()
+      this.drawCircle(x1, y1, strokeColor)
+      this.drawCircle(x2, y1, strokeColor)
+      this.drawCircle(x2, y2, strokeColor)
+      this.drawCircle(x1, y2, strokeColor)
+    }
+  }
+
+  createRect = (x1: F, x2: F, y1: F, y2: F) => {
+    const { width, height } = this.canvas
+    return Math.abs(x2 - x1) <= MIN_RECT_WIDTH || Math.abs(y2 - y1) <= MIN_RECT_HEIGHT ? undefined : {
+      x1: x1 > width ? width : x1 < 0 ? 0 : x1,
+      x2: x2 > width ? width : x2 < 0 ? 0 : x2,
+      y1: y1 > height ? height : y1 < 0 ? 0 : y1,
+      y2: y2 > height ? height : y2 < 0 ? 0 : y2,
+    }
+  }
+
+  onClick = (e: React.MouseEvent, cursor_x: U, cursor_y: U, newShapes: DrawnShape[], drawnShapes: DrawnShape[], tag: S, start?: Position) => {
+    if (start && !this.resizedCorner) {
+      const newRect = this.createRect(start.x, cursor_x, start.y, cursor_y)
+      if (newRect) newShapes.unshift({ shape: { rect: newRect }, tag })
+    }
+
+    if (!this.resizedCorner && !start?.dragging && e.type !== 'mouseleave') {
+      newShapes.forEach(shape => shape.isFocused = false)
+      const intersecting = drawnShapes.find(shape => isIntersectingRect(cursor_x, cursor_y, shape.shape.rect))
+      if (intersecting) intersecting.isFocused = true
+    }
+
+    this.resizedCorner = undefined
+    this.movedRect = undefined
+  }
+
+  onMouseDown(cursor_x: U, cursor_y: U, rect: ImageAnnotatorRect) {
+    this.resizedCorner = getCorner(cursor_x, cursor_y, rect, true)
+  }
+
+  onMouseMove(clickStartPosition: Position, cursor_x: U, cursor_y: U, focused?: DrawnShape, intersected?: DrawnShape) {
+    const
+      x1 = clickStartPosition.x,
+      y1 = clickStartPosition.y
+
+    if (focused?.shape.rect && this.resizedCorner) {
+      if (this.resizedCorner === 'topLeft') {
+        focused.shape.rect.x1 += cursor_x - x1
+        focused.shape.rect.y1 += cursor_y - y1
+      }
+      else if (this.resizedCorner === 'topRight') {
+        focused.shape.rect.x1 += cursor_x - x1
+        focused.shape.rect.y2 += cursor_y - y1
+      }
+      else if (this.resizedCorner === 'bottomLeft') {
+        focused.shape.rect.x2 += cursor_x - x1
+        focused.shape.rect.y1 += cursor_y - y1
+      }
+      else if (this.resizedCorner === 'bottomRight') {
+        focused.shape.rect.x2 += cursor_x - x1
+        focused.shape.rect.y2 += cursor_y - y1
+      }
+
+      clickStartPosition.x = cursor_x
+      clickStartPosition.y = cursor_y
+    }
+    else if (this.movedRect || intersected?.isFocused) {
+      this.movedRect = this.movedRect || intersected
+      this.canvas.style.cursor = 'move'
+      if (!this.movedRect?.shape.rect) return
+
+      const
+        rect = this.movedRect.shape.rect,
+        xIncrement = cursor_x - x1,
+        yIncrement = cursor_y - y1,
+        newX1 = rect.x1 + xIncrement,
+        newX2 = rect.x2 + xIncrement,
+        newY1 = rect.y1 + yIncrement,
+        newY2 = rect.y2 + yIncrement,
+        { width, height } = this.canvas
+
+      // Prevent moving behind image boundaries.
+      // FIXME: Hitting boundary repeatedly causes rect to increase in size.
+      if (newX1 < rect.x1 && newX1 < 0) rect.x1 = Math.max(0, newX1)
+      else if (newX2 < rect.x2 && newX2 < 0) rect.x2 = Math.max(0, newX2)
+      else if (newY1 < rect.y1 && newY1 < 0) rect.y1 = Math.max(0, newY1)
+      else if (newY2 < rect.y2 && newY2 < 0) rect.y2 = Math.max(0, newY2)
+      else if (newX1 > rect.x1 && newX1 > width) rect.x1 = Math.min(newX1, width)
+      else if (newX2 > rect.x2 && newX2 > width) rect.x2 = Math.min(newX2, width)
+      else if (newY1 > rect.y1 && newY1 > height) rect.y1 = Math.min(newY1, height)
+      else if (newY2 > rect.y2 && newY2 > height) rect.y2 = Math.min(newY2, height)
+      else {
+        rect.x1 = newX1
+        rect.x2 = newX2
+        rect.y1 = newY1
+        rect.y2 = newY2
+      }
+
+      clickStartPosition.x = cursor_x
+      clickStartPosition.y = cursor_y
+    }
+    else {
+      return { rect: this.createRect(x1, cursor_x, y1, cursor_y) }
+    }
+  }
+}
+
+export const
+  isIntersectingRect = (cursor_x: U, cursor_y: U, rect?: ImageAnnotatorRect) => {
+    if (!rect) return false
+    const
+      { x2, x1, y2, y1 } = rect,
+      x_min = Math.min(x1, x2),
+      x_max = Math.max(x1, x2),
+      y_min = Math.min(y1, y2),
+      y_max = Math.max(y1, y2)
+
+    return cursor_x > x_min && cursor_x < x_max && cursor_y > y_min && cursor_y < y_max
+  },
+  getCorner = (x: U, y: U, { x1, y1, x2, y2 }: ImageAnnotatorRect, ignoreMaxMin = false) => {
+    const
+      x_min = ignoreMaxMin ? x1 : Math.min(x1, x2),
+      x_max = ignoreMaxMin ? x2 : Math.max(x1, x2),
+      y_min = ignoreMaxMin ? y1 : Math.min(y1, y2),
+      y_max = ignoreMaxMin ? y2 : Math.max(y1, y2)
+    if (x > x_min - ARC_RADIUS && x < x_min + ARC_RADIUS && y > y_min - ARC_RADIUS && y < y_min + ARC_RADIUS) return 'topLeft'
+    else if (x > x_min - ARC_RADIUS && x < x_min + ARC_RADIUS && y > y_max - ARC_RADIUS && y < y_max + ARC_RADIUS) return 'topRight'
+    else if (x > x_max - ARC_RADIUS && x < x_max + ARC_RADIUS && y > y_min - ARC_RADIUS && y < y_min + ARC_RADIUS) return 'bottomLeft'
+    else if (x > x_max - ARC_RADIUS && x < x_max + ARC_RADIUS && y > y_max - ARC_RADIUS && y < y_max + ARC_RADIUS) return 'bottomRight'
+  }

--- a/ui/src/setupTests.ts
+++ b/ui/src/setupTests.ts
@@ -12,10 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { initializeIcons } from '@fluentui/react'
+import { registerIcons } from '@fluentui/react'
+import * as Icons from '@fluentui/react-icons-mdl2'
 import { configure } from '@testing-library/dom'
 import '@testing-library/jest-dom/extend-expect'
 import 'jest-canvas-mock'
+import React from 'react'
 
 configure({ testIdAttribute: 'data-test' })
-initializeIcons()
+
+const icons = Object.entries(Icons).reduce((acc, [iconName, iconComponent]) => {
+  if ('displayName' in iconComponent) acc[iconName.slice(0, -4)] = React.createElement(iconComponent as React.FC)
+  return acc
+}, {} as { [key: string]: JSX.Element })
+registerIcons({ icons })

--- a/ui/src/theme.ts
+++ b/ui/src/theme.ts
@@ -46,6 +46,10 @@ export const
     prop = prop.substring(1)
     return getComputedStyle(document.body).getPropertyValue(`--${prop}`).trim()
   },
+  rgb = (hex: S): [U, U, U] => {
+    const x = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex)
+    return x ? [parseInt(x[1], 16), parseInt(x[2], 16), parseInt(x[3], 16)] : [0, 0, 0]
+  },
   // The width is applied to both form item container and component root which is a problem for percentages.
   // E.g. 50% width on both form container and component results in 25% of total form width instead of 50% (component takes 50% of 50% of the form = 25% total).
   formItemWidth = (width?: S) => width?.includes('%') ? '100%' : width,
@@ -572,10 +576,6 @@ const
         black: '#2f2f2f',
       },
     },
-  },
-  rgb = (hex: S): [U, U, U] => {
-    const x = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex)
-    return x ? [parseInt(x[1], 16), parseInt(x[2], 16), parseInt(x[3], 16)] : [0, 0, 0]
   },
   themeRules = Fluent.themeRulesStandardCreator(),
   changeTheme = (themeName: S) => {

--- a/website/widgets/form/image_annotator.md
+++ b/website/widgets/form/image_annotator.md
@@ -22,6 +22,12 @@ q.page['example'] = ui.form_card(box='1 1 9 10', items=[
         ],
         items=[
             ui.image_annotator_item(shape=ui.image_annotator_rect(x1=649, y1=393, x2=383, y2=25), tag='p'),
+            ui.image_annotator_item(tag='p', shape=ui.image_annotator_polygon([
+                ui.image_annotator_point(x=828.2142857142857, y=135),
+                ui.image_annotator_point(x=731.7857142857142, y=212.14285714285714),
+                ui.image_annotator_point(x=890.3571428571429, y=354.6428571428571),
+                ui.image_annotator_point(x=950.3571428571429, y=247.5)
+            ])),
         ],
     ),
     ui.button(name='submit', label='Submit', primary=True)


### PR DESCRIPTION
## Preview

https://user-images.githubusercontent.com/64769322/192780336-c3d5fc43-8186-4d66-894f-c0fac4e6bb1e.mov

## API Review

@lo5

```ts
/** Create a polygon annotation point with x and y coordinates.. */
export interface ImageAnnotatorPoint {
  /** `x` coordinate of the point. */
  x: F
  /** `y` coordinate of the point. */
  y: F
}

/** Create a polygon annotation shape. */
export interface ImageAnnotatorPolygon {
  /** List of points of the polygon. */
  items: ImageAnnotatorPoint[]
}
```
```py
ui.image_annotator_item(tag='p', shape=ui.image_annotator_polygon([
    ui.image_annotator_point(x=828.2142857142857, y=135),
    ui.image_annotator_point(x=731.7857142857142, y=212.14285714285714),
    ui.image_annotator_point(x=890.3571428571429, y=354.6428571428571),
    ui.image_annotator_point(x=950.3571428571429, y=247.5)
])),
```
return value:

```js
[
  {
    'tag': 'p',
    'shape': {
      'polygon': {
        'items': [
          { 'x': 828.2142857142857, 'y': 135 },
          { 'x': 731.7857142857142, 'y': 212.14285714285714 },
          { 'x': 890.3571428571429, 'y': 354.6428571428571 },
          { 'x': 950.3571428571429, 'y': 247.5 }]
      }
    }
  }]
```

## To be done

* Add unit tests.
* Fix a few small bugs.
* Add more polygon editing features.

Part of #1597