### PR TITLE
docs: Fix the footnote links not working

### DIFF
--- a/website/docs/architecture.md
+++ b/website/docs/architecture.md
@@ -98,6 +98,4 @@ The Wave server retains content. This is an important concept to understand, and
 
 Different parts of the same page can be updated by different scripts running on different devices. Also, all content is live (or reactive) all the time: browsers always display up-to-date content without the need to reload.
 
----
-
-[^1] Linux, Windows, Darwin, BSD, Solaris, Android on amd64, arm, 386, ppc, mips; [almost everywhere](https://gist.github.com/asukakenji/f15ba7e588ac42795f421b48b8aede63).
+[^1]: Linux, Windows, Darwin, BSD, Solaris, Android on amd64, arm, 386, ppc, mips; [almost everywhere](https://gist.github.com/asukakenji/f15ba7e588ac42795f421b48b8aede63).

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -101,13 +101,11 @@ H2O Wave is rapid application development for a more... civilized age[^3].
 
 Also, this page was mostly hyperbole, so let's download it and take it for a spin, shall we.
 
----
+[^1]: The model parallels [retained mode](https://en.wikipedia.org/wiki/Retained_mode) graphics, with compositing performed on an remote server.
 
-[^1] The model parallels [retained mode](https://en.wikipedia.org/wiki/Retained_mode) graphics, with compositing performed on an remote server.
+[^2]: Runs anywhere Go executables run, which is [almost everywhere](https://gist.github.com/asukakenji/f15ba7e588ac42795f421b48b8aede63).
 
-[^2] Runs anywhere Go executables run, which is [almost everywhere](https://gist.github.com/asukakenji/f15ba7e588ac42795f421b48b8aede63).
-
-[^3] Hat tip to [xkcd](https://xkcd.com/297/).
+[^3]: Hat tip to [xkcd](https://xkcd.com/297/).
 
 ## Interactive learning
 


### PR DESCRIPTION
The syntax used for footnotes was incorrect, making them render incorrectly (they were rendering as footnote references instead).

Fixes #1720