### PR TITLE
feat: Allow users to remove paddings on frame cards

### DIFF
--- a/py/h2o_wave/types.py
+++ b/py/h2o_wave/types.py
@@ -8242,14 +8242,14 @@ class FrameCard:
             title: str,
             path: Optional[str] = None,
             content: Optional[str] = None,
-            has_padding: Optional[bool] = None,
+            compact: Optional[bool] = None,
             commands: Optional[List[Command]] = None,
     ):
         _guard_scalar('FrameCard.box', box, (str,), False, False, False)
         _guard_scalar('FrameCard.title', title, (str,), False, False, False)
         _guard_scalar('FrameCard.path', path, (str,), False, True, False)
         _guard_scalar('FrameCard.content', content, (str,), False, True, False)
-        _guard_scalar('FrameCard.has_padding', has_padding, (bool,), False, True, False)
+        _guard_scalar('FrameCard.compact', compact, (bool,), False, True, False)
         _guard_vector('FrameCard.commands', commands, (Command,), False, True, False)
         self.box = box
         """A string indicating how to place this component on the page."""
@@ -8259,8 +8259,8 @@ class FrameCard:
         """The path or URL of the web page, e.g. `/foo.html` or `http://example.com/foo.html`."""
         self.content = content
         """The HTML content of the page. A string containing `<html>...</html>`."""
-        self.has_padding = has_padding
-        """True if the component should have paddings. Defaults to True."""
+        self.compact = compact
+        """True if title and padding should be removed. Defaults to False."""
         self.commands = commands
         """Contextual menu commands for this component."""
 
@@ -8270,7 +8270,7 @@ class FrameCard:
         _guard_scalar('FrameCard.title', self.title, (str,), False, False, False)
         _guard_scalar('FrameCard.path', self.path, (str,), False, True, False)
         _guard_scalar('FrameCard.content', self.content, (str,), False, True, False)
-        _guard_scalar('FrameCard.has_padding', self.has_padding, (bool,), False, True, False)
+        _guard_scalar('FrameCard.compact', self.compact, (bool,), False, True, False)
         _guard_vector('FrameCard.commands', self.commands, (Command,), False, True, False)
         return _dump(
             view='frame',
@@ -8278,7 +8278,7 @@ class FrameCard:
             title=self.title,
             path=self.path,
             content=self.content,
-            has_padding=self.has_padding,
+            compact=self.compact,
             commands=None if self.commands is None else [__e.dump() for __e in self.commands],
         )
 
@@ -8293,22 +8293,22 @@ class FrameCard:
         _guard_scalar('FrameCard.path', __d_path, (str,), False, True, False)
         __d_content: Any = __d.get('content')
         _guard_scalar('FrameCard.content', __d_content, (str,), False, True, False)
-        __d_has_padding: Any = __d.get('has_padding')
-        _guard_scalar('FrameCard.has_padding', __d_has_padding, (bool,), False, True, False)
+        __d_compact: Any = __d.get('compact')
+        _guard_scalar('FrameCard.compact', __d_compact, (bool,), False, True, False)
         __d_commands: Any = __d.get('commands')
         _guard_vector('FrameCard.commands', __d_commands, (dict,), False, True, False)
         box: str = __d_box
         title: str = __d_title
         path: Optional[str] = __d_path
         content: Optional[str] = __d_content
-        has_padding: Optional[bool] = __d_has_padding
+        compact: Optional[bool] = __d_compact
         commands: Optional[List[Command]] = None if __d_commands is None else [Command.load(__e) for __e in __d_commands]
         return FrameCard(
             box,
             title,
             path,
             content,
-            has_padding,
+            compact,
             commands,
         )
 

--- a/py/h2o_wave/types.py
+++ b/py/h2o_wave/types.py
@@ -8242,12 +8242,14 @@ class FrameCard:
             title: str,
             path: Optional[str] = None,
             content: Optional[str] = None,
+            has_padding: Optional[bool] = None,
             commands: Optional[List[Command]] = None,
     ):
         _guard_scalar('FrameCard.box', box, (str,), False, False, False)
         _guard_scalar('FrameCard.title', title, (str,), False, False, False)
         _guard_scalar('FrameCard.path', path, (str,), False, True, False)
         _guard_scalar('FrameCard.content', content, (str,), False, True, False)
