### PR TITLE
fix: Reduce space between searchbar and table

### DIFF
--- a/ui/src/table.tsx
+++ b/ui/src/table.tsx
@@ -860,7 +860,7 @@ export const
         if (items.length > 10) return 500
 
         const
-          topToolbarHeight = searchableKeys.length || groupable ? 80 : 0,
+          topToolbarHeight = searchableKeys.length || groupable ? (groupable ? 80 : 46) : 0,
           headerHeight = 50,
           rowHeight = m.columns.some(c => c.cell_type?.progress) ? 76 : 48,
           footerHeight = m.downloadable || m.resettable || searchableKeys.length || m.columns.some(c => c.filterable) ? 46 : 0,
@@ -952,7 +952,7 @@ export const
           componentRef={contentRef}
           scrollbarVisibility={Fluent.ScrollbarVisibility.auto}
           styles={{
-            root: { top: groupable || searchableKeys.length ? 80 : 0, bottom: shouldShowFooter ? 46 : 0 },
+            root: { top: groupable || searchableKeys.length ? (groupable ? 80 : 46) : 0, bottom: shouldShowFooter ? 46 : 0 },
             stickyAbove: { right: important('12px'), border: border(2, 'transparent'), zIndex: 2 },
             contentContainer: { border: border(2, cssVar('$neutralLight')), borderRadius: '4px 4px 0 0' }
           }}>

--- a/ui/src/table.tsx
+++ b/ui/src/table.tsx
@@ -860,7 +860,7 @@ export const
         if (items.length > 10) return 500
 
         const
-          topToolbarHeight = searchableKeys.length || groupable ? (groupable ? 80 : 46) : 0,
+          topToolbarHeight = searchableKeys.length || groupable ? (groupable ? 74 : 48) : 0,
           headerHeight = 50,
           rowHeight = m.columns.some(c => c.cell_type?.progress) ? 76 : 48,
           footerHeight = m.downloadable || m.resettable || searchableKeys.length || m.columns.some(c => c.filterable) ? 46 : 0,
@@ -952,7 +952,7 @@ export const
           componentRef={contentRef}
           scrollbarVisibility={Fluent.ScrollbarVisibility.auto}
           styles={{
-            root: { top: groupable || searchableKeys.length ? (groupable ? 80 : 46) : 0, bottom: shouldShowFooter ? 46 : 0 },
+            root: { top: groupable || searchableKeys.length ? (groupable ? 74 : 48) : 0, bottom: shouldShowFooter ? 46 : 0 },
             stickyAbove: { right: important('12px'), border: border(2, 'transparent'), zIndex: 2 },
             contentContainer: { border: border(2, cssVar('$neutralLight')), borderRadius: '4px 4px 0 0' }
           }}>


### PR DESCRIPTION
# Github Issue
Fixes #1492 

## Before 
![image](https://user-images.githubusercontent.com/3798410/198840828-00d48e00-9280-4188-b702-6a92a56d7d78.png)

## After
![image](https://user-images.githubusercontent.com/3798410/198840701-e32cddd9-5bc6-40af-ab7c-b66d293f6c63.png)

#### With pixel spacing dimension

![image](https://user-images.githubusercontent.com/3798410/198894855-26fc1932-2f4b-4492-8fe9-bac4bad1b6dc.png)

![image](https://user-images.githubusercontent.com/3798410/198894899-372a134c-b10b-4b63-9a3d-b981ef17dd46.png)

#### Side by side (groupby and search)

![image](https://user-images.githubusercontent.com/3798410/198897800-57df99f8-6519-4f94-9048-37aef3ece9b3.png)
![image](https://user-images.githubusercontent.com/3798410/198897806-e324fe14-63e0-486f-b5fa-558f8b52418d.png)


