### PR TITLE
ENV setup required when deploying with Uvicorn

### DIFF
--- a/website/docs/deployment.md
+++ b/website/docs/deployment.md
@@ -21,7 +21,7 @@ These commands are equivalent:
 ```
 
 ```shell
-(venv) $ uvicorn foo:main
+(venv) $ H2O_WAVE_APP_ADDRESS="http://127.0.0.1:8000" uvicorn foo:main
 ```
 
 For more information, see [uvicorn.org/deployment](https://www.uvicorn.org/deployment/) and [starlette.io/#performance](https://www.starlette.io/#performance).

--- a/website/docs/deployment.md
+++ b/website/docs/deployment.md
@@ -21,7 +21,11 @@ These commands are equivalent:
 ```
 
 ```shell
-(venv) $ H2O_WAVE_APP_ADDRESS="http://127.0.0.1:8000" uvicorn foo:main
+(venv) $ uvicorn foo:main
 ```
 
 For more information, see [uvicorn.org/deployment](https://www.uvicorn.org/deployment/) and [starlette.io/#performance](https://www.starlette.io/#performance).
+
+### Beyond defaults
+
+If different than defaults ports are used for Wave server (<http://localhost:10101>) or Wave app (<http://localhost:8000>) it's necessary to properly set `H2O_WAVE_LISTEN` and `H2O_WAVE_APP_ADDRESS` env variables. More info for configuration options can be found in the [configuration section](https://wave.h2o.ai/docs/configuration).


### PR DESCRIPTION
I was just running through the docs and was unable to get the Wave app to connect to the `waved` server when I ran the `uvicorn` command specified in the documentation.

I reached out via the **Discussions** threads and quickly received some help from @mturoci.

The documentation didn't mention the need to set the H2O_WAVE_APP_ADDRESS environment variable (at least not directly on the deployment page).

closes #1807