### PR TITLE
feat: Image lightbox component for image zoom and image grid

### DIFF
--- a/ui/src/image.tsx
+++ b/ui/src/image.tsx
@@ -77,7 +77,7 @@ export const
           : ''
     return <>
       <img className={css.img} alt={title} src={src} width={formItemWidth(width)} onClick={() => setLightboxVisible(true)} />
-      <Lightbox title={title} type={type} image={image} path={path} visible={lightboxVisible} onDismiss={() => setLightboxVisible(false)} />
+      <Lightbox images={[{ title, type, image, path }]} visible={lightboxVisible} onDismiss={() => setLightboxVisible(false)} />
     </>
   },
   View = bond(({ name, state, changed }: Model<State>) => {

--- a/ui/src/image.tsx
+++ b/ui/src/image.tsx
@@ -18,6 +18,7 @@ import { stylesheet } from 'typestyle'
 import { cards, Format, grid } from './layout'
 import { formItemWidth } from './theme'
 import { bond } from './ui'
+import { Lightbox } from './parts/lightbox'
 
 const
   css = stylesheet({
@@ -29,7 +30,8 @@ const
     img: {
       flexGrow: 1,
       objectFit: 'contain',
-      maxHeight: 'calc(100% - 20px)'
+      maxHeight: 'calc(100% - 20px)',
+      cursor: 'pointer'
     }
   })
 
@@ -67,12 +69,16 @@ export interface Image {
 export const
   XImage = ({ model: { title, type, image, path, width } }: { model: Image }) => {
     const
+      [lightboxVisible, setLightboxVisible] = React.useState(false),
       src = path
         ? path
         : (image && type)
           ? `data:image/${type};base64,${image}`
           : ''
-    return <img className={css.img} alt={title} src={src} width={formItemWidth(width)} />
+    return <>
+      <img className={css.img} alt={title} src={src} width={formItemWidth(width)} onClick={() => setLightboxVisible(true)} />
+      <Lightbox title={title} type={type} image={image} path={path} visible={lightboxVisible} onDismiss={() => setLightboxVisible(false)} />
+    </>
   },
   View = bond(({ name, state, changed }: Model<State>) => {
     const render = () => {

--- a/ui/src/parts/lightbox.tsx
+++ b/ui/src/parts/lightbox.tsx
@@ -40,11 +40,11 @@ const
         img: {
             // flexGrow: 1,
             maxWidth: '100%', // TODO: 3000x2000 vertical scrollbar
-            alignSelf: 'center',
-            // objectFit: 'scale-down',
-            transformOrigin: 'top left',
-            transition: 'transform 0.25s ease',
-            cursor: 'pointer',
+            // alignSelf: 'center',
+            objectFit: 'scale-down',
+            // transformOrigin: 'top left',
+            // transition: 'transform 0.25s ease',
+            // cursor: 'pointer',
         },
         header: {
             width: '100%',
@@ -108,7 +108,7 @@ const
             overflow: 'hidden',
         },
         title: { fontWeight: 500 },
-        description: { opacity: 0.85 }, // TODO: use proper color instead of opacity
+        description: { color: '#bbbbbb' }, // TODO: theme colors
         navImgPlaceholder: { display: 'inline-block', width: '124px' }
     })
 
@@ -125,49 +125,44 @@ interface Props {
     defaultImageIdx?: U
 }
 
-const
-    zoomLevels: { [key: U]: U } = { 0: 1, 1: 1.5, 2: 2, 3: 3, 4: 4 },
-    lazyImageObserver = new IntersectionObserver(entries => {
-        entries.forEach(entry => {
-            if (entry.isIntersecting) {
-                const lazyImage = entry.target as HTMLImageElement
-                lazyImage.src = lazyImage.dataset.src!
-                lazyImage.classList.remove("lazy")
-                lazyImageObserver.unobserve(lazyImage)
-            }
-        })
+const lazyImageObserver = new IntersectionObserver(entries => {
+    entries.forEach(entry => {
+        if (entry.isIntersecting) {
+            const lazyImage = entry.target as HTMLImageElement
+            lazyImage.src = lazyImage.dataset.src!
+            lazyImage.classList.remove("lazy")
+            lazyImageObserver.unobserve(lazyImage)
+        }
     })
+})
 
 export const Lightbox = ({ visible, onDismiss, images, defaultImageIdx }: Props) => {
     const
         [activeImageIdx, setActiveImageIdx] = React.useState(defaultImageIdx || 0),
-        [zoomLevel, setZoomLevel] = React.useState(0),
         imageNavRef = React.useRef<HTMLDivElement | undefined>(),
         handleClickLeft = () => {
             const nextImgIdx = (activeImageIdx === 0) ? (images.length - 1) : activeImageIdx - 1
             setActiveImageIdx(nextImgIdx)
-            setZoomLevel(0)
             if (imageNavRef.current) {
                 const isLeft = activeImageIdx <= Math.floor(imageNavRef.current.scrollLeft / 124)
                 if (nextImgIdx === images.length - 1) imageNavRef.current.scrollLeft = imageNavRef.current.scrollWidth - imageNavRef.current?.clientWidth
-                else if (isLeft) imageNavRef.current.scrollLeft = (activeImageIdx * 124) - 124
+                else if (isLeft) imageNavRef.current.scrollBy({ left: (activeImageIdx * 124) - 124 - imageNavRef.current.scrollLeft, top: 0, behavior: 'smooth' })
             }
         },
         handleClickRight = () => {
             const nextImgIdx = (activeImageIdx === images.length - 1) ? 0 : activeImageIdx + 1
             setActiveImageIdx(nextImgIdx)
-            setZoomLevel(0)
             if (imageNavRef.current) {
                 const pageImageCount = Math.floor(imageNavRef.current?.clientWidth / 124)
                 const isRight = activeImageIdx >= Math.floor(imageNavRef.current.scrollLeft / 124) + (pageImageCount - 1)
                 if (nextImgIdx === 0) imageNavRef.current.scrollLeft = 0
-                else if (isRight) imageNavRef.current.scrollLeft = ((activeImageIdx + 1 - pageImageCount) * 124) + 124
+                else if (isRight) imageNavRef.current.scrollBy({ left: ((activeImageIdx + 1 - pageImageCount) * 124) + 124 - imageNavRef.current.scrollLeft, top: 0, behavior: 'smooth' })
             }
         },
         onClose = () => {
-            setZoomLevel(0)
             onDismiss()
             setActiveImageIdx(defaultImageIdx || 0)
+            if (imageNavRef.current) imageNavRef.current.scrollLeft = 0
         }
 
     React.useLayoutEffect(() => {
@@ -200,14 +195,8 @@ export const Lightbox = ({ visible, onDismiss, images, defaultImageIdx }: Props)
                     alt={title}
                     src={src}
                     style={{
-                        transform: `scale(${zoomLevels[zoomLevel]})`, // TODO:
-                        cursor: zoomLevel < 4 ? 'zoom-in' : 'zoom-out',
-                        maxHeight: 'inherit',
+                        // maxHeight: 'inherit',
                         // objectFit: 'none'
-                    }}
-                    onClick={(_ev) => {
-                        const zoom = zoomLevel === 4 ? 0 : zoomLevel + 1
-                        setZoomLevel(zoom)
                     }}
                 />
                 {images.length > 1 &&

--- a/ui/src/parts/lightbox.tsx
+++ b/ui/src/parts/lightbox.tsx
@@ -12,75 +12,160 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { B, S } from 'h2o-wave'
+import { B, S, U } from 'h2o-wave'
 import React from 'react'
 import { stylesheet } from 'typestyle'
 import * as Fluent from '@fluentui/react'
+import { clas } from '../theme'
 
-const css = stylesheet({
-    body: {
-        position: 'fixed',
-        inset: '0px',
-        width: '100%',
-        height: '100%',
-        zIndex: 1,
-        backgroundColor: '#000000', // TODO:
-        touchAction: 'pinch-zoom' // TODO:
+const
+    iconStyles: Fluent.IButtonStyles = {
+        icon: { color: '#ffffff', lineHeight: 22, height: 'unset', padding: 4 },
+        iconHovered: { color: '#ffffff' }, // TODO:
+        iconPressed: { color: 'rgba(255, 255, 255, 0.7)' },
+        flexContainer: { justifyContent: 'center' },
+        root: { margin: '4px 4px', width: 38, height: 38, backgroundColor: 'rgba(0, 0, 0, 0.3)' },
+        rootHovered: { backgroundColor: 'rgba(255, 255, 255, 0.3)' }
     },
-    img: {
-        flexGrow: 1,
-        objectFit: 'contain',
-        cursor: 'pointer'
-    },
-    header: {
-        width: '100%',
-        height: '40px',
-        textAlign: 'right'
-    },
-    content: {
-        display: 'flex',
-        maxHeight: 'calc(100% - 100px)',
-        maxWidth: '100%',
-    },
-    footer: {
-        height: '60px',
-        textAlign: 'center',
-        color: '#ffffff', // TODO:
-        width: '100%'
-    }
-})
+    css = stylesheet({
+        body: {
+            position: 'fixed',
+            inset: '0px',
+            width: '100%',
+            height: '100%',
+            zIndex: 1,
+            backgroundColor: '#000000', // TODO:
+            touchAction: 'pinch-zoom' // TODO:
+        },
+        img: {
+            flexGrow: 1,
+            objectFit: 'contain',
+            cursor: 'pointer'
+        },
+        header: {
+            width: '100%',
+            height: '40px',
+            textAlign: 'right'
+        },
+        content: {
+            display: 'flex',
+            maxWidth: '100%',
+        },
+        footer: {
+            textAlign: 'center',
+            color: '#ffffff', // TODO:
+            width: '100%'
+        },
+        imageNav: {
+            height: '180px',
+            padding: '20px 0px',
+            overflow: 'auto',
+            whiteSpace: 'nowrap'
+        },
+        navImg: {
+            height: '160px',
+            padding: '0px 1px',
+            opacity: 0.6,
+            $nest: {
+                '&:hover': {
+                    opacity: 1
+                }
+            }
+        },
+        arrow: {
+            cursor: "pointer",
+            position: "absolute",
+            top: "50%",
+            width: "auto",
+            padding: "16px",
+            marginTop: "-50px",
+            color: "white",
+            fontWeight: "bold",
+            fontSize: "20px",
+            transition: "0.6s ease",
+            borderRadius: "0 3px 3px 0",
+            userSelect: "none",
+        }
+    })
 
 interface Props {
     visible: B,
     onDismiss: () => void,
-    title: S,
-    description?: S,
-    type?: S,
-    image?: S,
-    path?: S,
+    images: {
+        title: S,
+        description?: S,
+        type?: S,
+        image?: S,
+        path?: S,
+    }[],
+    defaultImageIdx?: U
 }
 
-export const Lightbox = ({ visible, onDismiss, type, image, path, title, description }: Props) => {
+export const Lightbox = ({ visible, onDismiss, images, defaultImageIdx }: Props) => {
     const
+        [activeImageIdx, setActiveImageIdx] = React.useState(defaultImageIdx || 0),
+        imageNavRef = React.useRef<HTMLDivElement | undefined>()
+
+    React.useEffect(() => {
+        if (imageNavRef.current) imageNavRef.current.scrollLeft = activeImageIdx * 162
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [imageNavRef.current, activeImageIdx])
+
+    if (images.length === 0 || (activeImageIdx >= images.length)) return <>{'Error'}</> // TODO:
+    const
+        { type, image, path, title, description } = images[activeImageIdx],
         src = path
             ? path
             : (image && type)
                 ? `data:image/${type};base64,${image}`
                 : ''
+
+
+
+
     return (
         <div aria-hidden={true} className={css.body} style={visible ? undefined : { display: 'none' }} >
             <div className={css.header}>
                 <Fluent.ActionButton
-                    styles={{
-                        icon: { color: '#ffffff' }, // TODO:
-                        root: { padding: '10px 10px' }
-                    }}
+                    styles={iconStyles}
                     onClick={onDismiss}
                     iconProps={{ iconName: 'Cancel', style: { fontSize: '22px' } }}
                 />
             </div>
-            <div className={css.content}><img className={css.img} alt={title} src={src} /></div>
-            <div className={css.footer}>{title}{description ? ` - ${description}` : ''}</div>
+            <div className={css.content} style={{ maxHeight: `calc(100% - ${images.length > 1 ? '300px' : '100px'})` }}>
+                <img className={css.img} alt={title} src={src} />
+                {images.length > 1 &&
+                    <>
+                        <div className={css.arrow} style={{ left: 0 }}>
+                            <Fluent.ActionButton
+                                styles={iconStyles}
+                                onClick={() => setActiveImageIdx((activeImageIdx === 0) ? (images.length - 1) : activeImageIdx - 1)}
+                                iconProps={{ iconName: 'ChevronLeft', style: { fontSize: '22px' } }}
+                            />
+                        </div>
+                        <div className={css.arrow} style={{ right: 0 }}>
+                            <Fluent.ActionButton
+                                styles={iconStyles}
+                                onClick={() => setActiveImageIdx((activeImageIdx === images.length - 1) ? 0 : activeImageIdx + 1)}
+                                iconProps={{ iconName: 'ChevronRight', style: { fontSize: '22px' } }}
+                            />
+                        </div>
+                    </>
+                }
+            </div>
+            <div className={css.footer} style={{ height: images.length > 1 ? '260px' : '60px' }}>
+                {title}{description ? ` - ${description}` : ''}
+                {images.length > 1 && <div className={css.imageNav} ref={imageNavRef}>
+                    {images.map(({ type, image, path, title }, idx) => {
+                        const src = path
+                            ? path
+                            : (image && type)
+                                ? `data:image/${type};base64,${image}`
+                                : ''
+                        return <img key={idx} className={clas(css.img, css.navImg)} style={activeImageIdx === idx ? { opacity: 1 } : undefined} alt={title} src={src} onClick={() => { setActiveImageIdx(idx) }} />
+                    })}
+                </div>}
+            </div>
         </div>
     )
 }

--- a/ui/src/parts/lightbox.tsx
+++ b/ui/src/parts/lightbox.tsx
@@ -166,7 +166,7 @@ export const Lightbox = ({ visible, onDismiss, images, defaultImageIdx }: Lightb
       if (ev.keyCode === keys.right) setActiveImageIdx(imgIdx === images.length - 1 ? 0 : imgIdx + 1)
       else if (ev.keyCode === keys.left) setActiveImageIdx(imgIdx === 0 ? images.length - 1 : imgIdx - 1)
     },
-    imageNav = images.map((image, idx) =>
+    imageNav = isGallery ? images.map((image, idx) =>
       <div key={idx} className={css.navImgPlaceholder}>
         <img
           className={clas(css.img, css.navImg, 'lazy')}
@@ -177,11 +177,11 @@ export const Lightbox = ({ visible, onDismiss, images, defaultImageIdx }: Lightb
           onClick={() => setActiveImageIdx(idx)}
         />
       </div>
-    )
+    ) : undefined
 
   React.useEffect(() => {
     // Set initial scroll position.
-    navImgRefs[activeImageIdx].current!.scrollIntoView({ behavior: 'auto', inline: 'center', block: 'center' })
+    if (isGallery) navImgRefs[activeImageIdx].current!.scrollIntoView({ behavior: 'auto', inline: 'center', block: 'center' })
     // Add keyboard events listener.
     if (visible) window.addEventListener("keydown", handleKeyDown)
     else window.removeEventListener("keydown", handleKeyDown)
@@ -190,11 +190,14 @@ export const Lightbox = ({ visible, onDismiss, images, defaultImageIdx }: Lightb
   }, [visible])
 
   // Handle image navigation scroll.
-  React.useEffect(() => navImgRefs[activeImageIdx].current!.scrollIntoView({
-    behavior: (activeImageIdx === 0 || activeImageIdx === images.length - 1) ? 'auto' : 'smooth',
-    inline: 'center',
-    block: 'center'
-  }), [activeImageIdx, images.length, navImgRefs])
+  React.useEffect(() => {
+    if (isGallery) navImgRefs[activeImageIdx].current!.scrollIntoView({
+      behavior: (activeImageIdx === 0 || activeImageIdx === images.length - 1) ? 'auto' : 'smooth',
+      inline: 'center',
+      block: 'center'
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeImageIdx, images.length, navImgRefs])
 
   React.useLayoutEffect(() => {
     // Initialize intersection observer for lazy images.

--- a/ui/src/parts/lightbox.tsx
+++ b/ui/src/parts/lightbox.tsx
@@ -108,7 +108,8 @@ const
             overflow: 'hidden',
         },
         title: { fontWeight: 500 },
-        description: { opacity: 0.85 } // TODO: use proper color instead of opacity
+        description: { opacity: 0.85 }, // TODO: use proper color instead of opacity
+        navImgPlaceholder: { display: 'inline-block', width: '124px' }
     })
 
 interface Props {
@@ -147,9 +148,8 @@ export const Lightbox = ({ visible, onDismiss, images, defaultImageIdx }: Props)
             setActiveImageIdx(nextImgIdx)
             setZoomLevel(0)
             if (imageNavRef.current) {
-                // const pageImageCount = Math.floor(imageNavRef.current?.offsetWidth / 124)
                 const isLeft = activeImageIdx <= Math.floor(imageNavRef.current.scrollLeft / 124)
-                if (nextImgIdx === images.length - 1) imageNavRef.current.scrollLeft = imageNavRef.current.scrollWidth - imageNavRef.current?.clientWidth // TODO: fix jump by providing 124x124 placeholder for lazy loaded images
+                if (nextImgIdx === images.length - 1) imageNavRef.current.scrollLeft = imageNavRef.current.scrollWidth - imageNavRef.current?.clientWidth
                 else if (isLeft) imageNavRef.current.scrollLeft = (activeImageIdx * 124) - 124
             }
         },
@@ -163,6 +163,11 @@ export const Lightbox = ({ visible, onDismiss, images, defaultImageIdx }: Props)
                 if (nextImgIdx === 0) imageNavRef.current.scrollLeft = 0
                 else if (isRight) imageNavRef.current.scrollLeft = ((activeImageIdx + 1 - pageImageCount) * 124) + 124
             }
+        },
+        onClose = () => {
+            setZoomLevel(0)
+            onDismiss()
+            setActiveImageIdx(defaultImageIdx || 0)
         }
 
     React.useLayoutEffect(() => {
@@ -185,10 +190,7 @@ export const Lightbox = ({ visible, onDismiss, images, defaultImageIdx }: Props)
             <div className={css.header}>
                 <Fluent.ActionButton
                     styles={iconStyles}
-                    onClick={() => {
-                        setZoomLevel(0)
-                        onDismiss()
-                    }}
+                    onClick={onClose}
                     iconProps={{ iconName: 'Cancel', style: { fontSize: '22px' }, }}
                 />
             </div>
@@ -239,7 +241,16 @@ export const Lightbox = ({ visible, onDismiss, images, defaultImageIdx }: Props)
                             : (image && type)
                                 ? `data:image/${type};base64,${image}`
                                 : ''
-                        return <div key={idx}><img key={'img' + idx} className={clas(css.img, css.navImg, 'lazy')} style={activeImageIdx === idx ? { filter: 'unset', border: '2px solid red' } : undefined} alt={title} data-src={src} onClick={() => { setActiveImageIdx(idx) }} /></div>
+                        return <div key={idx} className={css.navImgPlaceholder}>
+                            <img
+                                key={'img' + idx}
+                                className={clas(css.img, css.navImg, 'lazy')}
+                                style={activeImageIdx === idx ? { filter: 'unset', border: '2px solid red' } : undefined}
+                                alt={title}
+                                data-src={src}
+                                onClick={() => { setActiveImageIdx(idx) }}
+                            />
+                        </div>
                     })}
                 </div>}
             </div>

--- a/ui/src/parts/lightbox.tsx
+++ b/ui/src/parts/lightbox.tsx
@@ -1,0 +1,86 @@
+// Copyright 2020 H2O.ai, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { B, S } from 'h2o-wave'
+import React from 'react'
+import { stylesheet } from 'typestyle'
+import * as Fluent from '@fluentui/react'
+
+const css = stylesheet({
+    body: {
+        position: 'fixed',
+        inset: '0px',
+        width: '100%',
+        height: '100%',
+        zIndex: 1,
+        backgroundColor: '#000000', // TODO:
+        touchAction: 'pinch-zoom' // TODO:
+    },
+    img: {
+        flexGrow: 1,
+        objectFit: 'contain',
+        cursor: 'pointer'
+    },
+    header: {
+        width: '100%',
+        height: '40px',
+        textAlign: 'right'
+    },
+    content: {
+        display: 'flex',
+        maxHeight: 'calc(100% - 100px)',
+        maxWidth: '100%',
+    },
+    footer: {
+        height: '60px',
+        textAlign: 'center',
+        color: '#ffffff', // TODO:
+        width: '100%'
+    }
+})
+
+interface Props {
+    visible: B,
+    onDismiss: () => void,
+    title: S,
+    description?: S,
+    type?: S,
+    image?: S,
+    path?: S,
+}
+
+export const Lightbox = ({ visible, onDismiss, type, image, path, title, description }: Props) => {
+    const
+        src = path
+            ? path
+            : (image && type)
+                ? `data:image/${type};base64,${image}`
+                : ''
+    return (
+        <div aria-hidden={true} className={css.body} style={visible ? undefined : { display: 'none' }} >
+            <div className={css.header}>
+                <Fluent.ActionButton
+                    styles={{
+                        icon: { color: '#ffffff' }, // TODO:
+                        root: { padding: '10px 10px' }
+                    }}
+                    onClick={onDismiss}
+                    iconProps={{ iconName: 'Cancel', style: { fontSize: '22px' } }}
+                />
+            </div>
+            <div className={css.content}><img className={css.img} alt={title} src={src} /></div>
+            <div className={css.footer}>{title}{description ? ` - ${description}` : ''}</div>
+        </div>
+    )
+}

--- a/ui/src/parts/lightbox.tsx
+++ b/ui/src/parts/lightbox.tsx
@@ -19,226 +19,208 @@ import * as Fluent from '@fluentui/react'
 import { clas } from '../theme'
 
 const
-    iconStyles: Fluent.IButtonStyles = {
-        icon: { color: '#fff', lineHeight: 22, height: 'unset', padding: 4 },
-        iconHovered: { color: '#fff' },
-        iconPressed: { color: 'rgba(255, 255, 255, 0.7)' },
-        flexContainer: { justifyContent: 'center' },
-        root: { margin: '4px 4px', width: 38, height: 38, backgroundColor: 'rgba(0, 0, 0, 0.3)' },
-        rootHovered: { backgroundColor: 'rgba(255, 255, 255, 0.3)' }
+  iconStyles: Fluent.IButtonStyles = {
+    flexContainer: { justifyContent: 'center' },
+    root: { margin: '4px 4px', width: 38, height: 38, backgroundColor: 'rgba(0, 0, 0, 0.3)' },
+    rootHovered: { backgroundColor: 'rgba(255, 255, 255, 0.3)' },
+    icon: { color: '#fff', lineHeight: 22, height: 'unset', padding: 4 },
+    iconHovered: { color: '#fff' },
+    iconPressed: { color: 'rgba(255, 255, 255, 0.7)' },
+  },
+  css = stylesheet({
+    body: {
+      position: 'fixed',
+      inset: '0px',
+      width: '100%',
+      height: '100%',
+      zIndex: 1,
+      backgroundColor: 'rgba(0, 0, 0, 0.9)',
     },
-    css = stylesheet({
-        body: {
-            position: 'fixed',
-            inset: '0px',
-            width: '100%',
-            height: '100%',
-            zIndex: 1,
-            backgroundColor: 'rgba(0, 0, 0, 0.9)',
-        },
-        img: {
-            maxWidth: '100%',
-            objectFit: 'scale-down',
-        },
-        header: {
-            width: '100%',
-            height: '40px',
-            textAlign: 'right'
-        },
-        content: {
-            display: 'flex',
-            position: 'relative',
-            overflow: 'auto',
-            justifyContent: 'center',
-        },
-        footer: {
-            textAlign: 'center',
-            color: '#fff',
-            width: '100%'
-        },
-        imageNav: {
-            height: '142px',
-            paddingTop: '20px',
-            overflow: 'auto',
-            whiteSpace: 'nowrap'
-        },
-        navImg: {
-            boxSizing: 'border-box',
-            objectFit: 'cover',
-            height: '120px',
-            width: '120px',
-            margin: '0px 2px',
-            filter: 'brightness(30%)',
-            border: '2px solid black',
-            $nest: { '&:hover': { filter: 'unset', border: '2px solid red' } }
-        },
-        arrow: {
-            cursor: "pointer",
-            position: "absolute",
-            top: "50%",
-            width: "auto",
-            padding: "16px",
-            marginTop: "-50px",
-            color: "#fff",
-            userSelect: "none",
-        },
-        imgCaptions: {
-            whiteSpace: 'nowrap',
-            padding: '10px 40px',
-            height: '20px'
-        },
-        text: { textOverflow: 'ellipsis', overflow: 'hidden' },
-        title: { fontWeight: 500 },
-        description: { color: '#bbb' },
-        navImgPlaceholder: { display: 'inline-block', width: '124px' }
-    })
+    img: {
+      maxWidth: '100%',
+      objectFit: 'scale-down',
+    },
+    header: {
+      width: '100%',
+      height: '40px',
+      textAlign: 'right'
+    },
+    content: {
+      display: 'flex',
+      position: 'relative',
+      overflow: 'auto',
+      justifyContent: 'center',
+    },
+    footer: {
+      textAlign: 'center',
+      color: '#fff',
+      width: '100%'
+    },
+    imageNav: {
+      height: '142px',
+      paddingTop: '20px',
+      overflow: 'auto',
+      whiteSpace: 'nowrap'
+    },
+    navImg: {
+      boxSizing: 'border-box',
+      objectFit: 'cover',
+      height: '120px',
+      width: '120px',
+      margin: '0px 2px',
+      cursor: 'pointer',
+      filter: 'brightness(30%)',
+      border: '2px solid black',
+      $nest: { '&:hover': { filter: 'unset', border: '2px solid red' } }
+    },
+    arrow: {
+      cursor: "pointer",
+      position: "absolute",
+      top: "50%",
+      width: "auto",
+      padding: "16px",
+      marginTop: "-50px",
+      color: "#fff",
+      userSelect: "none",
+    },
+    imgCaptions: { whiteSpace: 'nowrap', padding: '10px 40px', height: '20px' },
+    text: { textOverflow: 'ellipsis', overflow: 'hidden' },
+    title: { fontWeight: 500 },
+    description: { color: '#bbb' },
+    navImgPlaceholder: { display: 'inline-block', width: '124px' }
+  })
+
+type Image = { title: S, description?: S, type?: S, image?: S, path?: S }
+type ArrowControlProps = { activeImageIdx: U, setActiveImageIdx: (idx: U) => void, images: Image[] }
 
 interface LightboxProps {
-    visible: B,
-    onDismiss: () => void,
-    images: { title: S, description?: S, type?: S, image?: S, path?: S, }[],
-    defaultImageIdx?: U
+  visible: B,
+  onDismiss: () => void,
+  images: Image[],
+  defaultImageIdx?: U
 }
 
 const
-    keys = { esc: 27, left: 37, right: 39 },
-    lazyImageObserver = new IntersectionObserver(entries =>
-        entries.forEach(entry => {
-            if (entry.isIntersecting) {
-                const lazyImage = entry.target as HTMLImageElement
-                lazyImage.src = lazyImage.dataset.src!
-                lazyImage.classList.remove("lazy")
-                lazyImageObserver.unobserve(lazyImage)
-            }
-        })
-    )
+  keys = { esc: 27, left: 37, right: 39 },
+  lazyImageObserver = new IntersectionObserver(entries =>
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        const lazyImage = entry.target as HTMLImageElement
+        lazyImage.src = lazyImage.dataset.src!
+        lazyImage.classList.remove("lazy")
+        lazyImageObserver.unobserve(lazyImage)
+      }
+    })
+  ),
+  getImageSrc = ({ type, image, path }: Image) => path
+    ? path
+    : (image && type)
+      ? `data:image/${type};base64,${image}`
+      : '',
+  ArrowControls = ({ activeImageIdx, setActiveImageIdx, images }: ArrowControlProps) =>
+    <>
+      <div className={css.arrow} style={{ left: 0 }}>
+        <Fluent.ActionButton
+          styles={iconStyles}
+          onClick={() => setActiveImageIdx(activeImageIdx === 0 ? images.length - 1 : activeImageIdx - 1)}
+          iconProps={{ iconName: 'ChevronLeft', style: { fontSize: '22px' } }}
+        />
+      </div>
+      <div className={css.arrow} style={{ right: 0 }}>
+        <Fluent.ActionButton
+          styles={iconStyles}
+          onClick={() => setActiveImageIdx(activeImageIdx === images.length - 1 ? 0 : activeImageIdx + 1)}
+          iconProps={{ iconName: 'ChevronRight', style: { fontSize: '22px' } }}
+        />
+      </div>
+    </>,
+  CloseButton = ({ onClose }: { onClose: () => void }) =>
+    <Fluent.ActionButton
+      styles={iconStyles}
+      onClick={onClose}
+      iconProps={{ iconName: 'Cancel', style: { fontSize: '22px' } }}
+    />
 
 export const Lightbox = ({ visible, onDismiss, images, defaultImageIdx }: LightboxProps) => {
-    const
-        [activeImageIdx, _setActiveImageIdx] = React.useState(defaultImageIdx || 0),
-        activeImageIdxRef = React.useRef(defaultImageIdx || 0),
-        setActiveImageIdx = (idx: U) => {
-            // Store activeImageIdx inside ref to make it accessible from window key event closure.
-            activeImageIdxRef.current = idx
-            _setActiveImageIdx(idx)
-        },
-        imageNavRef = React.useRef<HTMLDivElement | null>(null)
-
-    // Initialize intersection observer for lazy images.
-    React.useLayoutEffect(() => {
-        const lazyImages = [].slice.call(document.querySelectorAll(".lazy"))
-        lazyImages.forEach(lazyImage => lazyImageObserver.observe(lazyImage))
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [])
-
-    // Add keyboard events listener.
-    React.useEffect(() => {
-        window.addEventListener("keydown", handleKeyDown)
-        return () => window.removeEventListener("keydown", handleKeyDown)
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [])
-
-    // Set initial scroll position when defaultImageIdx is specified.
-    React.useEffect(() => {
-        if (defaultImageIdx && imageNavRef.current) {
-            imageNavRef.current.scrollLeft = (activeImageIdx * 124) - 124 - imageNavRef.current.scrollLeft
-        }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [visible])
-
-    // Handle image navigation scroll.
-    React.useEffect(() => {
-        const navRef = imageNavRef.current
-        if (navRef) {
-            const
-                viewportImageCount = Math.floor(navRef?.clientWidth / 124),
-                isActiveImageRight = activeImageIdx >= Math.floor(navRef.scrollLeft / 124) + (viewportImageCount - 1),
-                isActiveImageLeft = activeImageIdx <= Math.floor(navRef.scrollLeft / 124)
-
-            if (activeImageIdx === 0) navRef.scrollLeft = 0
-            else if (activeImageIdx === images.length - 1) navRef.scrollLeft = navRef.scrollWidth - navRef?.clientWidth
-            else if (isActiveImageLeft) navRef.scrollBy({ left: (activeImageIdx - 1) * 124 - navRef.scrollLeft, behavior: 'smooth' })
-            else if (isActiveImageRight) navRef.scrollBy({ left: (activeImageIdx + 2 - viewportImageCount) * 124 - navRef.scrollLeft, behavior: 'smooth' })
-        }
-    }, [activeImageIdx, images.length])
-
-    if (images.length === 0) throw new Error('No images passed to image lightbox component.')
-    if (activeImageIdx >= images.length) throw new Error(`Image with defaultImageIdx:${activeImageIdx} does not exist.`)
-
-    const
-        { type, image, path, title, description } = images[activeImageIdx],
-        src = path
-            ? path
-            : (image && type)
-                ? `data:image/${type};base64,${image}`
-                : '',
-        isGallery = images.length > 1,
-        onClose = () => {
-            onDismiss()
-            setActiveImageIdx(defaultImageIdx || 0)
-            if (imageNavRef.current) imageNavRef.current.scrollLeft = 0
-        },
-        handleKeyDown = React.useCallback((ev: KeyboardEvent) => {
-            if (ev.keyCode === keys.right) setActiveImageIdx(activeImageIdxRef.current === images.length - 1 ? 0 : activeImageIdxRef.current + 1)
-            else if (ev.keyCode === keys.left) setActiveImageIdx(activeImageIdxRef.current === 0 ? images.length - 1 : activeImageIdxRef.current - 1)
-            else if (ev.keyCode === keys.esc) onClose()
-            // eslint-disable-next-line react-hooks/exhaustive-deps
-        }, [activeImageIdxRef.current, images.length])
-
-    return (
-        <div aria-hidden={true} className={css.body} style={visible ? undefined : { display: 'none' }}>
-            <div className={css.header}>
-                <Fluent.ActionButton
-                    styles={iconStyles}
-                    onClick={onClose}
-                    iconProps={{ iconName: 'Cancel', style: { fontSize: '22px' }, }}
-                />
-            </div>
-            <div className={css.content} style={{ height: `calc(100% - ${isGallery ? '262px' : '100px'})` }}>
-                <img className={css.img} alt={title} src={src} />
-                {isGallery &&
-                    <>
-                        <div className={css.arrow} style={{ left: 0 }}>
-                            <Fluent.ActionButton
-                                styles={iconStyles}
-                                onClick={() => setActiveImageIdx(activeImageIdx === 0 ? images.length - 1 : activeImageIdx - 1)}
-                                iconProps={{ iconName: 'ChevronLeft', style: { fontSize: '22px' } }}
-                            />
-                        </div>
-                        <div className={css.arrow} style={{ right: 0 }}>
-                            <Fluent.ActionButton
-                                styles={iconStyles}
-                                onClick={() => setActiveImageIdx(activeImageIdx === images.length - 1 ? 0 : activeImageIdx + 1)}
-                                iconProps={{ iconName: 'ChevronRight', style: { fontSize: '22px' } }}
-                            />
-                        </div>
-                    </>
-                }
-            </div>
-            <div className={css.footer} style={{ height: isGallery ? '260px' : '60px' }}>
-                <div className={css.imgCaptions}>
-                    <div title={title} className={clas(css.text, css.title)}>{title}</div>
-                    <div title={description} className={clas(css.text, css.description)}>{description || ''}</div>
-                </div>
-                {isGallery && <div className={css.imageNav} ref={imageNavRef}>
-                    {images.map(({ type, image, path, title }, idx) => {
-                        const src = path
-                            ? path
-                            : (image && type)
-                                ? `data:image/${type};base64,${image}`
-                                : ''
-                        return <div key={idx} className={css.navImgPlaceholder}>
-                            <img
-                                className={clas(css.img, css.navImg, 'lazy')}
-                                style={activeImageIdx === idx ? { filter: 'unset', border: '2px solid red' } : undefined}
-                                alt={title}
-                                data-src={src}
-                                onClick={() => setActiveImageIdx(idx)}
-                            />
-                        </div>
-                    })}
-                </div>}
-            </div>
-        </div>
+  const
+    [activeImageIdx, _setActiveImageIdx] = React.useState(defaultImageIdx || 0),
+    { title, description } = images[activeImageIdx],
+    isGallery = images.length > 1,
+    src = getImageSrc(images[activeImageIdx]),
+    imageNavRef = React.useRef<HTMLDivElement | null>(null),
+    navImgRefs: React.RefObject<HTMLImageElement>[] = images.map(() => React.createRef()),
+    activeImageIdxRef = React.useRef(activeImageIdx),
+    setActiveImageIdx = (idx: U) => {
+      // Store activeImageIdx inside ref to make it accessible from window key event closure.
+      _setActiveImageIdx(idx)
+      activeImageIdxRef.current = idx
+    },
+    onClose = () => {
+      onDismiss()
+      setActiveImageIdx(defaultImageIdx || 0)
+      if (imageNavRef.current) imageNavRef.current.scrollLeft = 0
+    },
+    handleKeyDown = (ev: KeyboardEvent) => {
+      if (ev.keyCode === keys.esc) onClose()
+      const imgIdx = activeImageIdxRef.current
+      if (ev.keyCode === keys.right) setActiveImageIdx(imgIdx === images.length - 1 ? 0 : imgIdx + 1)
+      else if (ev.keyCode === keys.left) setActiveImageIdx(imgIdx === 0 ? images.length - 1 : imgIdx - 1)
+    },
+    imageNav = images.map((image, idx) =>
+      <div key={idx} className={css.navImgPlaceholder}>
+        <img
+          className={clas(css.img, css.navImg, 'lazy')}
+          ref={navImgRefs[idx]}
+          style={activeImageIdx === idx ? { filter: 'unset', border: '2px solid red' } : undefined}
+          alt={title}
+          data-src={getImageSrc(image)}
+          onClick={() => setActiveImageIdx(idx)}
+        />
+      </div>
     )
+
+  React.useEffect(() => {
+    // Set initial scroll position.
+    navImgRefs[activeImageIdx].current!.scrollIntoView({ behavior: 'auto', inline: 'center', block: 'center' })
+    // Add keyboard events listener.
+    if (visible) window.addEventListener("keydown", handleKeyDown)
+    else window.removeEventListener("keydown", handleKeyDown)
+    return () => window.removeEventListener("keydown", handleKeyDown)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [visible])
+
+  // Handle image navigation scroll.
+  React.useEffect(() => navImgRefs[activeImageIdx].current!.scrollIntoView({
+    behavior: (activeImageIdx === 0 || activeImageIdx === images.length - 1) ? 'auto' : 'smooth',
+    inline: 'center',
+    block: 'center'
+  }), [activeImageIdx, images.length, navImgRefs])
+
+  React.useLayoutEffect(() => {
+    // Initialize intersection observer for lazy images.
+    const lazyImages = [].slice.call(document.querySelectorAll(".lazy"))
+    lazyImages.forEach(lazyImage => lazyImageObserver.observe(lazyImage))
+  }, [])
+
+  if (images.length === 0) throw new Error('No images passed to image lightbox component.')
+  if (activeImageIdx >= images.length) throw new Error(`Image with defaultImageIdx:${activeImageIdx} does not exist.`)
+
+  return (
+    <div className={css.body} style={visible ? undefined : { display: 'none' }}>
+      <div className={css.header}>
+        <CloseButton onClose={onClose} />
+      </div>
+      <div className={css.content} style={{ height: `calc(100% - ${isGallery ? '262px' : '100px'})` }}>
+        <img className={css.img} alt={title} src={src} />
+        {isGallery && <ArrowControls activeImageIdx={activeImageIdx} setActiveImageIdx={setActiveImageIdx} images={images} />}
+      </div>
+      <div className={css.footer} style={{ height: isGallery ? '260px' : '60px' }}>
+        <div className={css.imgCaptions}>
+          <div title={title} className={clas(css.text, css.title)}>{title}</div>
+          <div title={description} className={clas(css.text, css.description)}>{description || ''}</div>
+        </div>
+        {isGallery && <div className={css.imageNav} ref={imageNavRef}>{imageNav}</div>}
+      </div>
+    </div>
+  )
 }

--- a/ui/src/parts/lightbox.tsx
+++ b/ui/src/parts/lightbox.tsx
@@ -20,8 +20,8 @@ import { clas } from '../theme'
 
 const
     iconStyles: Fluent.IButtonStyles = {
-        icon: { color: '#ffffff', lineHeight: 22, height: 'unset', padding: 4 },
-        iconHovered: { color: '#ffffff' }, // TODO:
+        icon: { color: '#fff', lineHeight: 22, height: 'unset', padding: 4 },
+        iconHovered: { color: '#fff' },
         iconPressed: { color: 'rgba(255, 255, 255, 0.7)' },
         flexContainer: { justifyContent: 'center' },
         root: { margin: '4px 4px', width: 38, height: 38, backgroundColor: 'rgba(0, 0, 0, 0.3)' },
@@ -34,17 +34,11 @@ const
             width: '100%',
             height: '100%',
             zIndex: 1,
-            backgroundColor: 'rgba(0, 0, 0, 0.9)', // TODO:
-            touchAction: 'pinch-zoom' // TODO:
+            backgroundColor: 'rgba(0, 0, 0, 0.9)',
         },
         img: {
-            // flexGrow: 1,
-            maxWidth: '100%', // TODO: 3000x2000 vertical scrollbar
-            // alignSelf: 'center',
+            maxWidth: '100%',
             objectFit: 'scale-down',
-            // transformOrigin: 'top left',
-            // transition: 'transform 0.25s ease',
-            // cursor: 'pointer',
         },
         header: {
             width: '100%',
@@ -54,13 +48,12 @@ const
         content: {
             display: 'flex',
             position: 'relative',
-            maxWidth: '100%',
             overflow: 'auto',
             justifyContent: 'center',
         },
         footer: {
             textAlign: 'center',
-            color: '#ffffff', // TODO:
+            color: '#fff',
             width: '100%'
         },
         imageNav: {
@@ -71,8 +64,8 @@ const
         },
         navImg: {
             boxSizing: 'border-box',
-            height: '120px',
             objectFit: 'cover',
+            height: '120px',
             width: '120px',
             margin: '0px 2px',
             filter: 'brightness(30%)',
@@ -91,11 +84,7 @@ const
             width: "auto",
             padding: "16px",
             marginTop: "-50px",
-            color: "white",
-            fontWeight: "bold",
-            fontSize: "20px",
-            transition: "0.6s ease",
-            borderRadius: "0 3px 3px 0",
+            color: "#fff",
             userSelect: "none",
         },
         imgCaptions: {
@@ -103,85 +92,115 @@ const
             padding: '10px 40px',
             height: '20px'
         },
-        text: {
-            textOverflow: 'ellipsis',
-            overflow: 'hidden',
-        },
+        text: { textOverflow: 'ellipsis', overflow: 'hidden' },
         title: { fontWeight: 500 },
-        description: { color: '#bbbbbb' }, // TODO: theme colors
+        description: { color: '#bbb' },
         navImgPlaceholder: { display: 'inline-block', width: '124px' }
     })
 
 interface Props {
     visible: B,
     onDismiss: () => void,
-    images: {
-        title: S,
-        description?: S,
-        type?: S,
-        image?: S,
-        path?: S,
-    }[],
+    images: { title: S, description?: S, type?: S, image?: S, path?: S, }[],
     defaultImageIdx?: U
 }
 
-const lazyImageObserver = new IntersectionObserver(entries => {
-    entries.forEach(entry => {
-        if (entry.isIntersecting) {
-            const lazyImage = entry.target as HTMLImageElement
-            lazyImage.src = lazyImage.dataset.src!
-            lazyImage.classList.remove("lazy")
-            lazyImageObserver.unobserve(lazyImage)
-        }
+const
+    keys = { esc: 27, left: 37, right: 39 } as const,
+    lazyImageObserver = new IntersectionObserver(entries => {
+        entries.forEach(entry => {
+            if (entry.isIntersecting) {
+                const lazyImage = entry.target as HTMLImageElement
+                lazyImage.src = lazyImage.dataset.src!
+                lazyImage.classList.remove("lazy")
+                lazyImageObserver.unobserve(lazyImage)
+            }
+        })
     })
-})
 
 export const Lightbox = ({ visible, onDismiss, images, defaultImageIdx }: Props) => {
     const
-        [activeImageIdx, setActiveImageIdx] = React.useState(defaultImageIdx || 0),
-        imageNavRef = React.useRef<HTMLDivElement | undefined>(),
-        handleClickLeft = () => {
-            const nextImgIdx = (activeImageIdx === 0) ? (images.length - 1) : activeImageIdx - 1
-            setActiveImageIdx(nextImgIdx)
-            if (imageNavRef.current) {
-                const isLeft = activeImageIdx <= Math.floor(imageNavRef.current.scrollLeft / 124)
-                if (nextImgIdx === images.length - 1) imageNavRef.current.scrollLeft = imageNavRef.current.scrollWidth - imageNavRef.current?.clientWidth
-                else if (isLeft) imageNavRef.current.scrollBy({ left: (activeImageIdx * 124) - 124 - imageNavRef.current.scrollLeft, top: 0, behavior: 'smooth' })
-            }
+        [activeImageIdx, _setActiveImageIdx] = React.useState(defaultImageIdx || 0),
+        activeImageRef = React.useRef(defaultImageIdx || 0),
+        setActiveImageIdx = (idx: U) => {
+            activeImageRef.current = idx
+            _setActiveImageIdx(idx)
         },
-        handleClickRight = () => {
-            const nextImgIdx = (activeImageIdx === images.length - 1) ? 0 : activeImageIdx + 1
-            setActiveImageIdx(nextImgIdx)
-            if (imageNavRef.current) {
-                const pageImageCount = Math.floor(imageNavRef.current?.clientWidth / 124)
-                const isRight = activeImageIdx >= Math.floor(imageNavRef.current.scrollLeft / 124) + (pageImageCount - 1)
-                if (nextImgIdx === 0) imageNavRef.current.scrollLeft = 0
-                else if (isRight) imageNavRef.current.scrollBy({ left: ((activeImageIdx + 1 - pageImageCount) * 124) + 124 - imageNavRef.current.scrollLeft, top: 0, behavior: 'smooth' })
-            }
-        },
-        onClose = () => {
-            onDismiss()
-            setActiveImageIdx(defaultImageIdx || 0)
-            if (imageNavRef.current) imageNavRef.current.scrollLeft = 0
-        }
+        imageNavRef = React.useRef<HTMLDivElement | undefined>()
 
+    // handle image navigation scroll
+    React.useEffect(() => {
+        const navRef = imageNavRef.current
+        if (navRef) {
+            const
+                viewportImageCount = Math.floor(navRef?.clientWidth / 124),
+                isActiveImageRight = activeImageIdx >= Math.floor(navRef.scrollLeft / 124) + (viewportImageCount - 1),
+                isActiveImageLeft = activeImageIdx <= Math.floor(navRef.scrollLeft / 124)
+
+            if (activeImageIdx === 0) navRef.scrollLeft = 0
+            else if (activeImageIdx === images.length - 1) navRef.scrollLeft = navRef.scrollWidth - navRef?.clientWidth
+            else if (isActiveImageLeft) navRef.scrollBy({ left: (activeImageIdx - 1) * 124 - navRef.scrollLeft, behavior: 'smooth' })
+            else if (isActiveImageRight) navRef.scrollBy({ left: (activeImageIdx + 2 - viewportImageCount) * 124 - navRef.scrollLeft, behavior: 'smooth' })
+        }
+    }, [activeImageIdx, images.length])
+
+    // initialize intersection observer for lazy images
     React.useLayoutEffect(() => {
         const lazyImages = [].slice.call(document.querySelectorAll(".lazy"))
         lazyImages.forEach(lazyImage => lazyImageObserver.observe(lazyImage))
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 
-    if (images.length === 0 || (activeImageIdx >= images.length)) return <>{'Error'}</> // TODO:
+    // set initial scroll position when defaultImageIdx is specified
+    React.useEffect(() => {
+        if (defaultImageIdx && imageNavRef.current) {
+            imageNavRef.current.scrollLeft = (activeImageIdx * 124) - 124 - imageNavRef.current.scrollLeft
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [visible])
+
+    // Add keyboard events listener
+    React.useEffect(() => {
+        window.addEventListener("keydown", handleKeyDown)
+        return () => window.removeEventListener("keydown", handleKeyDown)
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [])
+
+    if (images.length === 0) throw new Error('No images passed to image lightbox component.')
+    if (activeImageIdx >= images.length) throw new Error(`Image with defaultImageIdx:${activeImageIdx} does not exist.`)
+
     const
         { type, image, path, title, description } = images[activeImageIdx],
         src = path
             ? path
             : (image && type)
                 ? `data:image/${type};base64,${image}`
-                : ''
+                : '',
+        isGallery = images.length > 1,
+        onClose = () => {
+            onDismiss()
+            setActiveImageIdx(defaultImageIdx || 0)
+            if (imageNavRef.current) imageNavRef.current.scrollLeft = 0
+        },
+        handleKeyDown = React.useCallback((ev: KeyboardEvent) => {
+            switch (ev.keyCode) {
+                case keys.right:
+                    setActiveImageIdx(activeImageRef.current === images.length - 1 ? 0 : activeImageRef.current + 1)
+                    break
+                case keys.left:
+                    setActiveImageIdx(activeImageRef.current === 0 ? images.length - 1 : activeImageRef.current - 1)
+                    break
+                case keys.esc:
+                    onClose()
+                    break
+                default:
+                    break
+            }
+            // eslint-disable-next-line react-hooks/exhaustive-deps
+        }, [activeImageIdx, images.length])
 
     return (
-        <div aria-hidden={true} className={css.body} style={visible ? undefined : { display: 'none' }} >
+        <div aria-hidden={true} className={css.body} style={visible ? undefined : { display: 'none' }}>
             <div className={css.header}>
                 <Fluent.ActionButton
                     styles={iconStyles}
@@ -189,41 +208,33 @@ export const Lightbox = ({ visible, onDismiss, images, defaultImageIdx }: Props)
                     iconProps={{ iconName: 'Cancel', style: { fontSize: '22px' }, }}
                 />
             </div>
-            <div className={css.content} style={{ height: `calc(100% - ${images.length > 1 ? '262px' : '100px'})` }}>
-                <img
-                    className={css.img}
-                    alt={title}
-                    src={src}
-                    style={{
-                        // maxHeight: 'inherit',
-                        // objectFit: 'none'
-                    }}
-                />
-                {images.length > 1 &&
+            <div className={css.content} style={{ height: `calc(100% - ${isGallery ? '262px' : '100px'})` }}>
+                <img className={css.img} alt={title} src={src} />
+                {isGallery &&
                     <>
                         <div className={css.arrow} style={{ left: 0 }}>
                             <Fluent.ActionButton
                                 styles={iconStyles}
-                                onClick={handleClickLeft}
+                                onClick={() => setActiveImageIdx(activeImageIdx === 0 ? images.length - 1 : activeImageIdx - 1)}
                                 iconProps={{ iconName: 'ChevronLeft', style: { fontSize: '22px' } }}
                             />
                         </div>
                         <div className={css.arrow} style={{ right: 0 }}>
                             <Fluent.ActionButton
                                 styles={iconStyles}
-                                onClick={handleClickRight}
+                                onClick={() => setActiveImageIdx(activeImageIdx === images.length - 1 ? 0 : activeImageIdx + 1)}
                                 iconProps={{ iconName: 'ChevronRight', style: { fontSize: '22px' } }}
                             />
                         </div>
                     </>
                 }
             </div>
-            <div className={css.footer} style={{ height: images.length > 1 ? '260px' : '60px' }}>
+            <div className={css.footer} style={{ height: isGallery ? '260px' : '60px' }}>
                 <div className={css.imgCaptions}>
                     <div title={title} className={clas(css.text, css.title)}>{title}</div>
-                    <div title={description} className={clas(css.text, css.description)}>{description ? description : ''}</div>
+                    <div title={description} className={clas(css.text, css.description)}>{description || ''}</div>
                 </div>
-                {images.length > 1 && <div className={css.imageNav} ref={imageNavRef}>
+                {isGallery && <div className={css.imageNav} ref={imageNavRef}>
                     {images.map(({ type, image, path, title }, idx) => {
                         const src = path
                             ? path
@@ -232,12 +243,11 @@ export const Lightbox = ({ visible, onDismiss, images, defaultImageIdx }: Props)
                                 : ''
                         return <div key={idx} className={css.navImgPlaceholder}>
                             <img
-                                key={'img' + idx}
                                 className={clas(css.img, css.navImg, 'lazy')}
                                 style={activeImageIdx === idx ? { filter: 'unset', border: '2px solid red' } : undefined}
                                 alt={title}
                                 data-src={src}
-                                onClick={() => { setActiveImageIdx(idx) }}
+                                onClick={() => setActiveImageIdx(idx)}
                             />
                         </div>
                     })}


### PR DESCRIPTION
New image lightbox component (not public facing API) for (almost) full-screen image view. 
Appears when **ui.image** is clicked.

```tsx
interface LightboxProps {
  visible: B,
  onDismiss: () => void,
  images: Image[],
  defaultImageIdx?: U
}
```
**For multi-image view:**

https://user-images.githubusercontent.com/23740173/194434539-6eb4d8c9-0fac-4e7a-82ad-bf749bf4ea29.mov

To be implemented with **ui.image_grid** component (#1599)

**For single image:**

https://user-images.githubusercontent.com/23740173/194434533-7edcdaf9-6555-4521-86a4-61461ee9de2a.mov



Closes #1542