### PR TITLE
docs: fix the home page button in dark mode #1740

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -27,6 +27,7 @@ html[data-theme="dark"] {
 .hero .button--outline {
   --ifm-button-background-color: var(--h2o-accent-color);
   --ifm-button-border-color: var(--h2o-accent-color);
+  --ifm-font-color-base: #000;
   box-shadow: 0 4px 14px 0 rgba(255, 255, 0, 0.39);
 }
 .hero h1 {


### PR DESCRIPTION
This PR fixes the home page hero button text color in dark mode.

![image](https://user-images.githubusercontent.com/7029582/206361386-984cac92-3b3d-4ce9-9825-dbc92d5b333e.png)

Closes #1740