+        _guard_scalar('FrameCard.has_padding', has_padding, (bool,), False, True, False)
         _guard_vector('FrameCard.commands', commands, (Command,), False, True, False)
         self.box = box
         """A string indicating how to place this component on the page."""
@@ -8257,6 +8259,8 @@ class FrameCard:
         """The path or URL of the web page, e.g. `/foo.html` or `http://example.com/foo.html`."""
         self.content = content
         """The HTML content of the page. A string containing `<html>...</html>`."""
+        self.has_padding = has_padding
+        """True if the component should have paddings. Defaults to True."""
         self.commands = commands
         """Contextual menu commands for this component."""
 
@@ -8266,6 +8270,7 @@ class FrameCard:
         _guard_scalar('FrameCard.title', self.title, (str,), False, False, False)
         _guard_scalar('FrameCard.path', self.path, (str,), False, True, False)
         _guard_scalar('FrameCard.content', self.content, (str,), False, True, False)
+        _guard_scalar('FrameCard.has_padding', self.has_padding, (bool,), False, True, False)
         _guard_vector('FrameCard.commands', self.commands, (Command,), False, True, False)
         return _dump(
             view='frame',
@@ -8273,6 +8278,7 @@ class FrameCard:
             title=self.title,
             path=self.path,
             content=self.content,
+            has_padding=self.has_padding,
             commands=None if self.commands is None else [__e.dump() for __e in self.commands],
         )
 
@@ -8287,18 +8293,22 @@ class FrameCard:
         _guard_scalar('FrameCard.path', __d_path, (str,), False, True, False)
         __d_content: Any = __d.get('content')
         _guard_scalar('FrameCard.content', __d_content, (str,), False, True, False)
+        __d_has_padding: Any = __d.get('has_padding')
+        _guard_scalar('FrameCard.has_padding', __d_has_padding, (bool,), False, True, False)
         __d_commands: Any = __d.get('commands')
         _guard_vector('FrameCard.commands', __d_commands, (dict,), False, True, False)
         box: str = __d_box
         title: str = __d_title
         path: Optional[str] = __d_path
         content: Optional[str] = __d_content
+        has_padding: Optional[bool] = __d_has_padding
         commands: Optional[List[Command]] = None if __d_commands is None else [Command.load(__e) for __e in __d_commands]
         return FrameCard(
             box,
             title,
             path,
             content,
+            has_padding,
             commands,
         )
 

--- a/py/h2o_wave/ui.py
+++ b/py/h2o_wave/ui.py
@@ -2889,7 +2889,7 @@ def frame_card(
         title: str,
         path: Optional[str] = None,
         content: Optional[str] = None,
-        has_padding: Optional[bool] = None,
+        compact: Optional[bool] = None,
         commands: Optional[List[Command]] = None,
 ) -> FrameCard:
     """Render a card containing a HTML page inside an inline frame (an `iframe`).
@@ -2901,7 +2901,7 @@ def frame_card(
         title: The title for this card.
         path: The path or URL of the web page, e.g. `/foo.html` or `http://example.com/foo.html`.
         content: The HTML content of the page. A string containing `<html>...</html>`.
-        has_padding: True if the component should have paddings. Defaults to True.
+        compact: True if title and padding should be removed. Defaults to False.
         commands: Contextual menu commands for this component.
     Returns:
         A `h2o_wave.types.FrameCard` instance.
@@ -2911,7 +2911,7 @@ def frame_card(
         title,
         path,
         content,
-        has_padding,
+        compact,
         commands,
     )
 

--- a/py/h2o_wave/ui.py
+++ b/py/h2o_wave/ui.py
@@ -2889,6 +2889,7 @@ def frame_card(
         title: str,
         path: Optional[str] = None,
         content: Optional[str] = None,
+        has_padding: Optional[bool] = None,
         commands: Optional[List[Command]] = None,
 ) -> FrameCard:
     """Render a card containing a HTML page inside an inline frame (an `iframe`).
