### PR TITLE
fix: Properly mutate page state during dropdown events.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,7 +19,6 @@
       "program": "${workspaceRoot}/ui/node_modules/jest/bin/jest.js",
       "args": [
         "--no-cache",
-        "--env=jsdom",
         "${file}"
       ],
       "cwd": "${workspaceRoot}/ui",

--- a/ui/src/dropdown.test.tsx
+++ b/ui/src/dropdown.test.tsx
@@ -174,16 +174,10 @@ describe('Dropdown.tsx', () => {
         it('Displays new value when "value" prop is updated', () => {
           const { getByRole, rerender } = render(<XDropdown model={{ ...defaultProps, value: 'A' }} />)
           expect(getByRole('combobox')).toHaveTextContent('Choice A')
-
-          rerender(<XDropdown model={{ ...defaultProps, value: 'B' }} />)
-          expect(getByRole('combobox')).toHaveTextContent('Choice B')
-        })
-
-        it('Sets wave args when "value" prop is updated ', () => {
-          const { rerender } = render(<XDropdown model={{ ...defaultProps, value: 'A' }} />)
           expect(wave.args[name]).toBe('A')
 
           rerender(<XDropdown model={{ ...defaultProps, value: 'B' }} />)
+          expect(getByRole('combobox')).toHaveTextContent('Choice B')
           expect(wave.args[name]).toBe('B')
         })
 
@@ -225,9 +219,11 @@ describe('Dropdown.tsx', () => {
           fireEvent.click(getByRole('combobox'))
           fireEvent.click(getByText('Choice A'))
           expect(getByRole('combobox')).toHaveTextContent('Choice A')
+          expect(wave.args[name]).toBe('A')
 
           rerender(<XDropdown model={{ ...defaultProps, value: 'B' }} />)
           expect(getByRole('combobox')).toHaveTextContent('Choice B')
+          expect(wave.args[name]).toBe('B')
         })
 
         it('Sets wave args when an option is selected and "value" prop updated', () => {
@@ -258,6 +254,19 @@ describe('Dropdown.tsx', () => {
 
           rerender(<XDropdown model={{ ...defaultProps, value: 'B' }} />)
           expect(wave.args[name]).toEqual('B')
+        })
+
+        it('Allows setting the same value multiple times', () => {
+          const { getByRole, getAllByText, rerender } = render(<XDropdown model={{ ...defaultProps, value: 'A' }} />)
+
+          fireEvent.click(getByRole('combobox'))
+          fireEvent.click(getAllByText('Choice C')[0])
+          expect(getByRole('combobox')).toHaveTextContent('Choice C')
+          expect(wave.args[name]).toEqual('C')
+
+          rerender(<XDropdown model={{ ...defaultProps, value: 'A' }} />)
+          expect(getByRole('combobox')).toHaveTextContent('Choice A')
+          expect(wave.args[name]).toEqual('A')
         })
       })
 
@@ -638,6 +647,21 @@ describe('Dropdown.tsx', () => {
 
           rerender(<XDropdown model={{ ...dialogProps, value: '2' }} />)
           expect(wave.args[name]).toBe('2')
+        })
+
+        it('Allows setting the same value multiple times', async () => {
+          const { getByText, getByTestId, rerender } = render(<XDropdown model={{ ...dialogProps, value: '1' }} />)
+          expect(wave.args[name]).toEqual('1')
+          await waitFor(() => expect(getByTestId(name)).toHaveValue('Choice 1'))
+
+          fireEvent.click(getByTestId(name))
+          fireEvent.click(getByText('Choice 2'))
+
+          expect(wave.args[name]).toEqual('2')
+          await waitFor(() => expect(getByTestId(name)).toHaveValue('Choice 2'))
+
+          rerender(<XDropdown model={{ ...defaultProps, value: '1' }} />)
+          expect(wave.args[name]).toEqual('1')
         })
       })
 

--- a/ui/src/dropdown.test.tsx
+++ b/ui/src/dropdown.test.tsx
@@ -660,7 +660,7 @@ describe('Dropdown.tsx', () => {
           expect(wave.args[name]).toEqual('2')
           await waitFor(() => expect(getByTestId(name)).toHaveValue('Choice 2'))
 
-          rerender(<XDropdown model={{ ...defaultProps, value: '1' }} />)
+          rerender(<XDropdown model={{ ...dialogProps, value: '1' }} />)
           expect(wave.args[name]).toEqual('1')
         })
       })

--- a/ui/src/dropdown.tsx
+++ b/ui/src/dropdown.tsx
@@ -105,7 +105,9 @@ const
             m.value = optionKey
           }
         }
