### PR TITLE
feat: Added label parameter to ui.menu

### DIFF
--- a/py/examples/menu.py
+++ b/py/examples/menu.py
@@ -28,7 +28,7 @@ async def serve(q: Q):
         q.page['example'].items = [
             ui.menu(image=image, items=commands),
             ui.menu(icon='Add', items=commands),
-            ui.menu(title='App', items=commands),
+            ui.menu(label='App', items=commands),
             ui.menu(items=commands)
         ]
     await q.page.save()

--- a/py/examples/menu.py
+++ b/py/examples/menu.py
@@ -28,6 +28,7 @@ async def serve(q: Q):
         q.page['example'].items = [
             ui.menu(image=image, items=commands),
             ui.menu(icon='Add', items=commands),
+            ui.menu(title='App', items=commands),
             ui.menu(items=commands)
         ]
     await q.page.save()

--- a/py/h2o_wave/types.py
+++ b/py/h2o_wave/types.py
@@ -3973,7 +3973,7 @@ class Links:
         self.label = label
         """The name of the link group."""
         self.inline = inline
-        """Render links horizontally. Defaults to 'false'."""
+        """Render links horizontally. Defaults to False."""
         self.width = width
         """The width of the links, e.g. '100px'."""
 
@@ -5850,7 +5850,7 @@ class Stats:
         self.width = width
         """The width of the stats, e.g. '100px'."""
         self.visible = visible
-        """True if the component should be visible. Defaults to true."""
+        """True if the component should be visible. Defaults to True."""
 
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""
@@ -5983,7 +5983,7 @@ class Image:
         self.width = width
         """The width of the image, e.g. '100px'."""
         self.visible = visible
-        """True if the component should be visible. Defaults to true."""
+        """True if the component should be visible. Defaults to True."""
 
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""
@@ -6709,22 +6709,22 @@ class Menu:
             icon: Optional[str] = None,
             image: Optional[str] = None,
             name: Optional[str] = None,
-            title: Optional[str] = None,
+            label: Optional[str] = None,
     ):
         _guard_vector('Menu.items', items, (Command,), False, False, False)
         _guard_scalar('Menu.icon', icon, (str,), False, True, False)
         _guard_scalar('Menu.image', image, (str,), False, True, False)
         _guard_scalar('Menu.name', name, (str,), True, True, False)
-        _guard_scalar('Menu.title', title, (str,), False, True, False)
+        _guard_scalar('Menu.label', label, (str,), False, True, False)
         self.items = items
         """Commands to render."""
         self.icon = icon
-        """The card's icon. Mutually exclusive with the image and title."""
+        """The card's icon. Mutually exclusive with the image and label."""
         self.image = image
-        """The card’s image, preferably user avatar. Mutually exclusive with the icon and title."""
+        """The card’s image, preferably user avatar. Mutually exclusive with the icon and label."""
         self.name = name
         """An identifying name for this component."""
-        self.title = title
+        self.label = label
         """The text displayed next to the chevron. Mutually exclusive with the icon and image."""
 
     def dump(self) -> Dict:
@@ -6733,13 +6733,13 @@ class Menu:
         _guard_scalar('Menu.icon', self.icon, (str,), False, True, False)
         _guard_scalar('Menu.image', self.image, (str,), False, True, False)
         _guard_scalar('Menu.name', self.name, (str,), True, True, False)
-        _guard_scalar('Menu.title', self.title, (str,), False, True, False)
+        _guard_scalar('Menu.label', self.label, (str,), False, True, False)
         return _dump(
             items=[__e.dump() for __e in self.items],
             icon=self.icon,
             image=self.image,
             name=self.name,
-            title=self.title,
+            label=self.label,
         )
 
     @staticmethod
@@ -6753,19 +6753,19 @@ class Menu:
         _guard_scalar('Menu.image', __d_image, (str,), False, True, False)
         __d_name: Any = __d.get('name')
         _guard_scalar('Menu.name', __d_name, (str,), True, True, False)
-        __d_title: Any = __d.get('title')
-        _guard_scalar('Menu.title', __d_title, (str,), False, True, False)
+        __d_label: Any = __d.get('label')
+        _guard_scalar('Menu.label', __d_label, (str,), False, True, False)
         items: List[Command] = [Command.load(__e) for __e in __d_items]
         icon: Optional[str] = __d_icon
         image: Optional[str] = __d_image
         name: Optional[str] = __d_name
