### PR TITLE
change breakpoint of dashboard to xs so that we dont need to go into …

### DIFF
--- a/py/demo/dashboard_blue.py
+++ b/py/demo/dashboard_blue.py
@@ -6,7 +6,7 @@ from .synthetic_data import *
 async def show_blue_dashboard(q: Q):
     q.page['meta'] = ui.meta_card(box='', layouts=[
         ui.layout(
-            breakpoint='xl',
+            breakpoint='xs',
             width='1200px',
             zones=[
                 ui.zone('header'),

--- a/py/demo/dashboard_cyan.py
+++ b/py/demo/dashboard_cyan.py
@@ -6,7 +6,7 @@ from .synthetic_data import *
 async def show_cyan_dashboard(q: Q):
     q.page['meta'] = ui.meta_card(box='', layouts=[
         ui.layout(
-            breakpoint='xl',
+            breakpoint='xs',
             width='1200px',
             zones=[
                 ui.zone('header'),

--- a/py/demo/dashboard_grey.py
+++ b/py/demo/dashboard_grey.py
@@ -6,7 +6,7 @@ from .synthetic_data import *
 async def show_grey_dashboard(q: Q):
     q.page['meta'] = ui.meta_card(box='', layouts=[
         ui.layout(
-            breakpoint='xl',
+            breakpoint='xs',
             min_width='800px',
             zones=[
                 ui.zone('header'),

--- a/py/demo/dashboard_mint.py
+++ b/py/demo/dashboard_mint.py
@@ -6,7 +6,7 @@ from .synthetic_data import *
 async def show_mint_dashboard(q: Q):
     q.page['meta'] = ui.meta_card(box='', layouts=[
         ui.layout(
-            breakpoint='xl',
+            breakpoint='xs',
             width='1200px',
             zones=[
                 ui.zone('header'),

--- a/py/demo/dashboard_orange.py
+++ b/py/demo/dashboard_orange.py
@@ -6,7 +6,7 @@ from .synthetic_data import *
 async def show_orange_dashboard(q: Q):
     q.page['meta'] = ui.meta_card(box='', layouts=[
         ui.layout(
-            breakpoint='xl',
+            breakpoint='xs',
             width='1200px',
             zones=[
                 ui.zone('header'),

--- a/py/demo/dashboard_red.py
+++ b/py/demo/dashboard_red.py
@@ -6,7 +6,7 @@ from .synthetic_data import *
 async def show_red_dashboard(q: Q):
     q.page['meta'] = ui.meta_card(box='', layouts=[
         ui.layout(
-            breakpoint='xl',
+            breakpoint='xs',
             width='1200px',
             zones=[
                 ui.zone('header'),


### PR DESCRIPTION
Closes https://github.com/h2oai/wave/issues/527.

This issue seems to have been solved over the past 2 years, however, we realized that when running the dashboards initially the screen would be blank if it was not in "full screen" mode. We realized this was because the breakpoint of the dashboards was set to "xl", so if the window did not match the size requirement of "xl" when running the dashboard app at first it would be blank. This can be solved by changing the "xl" to "xs" and we will not need to put our screen into "full screen" size to be able to view the dashboard initially.

Special thanks to @mturoci for looking into this issue with us, as it was trickier than expected!

Collaborators:
@Qingyang-Sophia
@aruiz2