-        if (trigger) wave.push()
+
+        // HACK: Push clears args so run it after useEffect sets them due to model.value change.
+        if (trigger) setTimeout(() => wave.push(), 0)
       },
       selectAll = () => {
         if (!selection) return
@@ -201,7 +203,8 @@ const
         setItems(items => items.map(item => (({ ...item, checked: item.name === itemName ? checked : false, show: true }))))
         wave.args[name] = itemName
         model.value = itemName
-        if (trigger) wave.push()
+        // HACK: Push clears args so run it after useEffect sets them due to model.value change.
+        if (trigger) setTimeout(() => wave.push(), 0)
         toggleDialog()
       }
 
@@ -242,8 +245,9 @@ const
       </>
     )
   },
-  DialogDropdownMulti = ({ name, choices = [], values = [], disabled, required, trigger, placeholder, label }: Dropdown) => {
+  DialogDropdownMulti = ({ model }: { model: Dropdown }) => {
     const
+      { name, choices = [], values = [], disabled, required, trigger, placeholder, label } = model,
       [isDialogHidden, setIsDialogHidden] = React.useState(true),
       [items, setItems, onSearchChange] = useItems(choices, values),
       itemsOnDialogOpen = React.useRef(items),
@@ -261,7 +265,8 @@ const
       },
       submit = (items: DropdownItem[]) => {
         wave.args[name] = items.filter(i => i.checked).map(i => i.name)
-        if (trigger) wave.push()
+        // HACK: Push clears args so run it after useEffect sets them due to model.values change.
+        if (trigger) setTimeout(() => wave.push(), 0)
         closeDialog()
       },
       onChecked = (name: S) => (_ev?: React.FormEvent<HTMLElement | HTMLInputElement>, checked = false) => {
@@ -316,13 +321,13 @@ const
       </>
     )
   },
-  DialogDropdown = (props: Dropdown) => props.values ? <DialogDropdownMulti {...props} /> : <DialogDropdownSingle model={{ ...props }} />
+  DialogDropdown = ({ model }: { model: Dropdown }) => model.values ? <DialogDropdownMulti model={model} /> : <DialogDropdownSingle model={model} />
 
 export const XDropdown = ({ model: m }: { model: Dropdown }) =>
   m.popup === 'always'
-    ? <DialogDropdown {...m} />
+    ? <DialogDropdown model={m} />
     : m.popup === 'never'
-      ? <BaseDropdown model={{ ...m }} />
+      ? <BaseDropdown model={m} />
       : (m.choices?.length || 0) > 100
-        ? <DialogDropdown {...m} />
-        : <BaseDropdown model={{ ...m }} />
+        ? <DialogDropdown model={m} />
+        : <BaseDropdown model={m} />


### PR DESCRIPTION
This PR resolves half of the #1815 by proper mutations on `model.value`.

### Needs discussion

Current `handle_on` runs at most one handler function (depending on match). This is problematic since since we always return the current `#` in q.args (https://github.com/h2oai/wave/commit/bc409b3a6d3e0a403e637af60084e36c75561df2#diff-093127603bee40a36f6c601028f9af200504cb9dba3a73b808ae2b2643e5980c). This results in `handle_on` always handling the hash part if it matches. ignoring any other potential form outputs, e.g. dropdown value.

Fixing the `handle_on` would be a massive breaking change though so I suggest deprecating it in favor of newer mechanism proposed by @Far0n. cc @lo5 

### Workaround

The workaround for #1815 once this PR is merged would be to either completely ditch `handle_on` and fallback to if else statements or use `handle_on` for hash routing only.

Code applied to the repro in the corresponding issue:

```py
from h2o_wave import main, app, Q, ui, on, handle_on


choices = [
    ui.choice(name='A', label='Option A'),
    ui.choice(name='B', label='Option B'),
    ui.choice(name='C', label='Option C'),
    ui.choice(name='D', label='Option D'),
]


@on("#demo/{id_:str}/data")
async def show_scoring_data(q: Q, id_: str) -> None:
    q.page['example'] = ui.form_card(box='1 1 5 5', items=[
        ui.dropdown(
            name="dropdown",
            placeholder="Select Deployment",
            choices=choices,
            value=id_,
            trigger=True,
            popup='always',
            width="250px",
        ),
        ui.text_m(f"Your id is {id_}"),
    ])


@app('/')
async def serve(q: Q):
    if not q.client.initialized:
        q.client.initialized = True
        q.page['meta'] = ui.meta_card(box='')

    if q.args.dropdown:
        q.page["meta"].redirect = f"#demo/{q.args.dropdown}/data"
    elif not await handle_on(q):
        q.page["meta"].redirect = "#demo/A/data"

    await q.page.save()

```

Closes #1815