@@ -2900,6 +2901,7 @@ def frame_card(
         title: The title for this card.
         path: The path or URL of the web page, e.g. `/foo.html` or `http://example.com/foo.html`.
         content: The HTML content of the page. A string containing `<html>...</html>`.
+        has_padding: True if the component should have paddings. Defaults to True.
         commands: Contextual menu commands for this component.
     Returns:
         A `h2o_wave.types.FrameCard` instance.
@@ -2909,6 +2911,7 @@ def frame_card(
         title,
         path,
         content,
+        has_padding,
         commands,
     )
 

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -3350,6 +3350,7 @@ ui_form_card <- function(
 #' @param title The title for this card.
 #' @param path The path or URL of the web page, e.g. `/foo.html` or `http://example.com/foo.html`.
 #' @param content The HTML content of the page. A string containing `<html>...</html>`.
+#' @param has_padding True if the component should have paddings. Defaults to True.
 #' @param commands Contextual menu commands for this component.
 #' @return A FrameCard instance.
 #' @export
@@ -3358,17 +3359,20 @@ ui_frame_card <- function(
   title,
   path = NULL,
   content = NULL,
+  has_padding = NULL,
   commands = NULL) {
   .guard_scalar("box", "character", box)
   .guard_scalar("title", "character", title)
   .guard_scalar("path", "character", path)
   .guard_scalar("content", "character", content)
+  .guard_scalar("has_padding", "logical", has_padding)
   .guard_vector("commands", "WaveCommand", commands)
   .o <- list(
     box=box,
     title=title,
     path=path,
     content=content,
+    has_padding=has_padding,
     commands=commands,
     view='frame')
   class(.o) <- append(class(.o), c(.wave_obj, "WaveFrameCard"))

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -3350,7 +3350,7 @@ ui_form_card <- function(
 #' @param title The title for this card.
 #' @param path The path or URL of the web page, e.g. `/foo.html` or `http://example.com/foo.html`.
 #' @param content The HTML content of the page. A string containing `<html>...</html>`.
-#' @param has_padding True if the component should have paddings. Defaults to True.
+#' @param compact True if title and padding should be removed. Defaults to False.
 #' @param commands Contextual menu commands for this component.
 #' @return A FrameCard instance.
 #' @export
@@ -3359,20 +3359,20 @@ ui_frame_card <- function(
   title,
   path = NULL,
   content = NULL,
-  has_padding = NULL,
+  compact = NULL,
   commands = NULL) {
   .guard_scalar("box", "character", box)
   .guard_scalar("title", "character", title)
   .guard_scalar("path", "character", path)
   .guard_scalar("content", "character", content)
-  .guard_scalar("has_padding", "logical", has_padding)
+  .guard_scalar("compact", "logical", compact)
   .guard_vector("commands", "WaveCommand", commands)
   .o <- list(
     box=box,
     title=title,
     path=path,
     content=content,
-    has_padding=has_padding,
+    compact=compact,
     commands=commands,
     view='frame')
   class(.o) <- append(class(.o), c(.wave_obj, "WaveFrameCard"))

--- a/tools/intellij-plugin/src/main/resources/templates/wave-components.xml
+++ b/tools/intellij-plugin/src/main/resources/templates/wave-components.xml
@@ -1331,12 +1331,12 @@
       <option name="Python" value="true"/>
     </context>
   </template>
-  <template name="w_full_frame_card" value="ui.frame_card(box='$box$',title='$title$',path='$path$',content='$content$',has_padding=$has_padding$,commands=[&#10;	$commands$	&#10;])$END$" description="Create Wave FrameCard with full attributes." toReformat="true" toShortenFQNames="true">
+  <template name="w_full_frame_card" value="ui.frame_card(box='$box$',title='$title$',path='$path$',content='$content$',compact=$compact$,commands=[&#10;	$commands$	&#10;])$END$" description="Create Wave FrameCard with full attributes." toReformat="true" toShortenFQNames="true">
     <variable name="box" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="title" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="path" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="content" expression="" defaultValue="" alwaysStopAt="true"/>
-    <variable name="has_padding" expression="" defaultValue="&quot;True&quot;" alwaysStopAt="true"/>
+    <variable name="compact" expression="" defaultValue="&quot;False&quot;" alwaysStopAt="true"/>
     <variable name="commands" expression="" defaultValue="" alwaysStopAt="true"/>
     <context>
       <option name="Python" value="true"/>

--- a/tools/intellij-plugin/src/main/resources/templates/wave-components.xml
+++ b/tools/intellij-plugin/src/main/resources/templates/wave-components.xml
@@ -1331,11 +1331,12 @@
       <option name="Python" value="true"/>
     </context>
   </template>
-  <template name="w_full_frame_card" value="ui.frame_card(box='$box$',title='$title$',path='$path$',content='$content$',commands=[&#10;	$commands$	&#10;])$END$" description="Create Wave FrameCard with full attributes." toReformat="true" toShortenFQNames="true">
+  <template name="w_full_frame_card" value="ui.frame_card(box='$box$',title='$title$',path='$path$',content='$content$',has_padding=$has_padding$,commands=[&#10;	$commands$	&#10;])$END$" description="Create Wave FrameCard with full attributes." toReformat="true" toShortenFQNames="true">
     <variable name="box" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="title" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="path" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="content" expression="" defaultValue="" alwaysStopAt="true"/>
+    <variable name="has_padding" expression="" defaultValue="&quot;True&quot;" alwaysStopAt="true"/>
     <variable name="commands" expression="" defaultValue="" alwaysStopAt="true"/>
     <context>
       <option name="Python" value="true"/>

--- a/tools/vscode-extension/component-snippets.json
+++ b/tools/vscode-extension/component-snippets.json
@@ -1129,7 +1129,7 @@
   "Wave Full FrameCard": {
     "prefix": "w_full_frame_card",
     "body": [
-      "ui.frame_card(box='$1', title='$2', path='$3', content='$4', commands=[\n\t\t$5\t\t\n])$0"
+      "ui.frame_card(box='$1', title='$2', path='$3', content='$4', has_padding=${5:True}, commands=[\n\t\t$6\t\t\n])$0"
     ],
     "description": "Create a full Wave FrameCard."
   },

--- a/tools/vscode-extension/component-snippets.json
+++ b/tools/vscode-extension/component-snippets.json
@@ -1129,7 +1129,7 @@
   "Wave Full FrameCard": {
     "prefix": "w_full_frame_card",
     "body": [
-      "ui.frame_card(box='$1', title='$2', path='$3', content='$4', has_padding=${5:True}, commands=[\n\t\t$6\t\t\n])$0"
+      "ui.frame_card(box='$1', title='$2', path='$3', content='$4', compact=${5:False}, commands=[\n\t\t$6\t\t\n])$0"
     ],
     "description": "Create a full Wave FrameCard."
   },

--- a/ui/src/frame.tsx
+++ b/ui/src/frame.tsx
@@ -110,7 +110,7 @@ export const XFrame = ({ model: { name, path, content, width = '100%', height = 
 export const
   View = bond(({ name, state, changed }: Model<State>) => {
     const render = () => (
-      <div data-test={name} className={clas(css.card, (state.compact ?? false) ? '' : css.cardPadding)}>
+      <div data-test={name} className={clas(css.card, state.compact ? '' : css.cardPadding)}>
         {!state.compact && <div className='wave-s12 wave-w6'>{state.title}</div>}
         <div className={css.body}>
           <InlineFrame path={state.path} content={state.content} />

--- a/ui/src/frame.tsx
+++ b/ui/src/frame.tsx
@@ -26,6 +26,11 @@ const
       flexDirection: 'column',
       padding: grid.gap,
     },
+    card_no_padding: {
+      display: 'flex',
+      flexDirection: 'column',
+      padding: 0,
+    },
     body: {
       flexGrow: 1,
       position: 'relative',
@@ -83,6 +88,10 @@ interface State {
    * :value ""
    */
   content?: S
+  /**
+   * True if the component should have paddings. Defaults to True.
+   */
+  has_padding?: B
 }
 
 const
@@ -104,7 +113,7 @@ export const XFrame = ({ model: { name, path, content, width = '100%', height = 
 export const
   View = bond(({ name, state, changed }: Model<State>) => {
     const render = () => (
-      <div data-test={name} className={css.card}>
+      <div data-test={name} className={state.has_padding ? css.card : css.card_no_padding}>
         <div className='wave-s12 wave-w6'>{state.title}</div>
         <div className={css.body}>
           <InlineFrame path={state.path} content={state.content} />

--- a/ui/src/frame.tsx
+++ b/ui/src/frame.tsx
@@ -16,7 +16,7 @@ import { B, Model, S, xid } from 'h2o-wave'
 import React from 'react'
 import { stylesheet } from 'typestyle'
 import { cards, grid } from './layout'
-import { formItemWidth } from './theme'
+import { formItemWidth, clas } from './theme'
 import { bond } from './ui'
 
 const
@@ -24,12 +24,9 @@ const
     card: {
       display: 'flex',
       flexDirection: 'column',
-      padding: grid.gap,
     },
-    card_no_padding: {
-      display: 'flex',
-      flexDirection: 'column',
-      padding: 0,
+    cardPadding: {
+      padding: grid.gap,
     },
     body: {
       flexGrow: 1,
@@ -113,7 +110,7 @@ export const XFrame = ({ model: { name, path, content, width = '100%', height = 
 export const
   View = bond(({ name, state, changed }: Model<State>) => {
     const render = () => (
-      <div data-test={name} className={state.has_padding ? css.card : css.card_no_padding}>
+      <div data-test={name} className={clas(css.card, (state.has_padding ?? true) ? css.cardPadding : '')}>
         <div className='wave-s12 wave-w6'>{state.title}</div>
         <div className={css.body}>
           <InlineFrame path={state.path} content={state.content} />

--- a/ui/src/frame.tsx
+++ b/ui/src/frame.tsx
@@ -86,9 +86,9 @@ interface State {
    */
   content?: S
   /**
-   * True if the component should have paddings. Defaults to True.
+   * True if title and padding should be removed. Defaults to False.
    */
-  has_padding?: B
+  compact?: B
 }
 
 const
@@ -110,8 +110,8 @@ export const XFrame = ({ model: { name, path, content, width = '100%', height = 
 export const
   View = bond(({ name, state, changed }: Model<State>) => {
     const render = () => (
-      <div data-test={name} className={clas(css.card, (state.has_padding ?? true) ? css.cardPadding : '')}>
-        <div className='wave-s12 wave-w6'>{state.title}</div>
+      <div data-test={name} className={clas(css.card, (state.compact ?? false) ? '' : css.cardPadding)}>
+        {!state.compact && <div className='wave-s12 wave-w6'>{state.title}</div>}
         <div className={css.body}>
           <InlineFrame path={state.path} content={state.content} />
         </div>

--- a/website/widgets/content/frame.md
+++ b/website/widgets/content/frame.md
@@ -21,3 +21,18 @@ html = '''
 
 q.page['example'] = ui.frame_card(box='1 1 2 2', title='Example', content=html)
 ```
+
+You can specify the value of the parameter `compact` to True to remove the title and padding of a frame card. 
+
+```py
+html = '''
+<!DOCTYPE html>
+<html>
+<body>
+  <h1>Hello World!</h1>
+</body>
+</html>
+'''
+
+q.page['example'] = ui.frame_card(box='1 1 2 2', title='Example', content=html, compact=True)
+```

--- a/website/widgets/content/frame.md
+++ b/website/widgets/content/frame.md
@@ -22,7 +22,9 @@ html = '''
 q.page['example'] = ui.frame_card(box='1 1 2 2', title='Example', content=html)
 ```
 
-You can specify the value of the parameter `compact` to True to remove the title and padding of a frame card. 
+## Without padding
+
+You can set the `compact` attribute to `True` to remove the title and padding of a frame card.
 
 ```py
 html = '''


### PR DESCRIPTION
Added a parameter called `compact` in the `State` interface of `frame.tsx`. Users can specify whether they want the frame cards to have title and paddings or not. `compact` defaults to `False`.

Example:
<img width="1441" alt="Screenshot 2022-12-07 at 12 56 00" src="https://user-images.githubusercontent.com/92182939/206260220-f1ac1a8a-b7a3-4bbb-a811-a29d2dfcd5e3.png">
Frame card with no padding specified:
<img width="1455" alt="Screenshot 2022-12-07 at 12 56 13" src="https://user-images.githubusercontent.com/92182939/206260238-09773ab7-23db-4165-a005-772a4f2061c9.png">

The changes are reflected above. The first frame card with default padding (`compact` not specified), the second frame card with padding specified, and the third frame card with no padding specified. 

The code used for testing the changes above:
```py
# Frame card with default padding
page['example1'] = ui.frame_card(
    box='1 1 -1 4',
    title='Frame card with default padding',
    path='https://example.com',
)

# Frame card with padding
page['example2'] = ui.frame_card(
    box='1 5 -1 4',
    title='Frame card with padding specified',
    path='https://example.com',
    compact=False
)

# Frame card with no padding
page['example3'] = ui.frame_card(
    box='1 9 -1 4',
    title='Frame card with no padding specified',
    path='https://example.com',
    compact=True
)
```
This pull request closes #495.