### PR TITLE
Show a warning when at least one OIDC param detected, but not all are set

### DIFF
--- a/cmd/wave/main.go
+++ b/cmd/wave/main.go
@@ -245,22 +245,18 @@ func main() {
 
 	conf.Keychain = kc
 
-	if conf.IDE {
-		conf.Proxy = true // IDE won't function without proxy
-	}
-
 	requiredEnvOIDC := map[string]string{
 		"oidc-client-id":     auth.ClientID,
 		"oidc-client-secret": auth.ClientSecret,
 		"oidc-provider-url":  auth.ProviderURL,
 		"oidc-redirect-url":  auth.RedirectURL,
 	}
-	envOIDCEmpty := getEmptyOIDCValues(auth, requiredEnvOIDC)
-	emptyRequiredOIDCParams := len(envOIDCEmpty)
-	if emptyRequiredOIDCParams == 0 {
+	emptyRequiredOIDCParams := getEmptyOIDCValues(requiredEnvOIDC)
+	emptyRequiredOIDCParamsCount := len(emptyRequiredOIDCParams)
+	if emptyRequiredOIDCParamsCount == 0 {
 		conf.Auth = &auth
 	}
-	if emptyRequiredOIDCParams > 0 && emptyRequiredOIDCParams != len(requiredEnvOIDC) {
+	if emptyRequiredOIDCParamsCount > 0 && emptyRequiredOIDCParamsCount != len(requiredEnvOIDC) {
 		log.Println("#", "warning: the following OIDC required params were not set: ", emptyRequiredOIDCParams)
 	}
 
@@ -271,21 +267,11 @@ func main() {
 	wave.Run(conf)
 }
 
-// getEmptyOIDCValues checks if any of the required OIDC values were not set and returns which were not.
-func getEmptyOIDCValues(auth wave.AuthConf, requiredEnvOIDC map[string]string) []string {
+func getEmptyOIDCValues(requiredEnvOIDC map[string]string) []string {
 	var emptyRequiredOIDCParams []string
-	for key, val := range requiredEnvOIDC {
+	for param, val := range requiredEnvOIDC {
 		if val == "" {
-			switch key {
-			case "oidc-client-id":
-				emptyRequiredOIDCParams = append(emptyRequiredOIDCParams, "oidc-client-id")
-			case "oidc-client-secret":
-				emptyRequiredOIDCParams = append(emptyRequiredOIDCParams, "oidc-client-secret")
-			case "oidc-provider-url":
-				emptyRequiredOIDCParams = append(emptyRequiredOIDCParams, "oidc-provider-url")
-			case "oidc-redirect-url":
-				emptyRequiredOIDCParams = append(emptyRequiredOIDCParams, "oidc-redirect-url")
-			}
+			emptyRequiredOIDCParams = append(emptyRequiredOIDCParams, param)
 		}
 	}
 	return emptyRequiredOIDCParams

--- a/cmd/wave/main.go
+++ b/cmd/wave/main.go
@@ -245,14 +245,6 @@ func main() {
 
 	conf.Keychain = kc
 
-	if auth.ClientID != "" && auth.ClientSecret != "" && auth.ProviderURL != "" && auth.RedirectURL != "" {
-		conf.Auth = &auth
-	}
-
-	if conf.IDE {
-		conf.Proxy = true // IDE won't function without proxy
-	}
-
 	requiredEnvOIDC := map[string]string{
 		"oidc-client-id":     auth.ClientID,
 		"oidc-client-secret": auth.ClientSecret,
@@ -261,9 +253,17 @@ func main() {
 	}
 	envOIDCEmpty := getEmptyOIDCValues(auth, requiredEnvOIDC)
 	emptyRequiredOIDCParams := len(envOIDCEmpty)
+	if emptyRequiredOIDCParams == 0 {
+		conf.Auth = &auth
+	}
 	if emptyRequiredOIDCParams > 0 && emptyRequiredOIDCParams != len(requiredEnvOIDC) {
 		log.Println("#", "warning: the following OIDC required params were not set: ", emptyRequiredOIDCParams)
 	}
+
+	if conf.IDE {
+		conf.Proxy = true // IDE won't function without proxy
+	}
+
 	wave.Run(conf)
 }
 

--- a/cmd/wave/main.go
+++ b/cmd/wave/main.go
@@ -252,7 +252,47 @@ func main() {
 		conf.Proxy = true // IDE won't function without proxy
 	}
 
+	envOIDCEmpty := checkEmptyOIDCValues(auth)
+	warnEmptyOIDCValues(envOIDCEmpty)
+
 	wave.Run(conf)
+}
+
+// checkEmptyOIDCValues checks if any of the required OIDC values were not set and returns which were not.
+func checkEmptyOIDCValues(auth wave.AuthConf) []string {
+	envOIDC := []string{auth.ClientID, auth.ClientSecret, auth.ProviderURL, auth.RedirectURL}
+	var envOIDCEmpty []string
+	for i, val := range envOIDC {
+		if val == "" {
+			switch i {
+			case 0:
+				envOIDCEmpty = append(envOIDCEmpty, "oidc-client-id")
+			case 1:
+				envOIDCEmpty = append(envOIDCEmpty, "oidc-client-secret")
+			case 2:
+				envOIDCEmpty = append(envOIDCEmpty, "oidc-provider-url")
+			case 3:
+				envOIDCEmpty = append(envOIDCEmpty, "oidc-redirect-url")
+			}
+		}
+	}
+	return envOIDCEmpty
+}
+
+// warnEmptyOIDCValues warns the user about the required OIDC environment variables that have not been set.
+func warnEmptyOIDCValues(envOIDCEmpty []string) {
+	fmt.Printf("\n*********************\nWARNING!\nThe following OIDC environment values where not set:\n")
+	length := len(envOIDCEmpty)
+	fmt.Printf("\t[ ")
+	for i, val := range envOIDCEmpty {
+		switch i {
+		case length - 1:
+			fmt.Printf("%s", val)
+		default:
+			fmt.Printf("%s, ", val)
+		}
+	}
+	fmt.Printf("]\n*********************\n\n")
 }
 
 func getEnv(key, value string) string {

--- a/cmd/wave/main.go
+++ b/cmd/wave/main.go
@@ -245,6 +245,10 @@ func main() {
 
 	conf.Keychain = kc
 
+	if conf.IDE {
+		conf.Proxy = true // IDE won't function without proxy
+	}
+
 	requiredEnvOIDC := map[string]string{
 		"oidc-client-id":     auth.ClientID,
 		"oidc-client-secret": auth.ClientSecret,


### PR DESCRIPTION
Closes #1711.

Our code checks whether any of the OIDC required params are not empty in the function _checkEmptyOIDCValues()_. This function counts the amount of empty OIDC params. It returns a slice containing the empty OIDC params detected as well as a boolean which is true when some but not all OIDC params are empty.

After calling the function we just check if this boolean is true to display the required warning. 

Collaborators: 
@Qingyang-Sophia
@aruiz2
