### PR TITLE
fix: Make disabled ui.button icon and text colours consistent #1664

### DIFF
--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -63,7 +63,19 @@ const
       flexDirection: 'column',
       alignItems: 'center',
     },
-  })
+  }),
+  buttonStyles = { styles: { iconDisabled: { color: 'unset' } } },
+  // The global overrides for component styles.
+  componentCustomStyles = {
+    DefaultButton: buttonStyles,
+    PrimaryButton: buttonStyles,
+    IconButton: buttonStyles,
+    ActionButton: buttonStyles,
+    CommandButton: buttonStyles,
+    CommandBarButton: buttonStyles,
+    CompoundButton: buttonStyles,
+    SpinButton: buttonStyles,
+  }
 
 const
   BusyOverlay = bond(() => {
@@ -116,7 +128,7 @@ const
                 const page = e.page
                 const lightbox = lightboxB()
                 return (
-                  <Fluent.ThemeProvider>
+                  <Fluent.ThemeProvider theme={{ components: componentCustomStyles }}>
                     <div className={css.app}>
                       <PageLayout key={page.key} page={page} />
                       <BusyOverlay />

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -66,15 +66,17 @@ const
   }),
   buttonStyles = { styles: { iconDisabled: { color: 'unset' } } },
   // The global overrides for component styles.
-  componentCustomStyles = {
-    DefaultButton: buttonStyles,
-    PrimaryButton: buttonStyles,
-    IconButton: buttonStyles,
-    ActionButton: buttonStyles,
-    CommandButton: buttonStyles,
-    CommandBarButton: buttonStyles,
-    CompoundButton: buttonStyles,
-    SpinButton: buttonStyles,
+  customStyles = {
+    components: {
+      DefaultButton: buttonStyles,
+      PrimaryButton: buttonStyles,
+      IconButton: buttonStyles,
+      ActionButton: buttonStyles,
+      CommandButton: buttonStyles,
+      CommandBarButton: buttonStyles,
+      CompoundButton: buttonStyles,
+      SpinButton: buttonStyles
+    }
   }
 
 const
@@ -128,7 +130,7 @@ const
                 const page = e.page
                 const lightbox = lightboxB()
                 return (
-                  <Fluent.ThemeProvider theme={{ components: componentCustomStyles }}>
+                  <Fluent.ThemeProvider theme={customStyles}>
                     <div className={css.app}>
                       <PageLayout key={page.key} page={page} />
                       <BusyOverlay />

--- a/ui/src/button.tsx
+++ b/ui/src/button.tsx
@@ -135,7 +135,7 @@ const
         icon: {
           fontSize: 20,
           display: 'flex',
-          alignItems: 'center',
+          alignItems: 'center'
         }
       }
 

--- a/ui/src/button.tsx
+++ b/ui/src/button.tsx
@@ -135,7 +135,10 @@ const
         icon: {
           fontSize: 20,
           display: 'flex',
-          alignItems: 'center'
+          alignItems: 'center',
+        },
+        iconDisabled: {
+          color: 'unset'
         }
       }
 

--- a/ui/src/button.tsx
+++ b/ui/src/button.tsx
@@ -136,9 +136,6 @@ const
           fontSize: 20,
           display: 'flex',
           alignItems: 'center',
-        },
-        iconDisabled: {
-          color: 'unset'
         }
       }
 


### PR DESCRIPTION
This PR provides an override of icon colour for all disabled FluentUI buttons.


https://user-images.githubusercontent.com/23740173/203029158-a6c771f6-5731-4253-9a94-8a953f300aad.mov


Closes #1664 