### PR TITLE
Fix: Min and max column width not behaving as expected

### DIFF
--- a/ui/src/table.tsx
+++ b/ui/src/table.tsx
@@ -332,9 +332,9 @@ const
           }))
         }
       },
-      [columns, setColumns] = React.useState(m.columns.map((c): WaveColumn => {
+      [columns, setColumns] = React.useState(m.columns.map((c): WaveColumn => {      
         const
-          minWidth = c.min_width
+          initialMinWidth = c.min_width
             ? c.min_width.endsWith('px')
               ? +c.min_width.substring(0, c.min_width.length - 2)
               : +c.min_width
@@ -343,7 +343,10 @@ const
             ? c.max_width.endsWith('px')
               ? +c.max_width.substring(0, c.max_width.length - 2)
               : +c.max_width
-            : undefined
+            : undefined,
+
+          minWidth = (initialMinWidth === 0) ? 0.001 : initialMinWidth
+        
         return {
           key: c.name,
           name: c.label,


### PR DESCRIPTION
Solution for Issue #1622 
Set min_width to "0.001 px" if user enter "0 px" to resolve these unexpected behaviors:

- The size of min_width==0 is bigger than expected
- Tables are identical when using max_width regardless of if min_width is set or not, in that min_width seems to be ignored if max_width is set
 
Using the tables provided by the issuer: 
  
   ```
@app('/')
async def serve(q: Q):

      table_rows = [
                ui.table_row(name='row1', cells=['John', 'Doe', "7042 23rd Ave", "123-456-7890"]),
                ui.table_row(name='row2', cells=['John', 'Doe', "7042 23rd Ave", "123-456-7890"]),
                ui.table_row(name='row3', cells=['John', 'Doe', "7042 23rd Ave", "123-456-7890"]),
            ]
            column_names = ["name", "surname", "address", "phone"]
            columns_to_test = {
                "no_width": [ui.table_column(name=x, label=x) for x in column_names],
                "min_width_0": [ui.table_column(name=x, label=x, min_width="0px") for x in column_names],
                "max_width_100": [ui.table_column(name=x, label=x, max_width="100px") for x in column_names],
                "min_width_0_and_max_width_100": [ui.table_column(name=x, label=x, min_width="0px", max_width="100px") for x in column_names],
            }
        
            q.page["meta"] = ui.meta_card("", layouts=[ui.layout("xs", width="800px", zones=[ui.zone("default")])])
        
            for k in columns_to_test.keys():
                q.page[k] = ui.form_card(box='default', items=[
                    ui.text_xl(k),
                    ui.table(name=k, columns=columns_to_test[k], rows=table_rows, width="700px")
                ])

    await q.page.save()
```

Here is the behavior of the tables BEFORE our change: 
<img width="525" alt="Screen Shot 2022-12-05 at 12 41 13 PM" src="https://user-images.githubusercontent.com/77064318/205706918-aed2d712-cd22-491b-bb5a-69fcee5fcd9e.png">

Here is the behavior of the tables AFTER our change: 
<img width="582" alt="Screen Shot 2022-12-05 at 12 40 48 PM" src="https://user-images.githubusercontent.com/77064318/205706978-27d8cdc1-e0d3-4698-b223-bf5d6243f538.png">

"min_width_0_and_max_width_100" are no longer identical to "max_width_100". With the change, if the min_width is set, user is now able to use their cursor to change the width of the table col. This can be shown here: 
<img width="584" alt="Screen Shot 2022-12-05 at 12 52 35 PM" src="https://user-images.githubusercontent.com/77064318/205707554-135ef910-bb1b-44c7-830f-be9e3e6fc409.png">