-        title: Optional[str] = __d_title
+        label: Optional[str] = __d_label
         return Menu(
             items,
             icon,
             image,
             name,
-            title,
+            label,
         )
 
 

--- a/py/h2o_wave/types.py
+++ b/py/h2o_wave/types.py
@@ -6709,19 +6709,23 @@ class Menu:
             icon: Optional[str] = None,
             image: Optional[str] = None,
             name: Optional[str] = None,
+            label: Optional[str] = None,
     ):
         _guard_vector('Menu.items', items, (Command,), False, False, False)
         _guard_scalar('Menu.icon', icon, (str,), False, True, False)
         _guard_scalar('Menu.image', image, (str,), False, True, False)
         _guard_scalar('Menu.name', name, (str,), True, True, False)
+        _guard_scalar('Menu.label', label, (str,), False, True, False)
         self.items = items
         """Commands to render."""
         self.icon = icon
-        """The card's icon. Mutually exclusive with the image."""
+        """The card's icon. Mutually exclusive with the image and label."""
         self.image = image
-        """The card’s image, preferably user avatar. Mutually exclusive with the icon."""
+        """The card’s image, preferably user avatar. Mutually exclusive with the icon and label."""
         self.name = name
         """An identifying name for this component."""
+        self.label = label
+        """The card's label. Mutually exclusive with the icon and image."""
 
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""
@@ -6729,11 +6733,13 @@ class Menu:
         _guard_scalar('Menu.icon', self.icon, (str,), False, True, False)
         _guard_scalar('Menu.image', self.image, (str,), False, True, False)
         _guard_scalar('Menu.name', self.name, (str,), True, True, False)
+        _guard_scalar('Menu.label', self.label, (str,), False, True, False)
         return _dump(
             items=[__e.dump() for __e in self.items],
             icon=self.icon,
             image=self.image,
             name=self.name,
+            label=self.label,
         )
 
     @staticmethod
@@ -6747,15 +6753,19 @@ class Menu:
         _guard_scalar('Menu.image', __d_image, (str,), False, True, False)
         __d_name: Any = __d.get('name')
         _guard_scalar('Menu.name', __d_name, (str,), True, True, False)
+        __d_label: Any = __d.get('label')
+        _guard_scalar('Menu.label', __d_label, (str,), False, True, False)
         items: List[Command] = [Command.load(__e) for __e in __d_items]
         icon: Optional[str] = __d_icon
         image: Optional[str] = __d_image
         name: Optional[str] = __d_name
+        label: Optional[str] = __d_label
         return Menu(
             items,
             icon,
             image,
             name,
+            label,
         )
 
 

--- a/py/h2o_wave/types.py
+++ b/py/h2o_wave/types.py
@@ -6709,23 +6709,23 @@ class Menu:
             icon: Optional[str] = None,
             image: Optional[str] = None,
             name: Optional[str] = None,
-            label: Optional[str] = None,
+            title: Optional[str] = None,
     ):
         _guard_vector('Menu.items', items, (Command,), False, False, False)
         _guard_scalar('Menu.icon', icon, (str,), False, True, False)
         _guard_scalar('Menu.image', image, (str,), False, True, False)
         _guard_scalar('Menu.name', name, (str,), True, True, False)
-        _guard_scalar('Menu.label', label, (str,), False, True, False)
+        _guard_scalar('Menu.title', title, (str,), False, True, False)
         self.items = items
         """Commands to render."""
         self.icon = icon
-        """The card's icon. Mutually exclusive with the image and label."""
+        """The card's icon. Mutually exclusive with the image and title."""
         self.image = image
-        """The card’s image, preferably user avatar. Mutually exclusive with the icon and label."""
+        """The card’s image, preferably user avatar. Mutually exclusive with the icon and title."""
         self.name = name
         """An identifying name for this component."""
-        self.label = label
-        """The card's label. Mutually exclusive with the icon and image."""
+        self.title = title
+        """The text displayed next to the chevron. Mutually exclusive with the icon and image."""
 
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""
@@ -6733,13 +6733,13 @@ class Menu:
         _guard_scalar('Menu.icon', self.icon, (str,), False, True, False)
         _guard_scalar('Menu.image', self.image, (str,), False, True, False)
         _guard_scalar('Menu.name', self.name, (str,), True, True, False)
