### PR TITLE
feat: allow adjustable height of copyable text

### DIFF
--- a/py/examples/copyable_text.py
+++ b/py/examples/copyable_text.py
@@ -13,6 +13,7 @@ page = site['/demo']
 page['hello'] = ui.form_card(box='1 1 3 3', items=[
     ui.copyable_text(label='Copyable text', value='Hello world!'),
     ui.copyable_text(label='Copyable text', value=multiline_content, multiline=True),
+    ui.copyable_text(label='Copyable text', value=multiline_content, multiline=True, height='200px'),
 ])
 
 page.save()

--- a/ui/src/copyable_text.tsx
+++ b/ui/src/copyable_text.tsx
@@ -51,11 +51,13 @@ export interface CopyableText {
   name?: S
   /** True if the component should allow multi-line text entry. */
   multiline?: B
+  /** The adjustable height of the textbox. */
+  height?: S
 }
 
 export const XCopyableText = ({ model }: { model: CopyableText }) => {
   const
-    { name, multiline, label, value } = model,
+    { name, multiline, label, value, height } = model,
     ref = React.useRef<Fluent.ITextField>(null),
     timeoutRef = React.useRef<U>(),
     [copied, setCopied] = React.useState(false),
@@ -80,7 +82,14 @@ export const XCopyableText = ({ model }: { model: CopyableText }) => {
 
   return (
     <div data-test={name} className={multiline ? css.multiContainer : css.compactContainer}>
-      <Fluent.TextField componentRef={ref} value={value} label={label} multiline={multiline} styles={{ root: { width: pc(100) } }} readOnly />
+      <Fluent.TextField 
+        componentRef={ref}
+        value={value}
+        label={label}
+        multiline={multiline}
+        styles={ multiline ? { root: { width: pc(100), height: height} } : { root: { width: pc(100) } } }
+        readOnly
+      />
       <Fluent.PrimaryButton
         title='Copy to clipboard'
         onClick={onClick}

--- a/website/widgets/form/copyable_text.md
+++ b/website/widgets/form/copyable_text.md
@@ -32,3 +32,19 @@ q.page['form'] = ui.form_card(
     items=[ui.copyable_text(label='Copyable text', value=multiline_content, multiline=True)]
 )
 ```
+
+## Height of copyable text
+
+If you want to adjust the height of the copyable textbox, set the `height` attribute to your desired height.
+Note: The set height will only take effect if `multiline` is set to `True`.
+
+```py
+multiline_content = '''Wave is truly awesome.
+You should try all the features!
+Like setting the height to 200px!'''
+
+q.page['form'] = ui.form_card(
+    box='1 1 2 2',
+    items=[ui.copyable_text(label='Copyable text', value=multiline_content, multiline=True, height='200px')]
+)
+```


### PR DESCRIPTION
This change adds a height attribute to ui.copyable text so that copyable textbox height can stay consistent with textbox height, as specified in issue #1302.

See example use case:
- text box of certain height
- user enters text and hits Submit
- if the query was successfully, user gets back a "copyable text box" of same height (i.e. ui.copyable_text() of same height)

Also includes updated docs and example.

