### PR TITLE
feat: Allow specifying height for ui.inline #1780

### DIFF
--- a/py/h2o_wave/types.py
+++ b/py/h2o_wave/types.py
@@ -5998,7 +5998,7 @@ class Inline:
         self.inset = inset
         """Whether to display the components inset from the parent form, with a contrasting background."""
         self.height = height
-        """Height of the component. Use `px`, `vh` or `rem` CSS units or use '1' to fill all the remaining space. E.g. '100vh', '300px' or '1'."""
+        """Custom height  in `px`, `vh` or `rem`. Use '1' to fill the height of the remaining space. E.g. '100vh', '300px' or '1'."""
 
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""

--- a/py/h2o_wave/types.py
+++ b/py/h2o_wave/types.py
@@ -5982,11 +5982,13 @@ class Inline:
             justify: Optional[str] = None,
             align: Optional[str] = None,
             inset: Optional[bool] = None,
+            height: Optional[str] = None,
     ):
         _guard_vector('Inline.items', items, (Component,), False, False, False)
         _guard_enum('Inline.justify', justify, _InlineJustify, True)
         _guard_enum('Inline.align', align, _InlineAlign, True)
         _guard_scalar('Inline.inset', inset, (bool,), False, True, False)
+        _guard_scalar('Inline.height', height, (str,), False, True, False)
         self.items = items
         """The components laid out inline."""
         self.justify = justify
@@ -5995,6 +5997,8 @@ class Inline:
         """Specifies how the individual components are aligned on the vertical axis. Defaults to 'center'. One of 'start', 'end', 'center', 'baseline'. See enum h2o_wave.ui.InlineAlign."""
         self.inset = inset
         """Whether to display the components inset from the parent form, with a contrasting background."""
+        self.height = height
+        """Height of the component. Use `px`, `vh` or `rem` CSS units or use '1' to fill all the remaining space. E.g. '100vh', '300px' or '1'."""
 
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""
@@ -6002,11 +6006,13 @@ class Inline:
         _guard_enum('Inline.justify', self.justify, _InlineJustify, True)
         _guard_enum('Inline.align', self.align, _InlineAlign, True)
         _guard_scalar('Inline.inset', self.inset, (bool,), False, True, False)
+        _guard_scalar('Inline.height', self.height, (str,), False, True, False)
         return _dump(
             items=[__e.dump() for __e in self.items],
             justify=self.justify,
             align=self.align,
             inset=self.inset,
+            height=self.height,
         )
 
     @staticmethod
@@ -6020,15 +6026,19 @@ class Inline:
         _guard_enum('Inline.align', __d_align, _InlineAlign, True)
         __d_inset: Any = __d.get('inset')
         _guard_scalar('Inline.inset', __d_inset, (bool,), False, True, False)
+        __d_height: Any = __d.get('height')
+        _guard_scalar('Inline.height', __d_height, (str,), False, True, False)
         items: List['Component'] = [Component.load(__e) for __e in __d_items]
         justify: Optional[str] = __d_justify
         align: Optional[str] = __d_align
         inset: Optional[bool] = __d_inset
+        height: Optional[str] = __d_height
         return Inline(
             items,
             justify,
             align,
             inset,
+            height,
         )
 
 

--- a/py/h2o_wave/types.py
+++ b/py/h2o_wave/types.py
@@ -5998,7 +5998,7 @@ class Inline:
         self.inset = inset
         """Whether to display the components inset from the parent form, with a contrasting background."""
         self.height = height
-        """Custom height  in `px`, `vh` or `rem`. Use '1' to fill the height of the remaining space. E.g. '100vh', '300px' or '1'."""
+        """Height of the inline container. Accepts any valid CSS unit e.g. '100vh', '300px'. Use '1' to fill the remaining card space."""
 
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""

--- a/py/h2o_wave/ui.py
+++ b/py/h2o_wave/ui.py
@@ -2208,6 +2208,7 @@ def inline(
         justify: Optional[str] = None,
         align: Optional[str] = None,
         inset: Optional[bool] = None,
+        height: Optional[str] = None,
 ) -> Component:
     """Create an inline (horizontal) list of components.
 
@@ -2216,6 +2217,7 @@ def inline(
         justify: Specifies how to lay out the individual components. Defaults to 'start'. One of 'start', 'end', 'center', 'between', 'around'. See enum h2o_wave.ui.InlineJustify.
         align: Specifies how the individual components are aligned on the vertical axis. Defaults to 'center'. One of 'start', 'end', 'center', 'baseline'. See enum h2o_wave.ui.InlineAlign.
         inset: Whether to display the components inset from the parent form, with a contrasting background.
+        height: Height of the component. Use `px`, `vh` or `rem` CSS units or use '1' to fill all the remaining space. E.g. '100vh', '300px' or '1'.
     Returns:
         A `h2o_wave.types.Inline` instance.
     """
