### PR TITLE
fix: Don't access id_token if oauth2 workflow previously failed

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -427,7 +427,11 @@ func (h *LogoutHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if ok {
 		// Reload all of this user's browser tabs
 		h.broker.resetClients(session)
-		idToken, _ = session.token.Extra("id_token").(string) // raw id_token (required by Okta)
+
+		// A token may not be present if the oauth2 workflow failed, so check before access.
+		if session.token != nil {
+			idToken, _ = session.token.Extra("id_token").(string) // raw id_token (required by Okta)
+		}
 	}
 
 	h.redirect(w, r, idToken)


### PR DESCRIPTION
Ref: https://discord.com/channels/1022255416454946906/1039540632609378374/1039540632609378374


```
2022/11/08 13:42:12 # {"client":"<redacted>","err":"oauth2: cannot fetch token: 400 Bad Request\nResponse: {\"error\":\"invalid_grant\",\"error_description\":\"Token is not active\"}","t":"refresh_oauth2_token"}
2022/11/08 13:42:12 # {"error":"invalid session","session_id":"70a2ef33-8eca-430c-a7ec-382783418f09","t":"oauth2_session"}
2022/11/08 13:42:12 # {"client":"<redacted>","err":"oauth2: cannot fetch token: 400 Bad Request\nResponse: {\"error\":\"invalid_grant\",\"error_description\":\"Token is not active\"}","t":"refresh_oauth2_token"}
2022/11/08 13:42:12 http: panic serving <redacted>: runtime error: invalid memory address or nil pointer dereference
goroutine 6004 [running]:
net/http.(*conn).serve.func1(0xc00014f4a0)
        /opt/hostedtoolcache/go/1.16.15/x64/src/net/http/server.go:1805 +0x153
panic(0x7ead40, 0xaeb130)
        /opt/hostedtoolcache/go/1.16.15/x64/src/runtime/panic.go:971 +0x499
golang.org/x/oauth2.(*Token).Extra(0x0, 0x855f86, 0x8, 0xc00014f540, 0x1)
        /home/runner/go/pkg/mod/golang.org/x/oauth2@v0.0.0-20200902213428-5d25da1a8d43/token.go:97 +0x26
github.com/h2oai/wave.(*LogoutHandler).ServeHTTP(0xc0002ce3b0, 0x8dbed0, 0xc000234540, 0xc0000d3200)
        /home/runner/work/wave/wave/auth.go:430 +0x2a5
net/http.(*ServeMux).ServeHTTP(0xaf8e00, 0x8dbed0, 0xc000234540, 0xc0000d3200)
        /opt/hostedtoolcache/go/1.16.15/x64/src/net/http/server.go:2429 +0x1ad
net/http.serverHandler.ServeHTTP(0xc000234e00, 0x8dbed0, 0xc000234540, 0xc0000d3200)
        /opt/hostedtoolcache/go/1.16.15/x64/src/net/http/server.go:2868 +0xa3
net/http.(*conn).serve(0xc00014f4a0, 0x8dc740, 0xc00006af40)
        /opt/hostedtoolcache/go/1.16.15/x64/src/net/http/server.go:1933 +0x8cd
created by net/http.(*Server).Serve
        /opt/hostedtoolcache/go/1.16.15/x64/src/net/http/server.go:2994 +0x39b
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x77ce50]

goroutine 6023 [running]:
github.com/h2oai/wave.(*App).send(0xc000181f80, 0x0, 0x0, 0xc00014f540, 0xaae820, 0x20, 0x20, 0x0, 0x0)
        /home/runner/work/wave/wave/app.go:87 +0x510
github.com/h2oai/wave.(*App).forward(0xc000181f80, 0x0, 0x0, 0xc00014f540, 0xaae820, 0x20, 0x20)
        /home/runner/work/wave/wave/app.go:66 +0x85
github.com/h2oai/wave.(*Broker).resetClients.func1(0xc00014f540, 0xc000181f80)
        /home/runner/work/wave/wave/broker.go:212 +0x65
created by github.com/h2oai/wave.(*Broker).resetClients
        /home/runner/work/wave/wave/broker.go:211 +0xe5
```