-        _guard_scalar('Menu.label', self.label, (str,), False, True, False)
+        _guard_scalar('Menu.title', self.title, (str,), False, True, False)
         return _dump(
             items=[__e.dump() for __e in self.items],
             icon=self.icon,
             image=self.image,
             name=self.name,
-            label=self.label,
+            title=self.title,
         )
 
     @staticmethod
@@ -6753,19 +6753,19 @@ class Menu:
         _guard_scalar('Menu.image', __d_image, (str,), False, True, False)
         __d_name: Any = __d.get('name')
         _guard_scalar('Menu.name', __d_name, (str,), True, True, False)
-        __d_label: Any = __d.get('label')
-        _guard_scalar('Menu.label', __d_label, (str,), False, True, False)
+        __d_title: Any = __d.get('title')
+        _guard_scalar('Menu.title', __d_title, (str,), False, True, False)
         items: List[Command] = [Command.load(__e) for __e in __d_items]
         icon: Optional[str] = __d_icon
         image: Optional[str] = __d_image
         name: Optional[str] = __d_name
-        label: Optional[str] = __d_label
+        title: Optional[str] = __d_title
         return Menu(
             items,
             icon,
             image,
             name,
-            label,
+            title,
         )
 
 

--- a/py/h2o_wave/ui.py
+++ b/py/h2o_wave/ui.py
@@ -1525,7 +1525,7 @@ def links(
     Args:
         items: The links contained in this group.
         label: The name of the link group.
-        inline: Render links horizontally. Defaults to 'false'.
+        inline: Render links horizontally. Defaults to False.
         width: The width of the links, e.g. '100px'.
     Returns:
         A `h2o_wave.types.Links` instance.
@@ -2177,7 +2177,7 @@ def stats(
         justify: Specifies how to lay out the individual stats. Defaults to 'start'. One of 'start', 'end', 'center', 'between', 'around'. See enum h2o_wave.ui.StatsJustify.
         inset: Whether to display the stats with a contrasting background.
         width: The width of the stats, e.g. '100px'.
-        visible: True if the component should be visible. Defaults to true.
+        visible: True if the component should be visible. Defaults to True.
     Returns:
         A `h2o_wave.types.Stats` instance.
     """
@@ -2227,7 +2227,7 @@ def image(
         image: Image data, base64-encoded.
         path: The path or URL or data URL of the image, e.g. `/foo.png` or `http://example.com/foo.png` or `data:image/png;base64,???`.
         width: The width of the image, e.g. '100px'.
-        visible: True if the component should be visible. Defaults to true.
+        visible: True if the component should be visible. Defaults to True.
     Returns:
         A `h2o_wave.types.Image` instance.
     """
@@ -2502,16 +2502,16 @@ def menu(
         icon: Optional[str] = None,
         image: Optional[str] = None,
         name: Optional[str] = None,
-        title: Optional[str] = None,
+        label: Optional[str] = None,
 ) -> Component:
     """Create a contextual menu component. Useful when you have a lot of links and want to conserve the space.
 
     Args:
         items: Commands to render.
-        icon: The card's icon. Mutually exclusive with the image and title.
-        image: The card’s image, preferably user avatar. Mutually exclusive with the icon and title.
+        icon: The card's icon. Mutually exclusive with the image and label.
+        image: The card’s image, preferably user avatar. Mutually exclusive with the icon and label.
         name: An identifying name for this component.
-        title: The text displayed next to the chevron. Mutually exclusive with the icon and image.
+        label: The text displayed next to the chevron. Mutually exclusive with the icon and image.
     Returns:
         A `h2o_wave.types.Menu` instance.
     """
@@ -2520,7 +2520,7 @@ def menu(
         icon,
         image,
         name,
-        title,
+        label,
     ))
 
 

--- a/py/h2o_wave/ui.py
+++ b/py/h2o_wave/ui.py
@@ -2502,16 +2502,16 @@ def menu(
         icon: Optional[str] = None,
         image: Optional[str] = None,
         name: Optional[str] = None,
-        label: Optional[str] = None,
+        title: Optional[str] = None,
 ) -> Component:
     """Create a contextual menu component. Useful when you have a lot of links and want to conserve the space.
 
     Args:
         items: Commands to render.
-        icon: The card's icon. Mutually exclusive with the image and label.
-        image: The card’s image, preferably user avatar. Mutually exclusive with the icon and label.
+        icon: The card's icon. Mutually exclusive with the image and title.
+        image: The card’s image, preferably user avatar. Mutually exclusive with the icon and title.
         name: An identifying name for this component.
-        label: The card's label. Mutually exclusive with the icon and image
+        title: The text displayed next to the chevron. Mutually exclusive with the icon and image.
     Returns:
         A `h2o_wave.types.Menu` instance.
     """
@@ -2520,7 +2520,7 @@ def menu(
         icon,
         image,
         name,
-        label,
+        title,
     ))
 
 