@@ -2224,6 +2226,7 @@ def inline(
         justify,
         align,
         inset,
+        height,
     ))
 
 

--- a/py/h2o_wave/ui.py
+++ b/py/h2o_wave/ui.py
@@ -2217,7 +2217,7 @@ def inline(
         justify: Specifies how to lay out the individual components. Defaults to 'start'. One of 'start', 'end', 'center', 'between', 'around'. See enum h2o_wave.ui.InlineJustify.
         align: Specifies how the individual components are aligned on the vertical axis. Defaults to 'center'. One of 'start', 'end', 'center', 'baseline'. See enum h2o_wave.ui.InlineAlign.
         inset: Whether to display the components inset from the parent form, with a contrasting background.
-        height: Height of the component. Use `px`, `vh` or `rem` CSS units or use '1' to fill all the remaining space. E.g. '100vh', '300px' or '1'.
+        height: Custom height  in `px`, `vh` or `rem`. Use '1' to fill the height of the remaining space. E.g. '100vh', '300px' or '1'.
     Returns:
         A `h2o_wave.types.Inline` instance.
     """

--- a/py/h2o_wave/ui.py
+++ b/py/h2o_wave/ui.py
@@ -2217,7 +2217,7 @@ def inline(
         justify: Specifies how to lay out the individual components. Defaults to 'start'. One of 'start', 'end', 'center', 'between', 'around'. See enum h2o_wave.ui.InlineJustify.
         align: Specifies how the individual components are aligned on the vertical axis. Defaults to 'center'. One of 'start', 'end', 'center', 'baseline'. See enum h2o_wave.ui.InlineAlign.
         inset: Whether to display the components inset from the parent form, with a contrasting background.
-        height: Custom height  in `px`, `vh` or `rem`. Use '1' to fill the height of the remaining space. E.g. '100vh', '300px' or '1'.
+        height: Height of the inline container. Accepts any valid CSS unit e.g. '100vh', '300px'. Use '1' to fill the remaining card space.
     Returns:
         A `h2o_wave.types.Inline` instance.
     """

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -2593,7 +2593,7 @@ ui_stats <- function(
 #' @param align Specifies how the individual components are aligned on the vertical axis. Defaults to 'center'.
 #'   One of 'start', 'end', 'center', 'baseline'. See enum h2o_wave.ui.InlineAlign.
 #' @param inset Whether to display the components inset from the parent form, with a contrasting background.
-#' @param height Height of the component. Use `px`, `vh` or `rem` CSS units or use '1' to fill all the remaining space. E.g. '100vh', '300px' or '1'.
+#' @param height Custom height  in `px`, `vh` or `rem`. Use '1' to fill the height of the remaining space. E.g. '100vh', '300px' or '1'.
 #' @return A Inline instance.
 #' @export
 ui_inline <- function(

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -2593,7 +2593,7 @@ ui_stats <- function(
 #' @param align Specifies how the individual components are aligned on the vertical axis. Defaults to 'center'.
 #'   One of 'start', 'end', 'center', 'baseline'. See enum h2o_wave.ui.InlineAlign.
 #' @param inset Whether to display the components inset from the parent form, with a contrasting background.
-#' @param height Custom height  in `px`, `vh` or `rem`. Use '1' to fill the height of the remaining space. E.g. '100vh', '300px' or '1'.
+#' @param height Height of the inline container. Accepts any valid CSS unit e.g. '100vh', '300px'. Use '1' to fill the remaining card space.
 #' @return A Inline instance.
 #' @export
 ui_inline <- function(

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -2593,22 +2593,26 @@ ui_stats <- function(
 #' @param align Specifies how the individual components are aligned on the vertical axis. Defaults to 'center'.
 #'   One of 'start', 'end', 'center', 'baseline'. See enum h2o_wave.ui.InlineAlign.
 #' @param inset Whether to display the components inset from the parent form, with a contrasting background.
+#' @param height Height of the component. Use `px`, `vh` or `rem` CSS units or use '1' to fill all the remaining space. E.g. '100vh', '300px' or '1'.
 #' @return A Inline instance.
 #' @export
 ui_inline <- function(
   items,
   justify = NULL,
   align = NULL,
-  inset = NULL) {
+  inset = NULL,
+  height = NULL) {
   .guard_vector("items", "WaveComponent", items)
   # TODO Validate justify
   # TODO Validate align
   .guard_scalar("inset", "logical", inset)
+  .guard_scalar("height", "character", height)
   .o <- list(inline=list(
     items=items,
     justify=justify,
     align=align,
-    inset=inset))
+    inset=inset,
+    height=height))
   class(.o) <- append(class(.o), c(.wave_obj, "WaveComponent"))
   return(.o)
 }

--- a/tools/intellij-plugin/src/main/resources/templates/wave-components.xml
+++ b/tools/intellij-plugin/src/main/resources/templates/wave-components.xml
@@ -1304,10 +1304,11 @@
       <option name="Python" value="true"/>
     </context>
   </template>
-  <template name="w_full_inline" value="ui.inline(justify='$justify$',align='$align$',inset=$inset$,items=[&#10;	$items$	&#10;]),$END$" description="Create Wave Inline with full attributes." toReformat="true" toShortenFQNames="true">
+  <template name="w_full_inline" value="ui.inline(justify='$justify$',align='$align$',inset=$inset$,height='$height$',items=[&#10;	$items$	&#10;]),$END$" description="Create Wave Inline with full attributes." toReformat="true" toShortenFQNames="true">
     <variable name="justify" expression="" defaultValue="&quot;start&quot;" alwaysStopAt="true"/>
     <variable name="align" expression="" defaultValue="&quot;center&quot;" alwaysStopAt="true"/>
     <variable name="inset" expression="" defaultValue="&quot;False&quot;" alwaysStopAt="true"/>
+    <variable name="height" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="items" expression="" defaultValue="" alwaysStopAt="true"/>
     <context>
       <option name="Python" value="true"/>

--- a/tools/showcase/showcase.py
+++ b/tools/showcase/showcase.py
@@ -65,9 +65,9 @@ def generate_diff_view():
                 content += f'''
 <h2>{str(file).replace('test/diff', '')}</h2>
 <div class='row'>
-  <img src='{src.replace('diff', 'base', 1)}' />
-  <img src='{src.replace('diff', 'compare', 1)}' />
-  <img src='{src}' />
+  <img style="height: fit-content" src='{src.replace('diff', 'base', 1)}' />
+  <img style="height: fit-content" src='{src.replace('diff', 'compare', 1)}' />
+  <img style="height: fit-content" src='{src}' />
 </div>'''
             content += '\n</body>\n</html>'
             f.write(content)
@@ -98,9 +98,11 @@ def make_snippet_screenshot(code: List[str], img_name: str, page, groups: List[s
             path = base_path if is_base else os.path.join('test', 'compare', browser, groups, img_name)
 
         os.makedirs(os.path.dirname(path), exist_ok=True)
-        sub_selector = ' > *' if 'ui.form_card' in code_str else ''
         card_name = match[0][2] if match[0][2] != 'meta' else match[1][2]
-        selector = f'[data-test="{card_name}"]{sub_selector}'
+        selector = f'[data-test="{card_name}"]'
+        if('ui.form_card' in code_str):
+            widget_count = len(page.query_selector_all(f'{selector} > :first-child > *'))
+            selector = f'{selector} > *' if widget_count > 1 else f'{selector} > :first-child > *'
         page.wait_for_selector(selector)
         print(f'Generating {img_name}')
         page.query_selector(selector).screenshot(path=path)

--- a/tools/vscode-extension/component-snippets.json
+++ b/tools/vscode-extension/component-snippets.json
@@ -1108,7 +1108,7 @@
   "Wave Full Inline": {
     "prefix": "w_full_inline",
     "body": [
-      "ui.inline(justify='${1:start}', align='${2:center}', inset=${3:False}, items=[\n\t\t$4\t\t\n]),$0"
+      "ui.inline(justify='${1:start}', align='${2:center}', inset=${3:False}, height='$4', items=[\n\t\t$5\t\t\n]),$0"
     ],
     "description": "Create a full Wave Inline."
   },

--- a/ui/src/form.tsx
+++ b/ui/src/form.tsx
@@ -175,7 +175,7 @@ interface Inline {
   align?: 'start' | 'end' | 'center' | 'baseline'
   /** Whether to display the components inset from the parent form, with a contrasting background. */
   inset?: B
-  /** Height of the component. Use `px`, `vh` or `rem` CSS units or use '1' to fill all the remaining space. E.g. '100vh', '300px' or '1'. */
+  /** Custom height  in `px`, `vh` or `rem`. Use '1' to fill the height of the remaining space. E.g. '100vh', '300px' or '1'. */
   height?: S
 }
 
@@ -191,8 +191,8 @@ const
   defaults: Partial<State> = { items: [] },
   css = stylesheet({
     card: {
-      padding: 15,
       display: 'flex',
+      padding: 15,
     },
     vertical: {
       display: 'flex',

--- a/ui/src/form.tsx
+++ b/ui/src/form.tsx
@@ -175,6 +175,8 @@ interface Inline {
   align?: 'start' | 'end' | 'center' | 'baseline'
   /** Whether to display the components inset from the parent form, with a contrasting background. */
   inset?: B
+  /** Height of the component. Use `px`, `vh` or `rem` CSS units or use '1' to fill all the remaining space. E.g. '100vh', '300px' or '1'. */
+  height?: S
 }
 
 /** Create a form. */
@@ -190,6 +192,7 @@ const
   css = stylesheet({
     card: {
       padding: 15,
+      display: 'flex',
     },
     vertical: {
       display: 'flex',
@@ -214,35 +217,46 @@ const
       background: cssVar('$page'),
       padding: padding(10, 15)
     },
+    fullHeight: {
+      display: 'flex',
+      flexGrow: 1
+    }
   })
 
 type Justification = 'start' | 'end' | 'center' | 'between' | 'around'
 type Alignment = 'start' | 'end' | 'center' | 'baseline'
 
 export const
-  XComponents = ({ items, justify, align, inset }: { items: Component[], justify?: Justification, align?: Alignment, inset?: B }) => {
+  XComponents = ({ items, justify, align, inset, height }: { items: Component[], justify?: Justification, align?: Alignment, inset?: B, height?: S }) => {
     const
       components = items.map((m: any, i) => {
         const
           // All form items are wrapped by their component name (first and only prop of "m").
           [componentKey] = Object.keys(m),
-          { name, visible = true, width = 'auto' } = m[componentKey],
+          { name, visible = true, width = 'auto', height } = m[componentKey],
           visibleStyles: React.CSSProperties = visible ? {} : { display: 'none' },
           // TODO: Ugly, maybe use ui.inline's 'align' prop instead?
           alignSelf = componentKey === 'links' ? 'flex-start' : undefined
 
         return (
           // Recreate only if name or position within form items changed, update otherwise.
-          <div key={name || `${componentKey}-${i}`} data-visible={visible} style={{ ...visibleStyles, width, alignSelf }}>
+          <div
+            key={name || `${componentKey}-${i}`}
+            data-visible={visible}
+            className={height === '1' ? css.fullHeight : ''}
+            style={{ ...visibleStyles, width, alignSelf }}
+          >
             <XComponent model={m} />
           </div>
         )
       })
+
     return <div
-      className={clas(justify ? css.horizontal : css.vertical, inset ? css.inset : '')}
+      className={clas(justify ? css.horizontal : css.vertical, inset ? css.inset : '', height === '1' ? css.fullHeight : '')}
       style={{
         justifyContent: justifications[justify || ''],
         alignItems: alignments[align || ''],
+        height: height === '1' ? undefined : height,
       }}
     >{components}</div>
   },
@@ -252,6 +266,8 @@ export const
       justify={m.justify || 'start'}
       align={m.align || 'center'}
       inset={m.inset}
+      // Checks for positive float value ending with 'px', 'rem' or 'vh'.
+      height={/^\d+(\.\d+)?(px|rem|vh)$/.test(m.height || '') || m.height === '1' ? m.height : undefined}
     />
   )
 

--- a/ui/src/form.tsx
+++ b/ui/src/form.tsx
@@ -266,8 +266,8 @@ export const
       justify={m.justify || 'start'}
       align={m.align || 'center'}
       inset={m.inset}
-      // Checks for positive float value ending with 'px', 'rem' or 'vh'.
-      height={/^\d+(\.\d+)?(px|rem|vh)$/.test(m.height || '') || m.height === '1' ? m.height : undefined}
+      // Checks for '1' or positive float value ending with 'px', 'rem' or 'vh'.
+      height={/^\d+(\.\d+)?(px|rem|vh)$|^1$/.test(m.height || '') ? m.height : undefined}
     />
   )
 

--- a/ui/src/form.tsx
+++ b/ui/src/form.tsx
@@ -175,7 +175,7 @@ interface Inline {
   align?: 'start' | 'end' | 'center' | 'baseline'
   /** Whether to display the components inset from the parent form, with a contrasting background. */
   inset?: B
-  /** Custom height  in `px`, `vh` or `rem`. Use '1' to fill the height of the remaining space. E.g. '100vh', '300px' or '1'. */
+  /** Height of the inline container. Accepts any valid CSS unit e.g. '100vh', '300px'. Use '1' to fill the remaining card space. */
   height?: S
 }
 
@@ -266,8 +266,7 @@ export const
       justify={m.justify || 'start'}
       align={m.align || 'center'}
       inset={m.inset}
-      // Checks for '1' or positive float value ending with 'px', 'rem' or 'vh'.
-      height={/^\d+(\.\d+)?(px|rem|vh)$|^1$/.test(m.height || '') ? m.height : undefined}
+      height={m.height}
     />
   )
 

--- a/website/widgets/form/inline.md
+++ b/website/widgets/form/inline.md
@@ -64,9 +64,9 @@ q.page['align'] = ui.form_card(box='1 1 3 5', items=[
 
 ## Setting height
 
-In addition to the `width` attribute present on every form component, [ui.inline](/docs/api/ui#inline) provides also
-a way to control height via the `height` attribute. It supports all the [CSS units](https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/Values_and_units), however `%` may not always work as expected
-so better use static units like `px`, `rem` etc. instead. You can also use `1` to fill the remaining space. This is useful if you want to display form items in the middle of the card.
+Height of the `ui.inline` can be controlled via the `height` attribute, supporting all [valid CSS units](https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/Values_and_units). However, `%` may not always work as you might expect so it's advised to use static units like `px`, `rem` etc.
+
+It's also possible to specify `1` to fill the remaining card space. Useful for displaying form items in the middle of the card or just making more breathing room.
 
 ```py
 q.page['example'] = ui.form_card(box='1 1 -1 -1', items=[

--- a/website/widgets/form/inline.md
+++ b/website/widgets/form/inline.md
@@ -61,3 +61,20 @@ q.page['align'] = ui.form_card(box='1 1 3 5', items=[
     ui.inline(items, align='end'),
 ])
 ```
+
+## Setting height
+
+In addition to the `width` attribute present on every form component, [ui.inline](/docs/api/ui#inline) provides also
+a way to control height via the `height` attribute. It supports all the [CSS units](https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/Values_and_units), however `%` may not always work as expected
+so better use static units like `px`, `rem` etc. instead. You can also use `1` to fill the remaining space. This is useful if you want to display form items in the middle of the card.
+
+```py
+q.page['example'] = ui.form_card(box='1 1 -1 -1', items=[
+    ui.inline(
+        items=[ui.text('I am in the perfect center!')], 
+        justify='center',
+        align='center',
+        height='1'
+    )
+])
+```


### PR DESCRIPTION
This change adds the `height` prop for ui.inline component.
```ts
interface Inline {
  /** The components laid out inline. */
  items: Component[]
  /** Specifies how to lay out the individual components. Defaults to 'start'. */
  justify?: 'start' | 'end' | 'center' | 'between' | 'around'
  /** Specifies how the individual components are aligned on the vertical axis. Defaults to 'center'. */
  align?: 'start' | 'end' | 'center' | 'baseline'
  /** Whether to display the components inset from the parent form, with a contrasting background. */
  inset?: B
  /** Custom height  in `px`, `vh` or `rem`. Use '1' to fill the height of the remaining space. E.g. '100vh', '300px' or '1'. */
  height?: S
}
```
As API description says, the accepted values are the following CSS units: `px`, `vh` or `rem`. It is also possible to fill the all remaining height of the parent component by specifying `1`.

Resolves _ui.inline height_ part of the #1780.

Also regression tests are adjusted since this change defines `display: flex` for cards and could lead to empty space in screenshots. There are 2 changes for regression tests:

- the height is defined for the generated images
- the screenshot of the widget element is taken instead of the form element if there is only one widget in the form