### PR TITLE
fix: Allow formatting for more than just 1st ui.mark. #617

### DIFF
--- a/ui/src/plot.tsx
+++ b/ui/src/plot.tsx
@@ -877,18 +877,16 @@ const
     for (const m of marks) {
       if (m.x_field) {
         const [x_scale, x_axis] = makeScale(m.x_scale, m.x_format, m.x_title, m.x_min, m.x_max, m.x_nice)
-        scales[m.x_field] = x_scale
+        scales[m.x_field] = scales[m.x_field] ? { ...scales[m.x_field], ...x_scale } : x_scale
         if (x_axis) axes[m.x_field] = x_axis
-        break
       }
     }
 
     for (const m of marks) {
       if (m.y_field) {
         const [y_scale, y_axis] = makeScale(m.y_scale, m.y_format, m.y_title, m.y_min, m.y_max, m.y_nice)
-        scales[m.y_field] = y_scale
+        scales[m.y_field] = scales[m.y_field] ? { ...scales[m.y_field], ...y_scale } : y_scale
         if (y_axis) axes[m.y_field] = y_axis
-        break
       }
     }
 


### PR DESCRIPTION
Closes #617

@lo5 can you please have a quick look? Seems like the break statements I removed were there on purpose, but I couldn't figure out what it could be. I ran the changes through our visual regression testing and it doesn't break any of our plot examples so should be safe.