--- a/py/h2o_wave/ui.py
+++ b/py/h2o_wave/ui.py
@@ -2502,14 +2502,16 @@ def menu(
         icon: Optional[str] = None,
         image: Optional[str] = None,
         name: Optional[str] = None,
+        label: Optional[str] = None,
 ) -> Component:
     """Create a contextual menu component. Useful when you have a lot of links and want to conserve the space.
 
     Args:
         items: Commands to render.
-        icon: The card's icon. Mutually exclusive with the image.
-        image: The card’s image, preferably user avatar. Mutually exclusive with the icon.
+        icon: The card's icon. Mutually exclusive with the image and label.
+        image: The card’s image, preferably user avatar. Mutually exclusive with the icon and label.
         name: An identifying name for this component.
+        label: The card's label. Mutually exclusive with the icon and image
     Returns:
         A `h2o_wave.types.Menu` instance.
     """
@@ -2518,6 +2520,7 @@ def menu(
         icon,
         image,
         name,
+        label,
     ))
 
 

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -1764,7 +1764,7 @@ ui_link <- function(
 #'
 #' @param items The links contained in this group.
 #' @param label The name of the link group.
-#' @param inline Render links horizontally. Defaults to 'false'.
+#' @param inline Render links horizontally. Defaults to False.
 #' @param width The width of the links, e.g. '100px'.
 #' @return A Links instance.
 #' @export
@@ -2542,7 +2542,7 @@ ui_stat <- function(
 #'   One of 'start', 'end', 'center', 'between', 'around'. See enum h2o_wave.ui.StatsJustify.
 #' @param inset Whether to display the stats with a contrasting background.
 #' @param width The width of the stats, e.g. '100px'.
-#' @param visible True if the component should be visible. Defaults to true.
+#' @param visible True if the component should be visible. Defaults to True.
 #' @return A Stats instance.
 #' @export
 ui_stats <- function(
@@ -2596,7 +2596,7 @@ ui_inline <- function(
 #' @param image Image data, base64-encoded.
 #' @param path The path or URL or data URL of the image, e.g. `/foo.png` or `http://example.com/foo.png` or `data:image/png;base64,???`.
 #' @param width The width of the image, e.g. '100px'.
-#' @param visible True if the component should be visible. Defaults to true.
+#' @param visible True if the component should be visible. Defaults to True.
 #' @return A Image instance.
 #' @export
 ui_image <- function(
@@ -2906,10 +2906,10 @@ ui_copyable_text <- function(
 #' Create a contextual menu component. Useful when you have a lot of links and want to conserve the space.
 #'
 #' @param items Commands to render.
-#' @param icon The card's icon. Mutually exclusive with the image and title.
-#' @param image The card’s image, preferably user avatar. Mutually exclusive with the icon and title.
+#' @param icon The card's icon. Mutually exclusive with the image and label.
+#' @param image The card’s image, preferably user avatar. Mutually exclusive with the icon and label.
 #' @param name An identifying name for this component.
-#' @param title The text displayed next to the chevron. Mutually exclusive with the icon and image.
+#' @param label The text displayed next to the chevron. Mutually exclusive with the icon and image.
 #' @return A Menu instance.
 #' @export
 ui_menu <- function(
@@ -2917,18 +2917,18 @@ ui_menu <- function(
   icon = NULL,
   image = NULL,
   name = NULL,
-  title = NULL) {
+  label = NULL) {
   .guard_vector("items", "WaveCommand", items)
   .guard_scalar("icon", "character", icon)
   .guard_scalar("image", "character", image)
   .guard_scalar("name", "character", name)
-  .guard_scalar("title", "character", title)
+  .guard_scalar("label", "character", label)
   .o <- list(menu=list(
     items=items,
     icon=icon,
     image=image,
     name=name,
-    title=title))
+    label=label))
   class(.o) <- append(class(.o), c(.wave_obj, "WaveComponent"))
   return(.o)
 }

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -2906,25 +2906,29 @@ ui_copyable_text <- function(
 #' Create a contextual menu component. Useful when you have a lot of links and want to conserve the space.
 #'
 #' @param items Commands to render.
-#' @param icon The card's icon. Mutually exclusive with the image.
-#' @param image The card’s image, preferably user avatar. Mutually exclusive with the icon.
+#' @param icon The card's icon. Mutually exclusive with the image and title.
+#' @param image The card’s image, preferably user avatar. Mutually exclusive with the icon and title.
 #' @param name An identifying name for this component.
+#' @param title The text displayed next to the chevron. Mutually exclusive with the icon and image.
 #' @return A Menu instance.
 #' @export
 ui_menu <- function(
   items,
   icon = NULL,
   image = NULL,
-  name = NULL) {
+  name = NULL,
+  title = NULL) {
   .guard_vector("items", "WaveCommand", items)
   .guard_scalar("icon", "character", icon)
   .guard_scalar("image", "character", image)
   .guard_scalar("name", "character", name)
+  .guard_scalar("title", "character", title)
   .o <- list(menu=list(
     items=items,
     icon=icon,
     image=image,
-    name=name))
+    name=name,
+    title=title))
   class(.o) <- append(class(.o), c(.wave_obj, "WaveComponent"))
   return(.o)
 }

--- a/tools/intellij-plugin/src/main/resources/templates/wave-components.xml
+++ b/tools/intellij-plugin/src/main/resources/templates/wave-components.xml
@@ -1391,7 +1391,7 @@
     <variable name="image" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="path" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="width" expression="" defaultValue="" alwaysStopAt="true"/>
-    <variable name="visible" expression="" defaultValue="&quot;true&quot;" alwaysStopAt="true"/>
+    <variable name="visible" expression="" defaultValue="&quot;True&quot;" alwaysStopAt="true"/>
     <context>
       <option name="Python" value="true"/>
     </context>
@@ -1495,7 +1495,7 @@
   </template>
   <template name="w_full_links" value="ui.links(label='$label$',inline=$inline$,width='$width$',items=[&#10;	$items$	&#10;]),$END$" description="Create Wave Links with full attributes." toReformat="true" toShortenFQNames="true">
     <variable name="label" expression="" defaultValue="" alwaysStopAt="true"/>
-    <variable name="inline" expression="" defaultValue="&quot;false&quot;" alwaysStopAt="true"/>
+    <variable name="inline" expression="" defaultValue="&quot;False&quot;" alwaysStopAt="true"/>
     <variable name="width" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="items" expression="" defaultValue="" alwaysStopAt="true"/>
     <context>
@@ -1560,11 +1560,11 @@
       <option name="Python" value="true"/>
     </context>
   </template>
-  <template name="w_full_menu" value="ui.menu(icon='$icon$',image='$image$',name='$name$',title='$title$',items=[&#10;	$items$	&#10;]),$END$" description="Create Wave Menu with full attributes." toReformat="true" toShortenFQNames="true">
+  <template name="w_full_menu" value="ui.menu(icon='$icon$',image='$image$',name='$name$',label='$label$',items=[&#10;	$items$	&#10;]),$END$" description="Create Wave Menu with full attributes." toReformat="true" toShortenFQNames="true">
     <variable name="icon" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="image" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="name" expression="" defaultValue="" alwaysStopAt="true"/>
-    <variable name="title" expression="" defaultValue="" alwaysStopAt="true"/>
+    <variable name="label" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="items" expression="" defaultValue="" alwaysStopAt="true"/>
     <context>
       <option name="Python" value="true"/>
@@ -2136,7 +2136,7 @@
     <variable name="justify" expression="" defaultValue="&quot;start&quot;" alwaysStopAt="true"/>
     <variable name="inset" expression="" defaultValue="&quot;False&quot;" alwaysStopAt="true"/>
     <variable name="width" expression="" defaultValue="" alwaysStopAt="true"/>
-    <variable name="visible" expression="" defaultValue="&quot;true&quot;" alwaysStopAt="true"/>
+    <variable name="visible" expression="" defaultValue="&quot;True&quot;" alwaysStopAt="true"/>
     <variable name="items" expression="" defaultValue="" alwaysStopAt="true"/>
     <context>
       <option name="Python" value="true"/>

--- a/tools/intellij-plugin/src/main/resources/templates/wave-components.xml
+++ b/tools/intellij-plugin/src/main/resources/templates/wave-components.xml
@@ -1560,10 +1560,11 @@
       <option name="Python" value="true"/>
     </context>
   </template>
-  <template name="w_full_menu" value="ui.menu(icon='$icon$',image='$image$',name='$name$',items=[&#10;	$items$	&#10;]),$END$" description="Create Wave Menu with full attributes." toReformat="true" toShortenFQNames="true">
+  <template name="w_full_menu" value="ui.menu(icon='$icon$',image='$image$',name='$name$',title='$title$',items=[&#10;	$items$	&#10;]),$END$" description="Create Wave Menu with full attributes." toReformat="true" toShortenFQNames="true">
     <variable name="icon" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="image" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="name" expression="" defaultValue="" alwaysStopAt="true"/>
+    <variable name="title" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="items" expression="" defaultValue="" alwaysStopAt="true"/>
     <context>
       <option name="Python" value="true"/>

--- a/tools/vscode-extension/component-snippets.json
+++ b/tools/vscode-extension/component-snippets.json
@@ -1276,7 +1276,7 @@
   "Wave Full Menu": {
     "prefix": "w_full_menu",
     "body": [
-      "ui.menu(icon='$1', image='$2', name='$3', items=[\n\t\t$4\t\t\n]),$0"
+      "ui.menu(icon='$1', image='$2', name='$3', title='$4', items=[\n\t\t$5\t\t\n]),$0"
     ],
     "description": "Create a full Wave Menu."
   },

--- a/tools/vscode-extension/component-snippets.json
+++ b/tools/vscode-extension/component-snippets.json
@@ -1157,7 +1157,7 @@
   "Wave Full Image": {
     "prefix": "w_full_image",
     "body": [
-      "ui.image(title='$1', type='$2', image='$3', path='$4', width='$5', visible=${6:true}),$0"
+      "ui.image(title='$1', type='$2', image='$3', path='$4', width='$5', visible=${6:True}),$0"
     ],
     "description": "Create a full Wave Image."
   },
@@ -1227,7 +1227,7 @@
   "Wave Full Links": {
     "prefix": "w_full_links",
     "body": [
-      "ui.links(label='$1', inline=${2:false}, width='$3', items=[\n\t\t$4\t\t\n]),$0"
+      "ui.links(label='$1', inline=${2:False}, width='$3', items=[\n\t\t$4\t\t\n]),$0"
     ],
     "description": "Create a full Wave Links."
   },
@@ -1276,7 +1276,7 @@
   "Wave Full Menu": {
     "prefix": "w_full_menu",
     "body": [
-      "ui.menu(icon='$1', image='$2', name='$3', title='$4', items=[\n\t\t$5\t\t\n]),$0"
+      "ui.menu(icon='$1', image='$2', name='$3', label='$4', items=[\n\t\t$5\t\t\n]),$0"
     ],
     "description": "Create a full Wave Menu."
   },
@@ -1570,7 +1570,7 @@
   "Wave Full Stats": {
     "prefix": "w_full_stats",
     "body": [
-      "ui.stats(justify='${1:start}', inset=${2:False}, width='$3', visible=${4:true}, items=[\n\t\t$5\t\t\n]),$0"
+      "ui.stats(justify='${1:start}', inset=${2:False}, width='$3', visible=${4:True}, items=[\n\t\t$5\t\t\n]),$0"
     ],
     "description": "Create a full Wave Stats."
   },

--- a/ui/src/menu.tsx
+++ b/ui/src/menu.tsx
@@ -31,19 +31,19 @@ const css = stylesheet({
 export interface Menu {
   /** Commands to render. */
   items: Command[]
-  /** The card's icon. Mutually exclusive with the image and title. */
+  /** The card's icon. Mutually exclusive with the image and label. */
   icon?: S
-  /** The card’s image, preferably user avatar. Mutually exclusive with the icon and title. */
+  /** The card’s image, preferably user avatar. Mutually exclusive with the icon and label. */
   image?: S
   /** An identifying name for this component. */
   name?: Id
   /** The text displayed next to the chevron. Mutually exclusive with the icon and image. */
-  title?: S
+  label?: S
 }
 
 export const XMenu = ({ model }: { model: Menu }) => {
   const
-    { name, items, icon, image, title } = model,
+    { name, items, icon, image, label } = model,
     ref = React.useRef<HTMLDivElement>(null),
     [isMenuHidden, setIsMenuHidden] = React.useState(true),
     toggleMenu = () => setIsMenuHidden(isHidden => !isHidden)
@@ -53,7 +53,7 @@ export const XMenu = ({ model }: { model: Menu }) => {
     <div data-test={name} className={clas(css.card, 'w-menu')} ref={ref} onClick={toggleMenu}>
       {image && <Fluent.Persona imageUrl={image} size={Fluent.PersonaSize.size48} styles={{ details: { padding: 0 } }} />}
       {icon && <Fluent.FontIcon className={css.icon} iconName={icon} />}
-      {title && <Fluent.Text variant='mediumPlus' styles={{ root: { color: cssVar('$text') } }}>{title}</Fluent.Text>}
+      {label && <Fluent.Text variant='mediumPlus' styles={{ root: { color: cssVar('$text') } }}>{label}</Fluent.Text>}
       <Fluent.ContextualMenu
         items={toCommands(items)}
         target={ref}

--- a/ui/src/menu.tsx
+++ b/ui/src/menu.tsx
@@ -31,17 +31,19 @@ const css = stylesheet({
 export interface Menu {
   /** Commands to render. */
   items: Command[]
-  /** The card's icon. Mutually exclusive with the image. */
+  /** The card's icon. Mutually exclusive with the image and label. */
   icon?: S
-  /** The card’s image, preferably user avatar. Mutually exclusive with the icon. */
+  /** The card’s image, preferably user avatar. Mutually exclusive with the icon and label. */
   image?: S
   /** An identifying name for this component. */
   name?: Id
+  /** The card's label. Mutually exclusive with the icon and image */
+  label?: S
 }
 
 export const XMenu = ({ model }: { model: Menu }) => {
   const
-    { name, items, icon, image } = model,
+    { name, items, icon, image, label } = model,
     ref = React.useRef<HTMLDivElement>(null),
     [isMenuHidden, setIsMenuHidden] = React.useState(true),
     toggleMenu = () => setIsMenuHidden(isHidden => !isHidden)
@@ -51,6 +53,7 @@ export const XMenu = ({ model }: { model: Menu }) => {
     <div data-test={name} className={clas(css.card, 'w-menu')} ref={ref} onClick={toggleMenu}>
       {image && <Fluent.Persona imageUrl={image} size={Fluent.PersonaSize.size48} styles={{ details: { padding: 0 } }} />}
       {icon && <Fluent.FontIcon className={css.icon} iconName={icon} />}
+      {label}
       <Fluent.ContextualMenu
         items={toCommands(items)}
         target={ref}

--- a/ui/src/menu.tsx
+++ b/ui/src/menu.tsx
@@ -31,19 +31,19 @@ const css = stylesheet({
 export interface Menu {
   /** Commands to render. */
   items: Command[]
-  /** The card's icon. Mutually exclusive with the image and label. */
+  /** The card's icon. Mutually exclusive with the image and title. */
   icon?: S
-  /** The card’s image, preferably user avatar. Mutually exclusive with the icon and label. */
+  /** The card’s image, preferably user avatar. Mutually exclusive with the icon and title. */
   image?: S
   /** An identifying name for this component. */
   name?: Id
-  /** The card's label. Mutually exclusive with the icon and image */
-  label?: S
+  /** The text displayed next to the chevron. Mutually exclusive with the icon and image. */
+  title?: S
 }
 
 export const XMenu = ({ model }: { model: Menu }) => {
   const
-    { name, items, icon, image, label } = model,
+    { name, items, icon, image, title } = model,
     ref = React.useRef<HTMLDivElement>(null),
     [isMenuHidden, setIsMenuHidden] = React.useState(true),
     toggleMenu = () => setIsMenuHidden(isHidden => !isHidden)
@@ -53,7 +53,7 @@ export const XMenu = ({ model }: { model: Menu }) => {
     <div data-test={name} className={clas(css.card, 'w-menu')} ref={ref} onClick={toggleMenu}>
       {image && <Fluent.Persona imageUrl={image} size={Fluent.PersonaSize.size48} styles={{ details: { padding: 0 } }} />}
       {icon && <Fluent.FontIcon className={css.icon} iconName={icon} />}
-      {label}
+      {title && <Fluent.Text variant='mediumPlus' styles={{ root: { color: cssVar('$text') } }}>{title}</Fluent.Text>}
       <Fluent.ContextualMenu
         items={toCommands(items)}
         target={ref}

--- a/website/widgets/form/menu.md
+++ b/website/widgets/form/menu.md
@@ -27,7 +27,7 @@ q.page['form'] = ui.form_card(
 
 ## With image
 
-Use the `image` attribute when you want to inline an image (preferably a user avatar) with the context menu. This attribute is mutually exclusive with the `icon` attribute.
+Use the `image` attribute when you want to inline an image (preferably a user avatar) with the context menu. This attribute is mutually exclusive with the `icon` and `title` attributes.
 
 ```py
 q.page['form'] = ui.form_card(
@@ -46,7 +46,7 @@ q.page['form'] = ui.form_card(
 
 ## With icon
 
-Use the `icon` attribute when you want to inline an icon. This attribute is mutually exclusive with the `image` attribute.
+Use the `icon` attribute when you want to inline an icon. This attribute is mutually exclusive with the `image` and `title` attributes.
 
 ```py
 q.page['form'] = ui.form_card(
@@ -54,6 +54,25 @@ q.page['form'] = ui.form_card(
     items=[
         ui.menu(
             icon='Heart',
+            items=[
+                ui.command(name='profile', label='Profile', icon='Contact'),
+                ui.command(name='preferences', label='Preferences', icon='Settings'),
+                ui.command(name='logout', label='Logout', icon='SignOut'),
+            ])
+    ]
+)
+```
+
+## With title
+
+Use the `title` attribute when you want to inline a menu title. This attribute is mutually exclusive with the `icon` and `image` attributes.
+
+```py
+q.page['form'] = ui.form_card(
+    box='1 1 2 2',
+    items=[
+        ui.menu(
+            title='App',
             items=[
                 ui.command(name='profile', label='Profile', icon='Contact'),
                 ui.command(name='preferences', label='Preferences', icon='Settings'),

--- a/website/widgets/form/menu.md
+++ b/website/widgets/form/menu.md
@@ -27,7 +27,7 @@ q.page['form'] = ui.form_card(
 
 ## With image
 
-Use the `image` attribute when you want to inline an image (preferably a user avatar) with the context menu. This attribute is mutually exclusive with the `icon` and `title` attributes.
+Use the `image` attribute when you want to inline an image (preferably a user avatar) with the context menu. This attribute is mutually exclusive with the `icon` and `label` attributes.
 
 ```py
 q.page['form'] = ui.form_card(
@@ -46,7 +46,7 @@ q.page['form'] = ui.form_card(
 
 ## With icon
 
-Use the `icon` attribute when you want to inline an icon. This attribute is mutually exclusive with the `image` and `title` attributes.
+Use the `icon` attribute when you want to inline an icon. This attribute is mutually exclusive with the `image` and `label` attributes.
 
 ```py
 q.page['form'] = ui.form_card(
@@ -63,16 +63,16 @@ q.page['form'] = ui.form_card(
 )
 ```
 
-## With title
+## With label
 
-Use the `title` attribute when you want to inline a menu title. This attribute is mutually exclusive with the `icon` and `image` attributes.
+Use the `label` attribute when you want to inline a menu label. This attribute is mutually exclusive with the `icon` and `image` attributes.
 
 ```py
 q.page['form'] = ui.form_card(
     box='1 1 2 2',
     items=[
         ui.menu(
-            title='App',
+            label='App',
             items=[
                 ui.command(name='profile', label='Profile', icon='Contact'),
                 ui.command(name='preferences', label='Preferences', icon='Settings'),


### PR DESCRIPTION
## Github Issue

https://github.com/h2oai/wave/issues/1577

## Description

Added a 'label' parameter to the UI component of wave. This label will be displayed beside the arrow for the menu dropdown. It will also be clickable, i.e. the dropdown will open on clicking the arrow as well as the label.

## Successful local test - 

<img width="514" alt="Screen Shot 2022-10-07 at 5 36 00 PM" src="https://user-images.githubusercontent.com/24620969/194678652-6dec2b16-8bf5-45a0-a148-dbbce5ee346e.png">

