### PR TITLE
docs: Show how to use local CSS file as stylesheet.

### DIFF
--- a/py/examples/meta_stylesheet.py
+++ b/py/examples/meta_stylesheet.py
@@ -15,7 +15,7 @@ page['example'] = ui.markup_card(
 
 page['meta'] = ui.meta_card(
     box='',
-    # Load external stylesheet.
+    # Load external stylesheet. The `path` can also be the one returned from `q.site.upload` if you want to use your own CSS files.
     stylesheets=[ui.stylesheet(path='https://cdn.jsdelivr.net/npm/bootstrap@5.1.0/dist/css/bootstrap.min.css')]
 )
 

--- a/website/docs/custom-css.md
+++ b/website/docs/custom-css.md
@@ -24,15 +24,24 @@ q.page['meta'] = ui.meta_card(
 )
 ```
 
-It is also possible to host a stylesheet on the Wave server itself.
+### Using local CSS stylesheet
+
+Prior to using your own CSS files, they need to be uploaded to Wave server. There are 2 ways of doing this:
+
+* Uploading the CSS files from your Wave app via [q.site.upload](https://wave.h2o.ai/docs/files/#provide-file-downloads).
+* Serving the CSS files directly from Wave server via [public/private dir](https://wave.h2o.ai/docs/files/#serving-files-directly-from-the-wave-server).
 
 ```py
-example_dir = os.path.dirname(os.path.realpath(__file__))
+from h2o_wave import Q, main, app, ui
+import os
 
-@app('/demo')
+current_dir = os.path.dirname(os.path.realpath(__file__))
+
+@app('/')
 async def serve(q: Q):
-    # Upload the `styles.css` file to the Wave server and save its path into the `stylesheet_path` variable.
-    stylesheet_path, = await q.site.upload([os.path.join(example_dir, 'styles.css')])
+    # Upload the `styles.css` file to the Wave server 
+    # and save its path into the `stylesheet_path` variable.
+    stylesheet_path, = await q.site.upload([os.path.join(current_dir, 'styles.css')])
     # Use the uploaded file path in the `ui.stylesheet`.
     q.page['meta'] = ui.meta_card(
       box='', 

--- a/website/docs/custom-css.md
+++ b/website/docs/custom-css.md
@@ -33,7 +33,6 @@ example_dir = os.path.dirname(os.path.realpath(__file__))
 async def serve(q: Q):
     # Upload the `styles.css` file to the Wave server and save its path into the `stylesheet_path` variable.
     stylesheet_path, = await q.site.upload([os.path.join(example_dir, 'styles.css')])
-    q.page['my_header'] = ui.header_card(box='1 1 -1 1', title='Title', subtitle='Subtitle')
     # Use the uploaded file path in the `ui.stylesheet`.
     q.page['meta'] = ui.meta_card(
       box='', 

--- a/website/docs/custom-css.md
+++ b/website/docs/custom-css.md
@@ -24,6 +24,27 @@ q.page['meta'] = ui.meta_card(
 )
 ```
 
+It is also possible to host a stylesheet on the Wave server itself.
+
+```py
+example_dir = os.path.dirname(os.path.realpath(__file__))
+
+@app('/demo')
+async def serve(q: Q):
+    # Upload the `styles.css` file to the Wave server and save its path into the `stylesheet_path` variable.
+    stylesheet_path, = await q.site.upload([os.path.join(example_dir, 'styles.css')])
+    q.page['my_header'] = ui.header_card(box='1 1 -1 1', title='Title', subtitle='Subtitle')
+    # Use the uploaded file path in the `ui.stylesheet`.
+    q.page['meta'] = ui.meta_card(
+      box='', 
+      stylesheets=[
+        ui.stylesheet(stylesheet_path)
+      ]
+    )
+
+    await q.page.save()
+```
+
 ## Inline stylesheets
 
 On the other hand, if all you want to do is tweak a few things here and there, the simpler solution would be to use the `stylesheet` attribute that accepts a CSS string.

--- a/website/docs/custom-css.md
+++ b/website/docs/custom-css.md
@@ -28,8 +28,8 @@ q.page['meta'] = ui.meta_card(
 
 Prior to using your own CSS files, they need to be uploaded to Wave server. There are 2 ways of doing this:
 
-* Uploading the CSS files from your Wave app via [q.site.upload](https://wave.h2o.ai/docs/files/#provide-file-downloads).
-* Serving the CSS files directly from Wave server via [public/private dir](https://wave.h2o.ai/docs/files/#serving-files-directly-from-the-wave-server).
+* Uploading the CSS files from your Wave app via [q.site.upload](/docs/files/#provide-file-downloads).
+* Serving the CSS files directly from Wave server via [public/private dir](/docs/files/#serving-files-directly-from-the-wave-server).
 
 ```py
 from h2o_wave import Q, main, app, ui


### PR DESCRIPTION
Adds the example of how to apply the css stylesheet stored on the Wave server.

![image](https://user-images.githubusercontent.com/23740173/204485496-25120664-2b88-47f1-a063-a31ff1b82dbe.png)
