### PR TITLE
fix: Prevent table reset on items change for paginated table

### DIFF
--- a/py/examples/table_pagination.py
+++ b/py/examples/table_pagination.py
@@ -18,7 +18,7 @@ class Issue:
 
 
 all_rows = [Issue(text=i + 1, status=('Closed' if i % 2 == 0 else 'Open')) for i in range(100)]
-rows_per_page = 11
+rows_per_page = 10
 total_rows = len(all_rows)
 
 

--- a/py/examples/table_pagination.py
+++ b/py/examples/table_pagination.py
@@ -18,7 +18,7 @@ class Issue:
 
 
 all_rows = [Issue(text=i + 1, status=('Closed' if i % 2 == 0 else 'Open')) for i in range(100)]
-rows_per_page = 10
+rows_per_page = 11
 total_rows = len(all_rows)
 
 

--- a/py/h2o_lightwave/h2o_lightwave/ui.py
+++ b/py/h2o_lightwave/h2o_lightwave/ui.py
@@ -1414,6 +1414,8 @@ def table(
         groups: Optional[List[TableGroup]] = None,
         pagination: Optional[TablePagination] = None,
         events: Optional[List[str]] = None,
+        single: Optional[bool] = None,
+        value: Optional[str] = None,
 ) -> Component:
     """Create an interactive table.
 
@@ -1439,8 +1441,8 @@ def table(
         name: An identifying name for this component.
         columns: The columns in this table.
         rows: The rows in this table. Mutually exclusive with `groups` attr.
-        multiple: True to allow multiple rows to be selected.
-        groupable: True to allow group by feature. Not applicable when `pagination` is set.
+        multiple: True to allow multiple rows to be selected. Mutually exclusive with `single` attr.
+        groupable: True to allow group by feature.
         downloadable: Indicates whether the table rows can be downloaded as a CSV file. Defaults to False.
         resettable: Indicates whether a Reset button should be displayed to reset search / filter / group-by values to their defaults. Defaults to False.
         height: The height of the table, e.g. '400px', '50%', etc.
@@ -1451,7 +1453,9 @@ def table(
         tooltip: An optional tooltip message displayed when a user clicks the help icon to the right of the component.
         groups: Creates collapsible / expandable groups of data rows. Mutually exclusive with `rows` attr.
         pagination: Display a pagination control at the bottom of the table. Set this value using `ui.table_pagination()`.
-        events: The events to capture on this table. One of 'search' | 'sort' | 'filter' | 'download' | 'page_change' | 'reset'.
+        events: The events to capture on this table. One of 'search' | 'sort' | 'filter' | 'download' | 'page_change' | 'reset' | 'select'.
+        single: True to allow only one row to be selected at time. Mutually exclusive with `multiple` attr.
+        value: The name of the selected row. If this parameter is set, single selection will be allowed (`single` is assumed to be `True`).
     Returns:
         A `h2o_wave.types.Table` instance.
     """
@@ -1472,6 +1476,8 @@ def table(
         groups,
         pagination,
         events,
+        single,
+        value,
     ))
 
 
@@ -2202,6 +2208,8 @@ def inline(
         justify: Optional[str] = None,
         align: Optional[str] = None,
         inset: Optional[bool] = None,
+        height: Optional[str] = None,
+        direction: Optional[str] = None,
 ) -> Component:
     """Create an inline (horizontal) list of components.
 
@@ -2210,6 +2218,8 @@ def inline(
         justify: Specifies how to lay out the individual components. Defaults to 'start'. One of 'start', 'end', 'center', 'between', 'around'. See enum h2o_wave.ui.InlineJustify.
         align: Specifies how the individual components are aligned on the vertical axis. Defaults to 'center'. One of 'start', 'end', 'center', 'baseline'. See enum h2o_wave.ui.InlineAlign.
         inset: Whether to display the components inset from the parent form, with a contrasting background.
+        height: Height of the inline container. Accepts any valid CSS unit e.g. '100vh', '300px'. Use '1' to fill the remaining card space.
+        direction: Container direction. Defaults to 'row'. One of 'row', 'column'. See enum h2o_wave.ui.InlineDirection.
     Returns:
         A `h2o_wave.types.Inline` instance.
     """
@@ -2218,6 +2228,8 @@ def inline(
         justify,
         align,
         inset,
+        height,
+        direction,
     ))
 
 
@@ -2560,10 +2572,10 @@ def menu(
 
     Args:
         items: Commands to render.
-        icon: The card's icon. Mutually exclusive with the image and label.
-        image: The card’s image, preferably user avatar. Mutually exclusive with the icon and label.
+        icon: The card's icon.
+        image: The card’s image, preferably user avatar.
         name: An identifying name for this component.
-        label: The text displayed next to the chevron. Mutually exclusive with the icon and image.
+        label: The text displayed next to the chevron.
     Returns:
         A `h2o_wave.types.Menu` instance.
     """

--- a/py/h2o_wave/h2o_wave/types.py
+++ b/py/h2o_wave/h2o_wave/types.py
@@ -3741,7 +3741,7 @@ class Table:
         self.multiple = multiple
         """True to allow multiple rows to be selected. Mutually exclusive with `single` attr."""
         self.groupable = groupable
-        """True to allow group by feature. Not applicable when `pagination` is set."""
+        """True to allow group by feature."""
         self.downloadable = downloadable
         """Indicates whether the table rows can be downloaded as a CSV file. Defaults to False."""
         self.resettable = resettable
@@ -3765,7 +3765,7 @@ class Table:
         self.events = events
         """The events to capture on this table. One of 'search' | 'sort' | 'filter' | 'download' | 'page_change' | 'reset' | 'select'."""
         self.single = single
-        """True to allow only on row to be selected at time. Mutually exclusive with `multiple` attr."""
+        """True to allow only one row to be selected at time. Mutually exclusive with `multiple` attr."""
         self.value = value
         """The name of the selected row. If this parameter is set, single selection will be allowed (`single` is assumed to be `True`)."""
 

--- a/py/h2o_wave/h2o_wave/ui.py
+++ b/py/h2o_wave/h2o_wave/ui.py
@@ -1442,7 +1442,7 @@ def table(
         columns: The columns in this table.
         rows: The rows in this table. Mutually exclusive with `groups` attr.
         multiple: True to allow multiple rows to be selected. Mutually exclusive with `single` attr.
-        groupable: True to allow group by feature. Not applicable when `pagination` is set.
+        groupable: True to allow group by feature.
         downloadable: Indicates whether the table rows can be downloaded as a CSV file. Defaults to False.
         resettable: Indicates whether a Reset button should be displayed to reset search / filter / group-by values to their defaults. Defaults to False.
         height: The height of the table, e.g. '400px', '50%', etc.
@@ -1454,7 +1454,7 @@ def table(
         groups: Creates collapsible / expandable groups of data rows. Mutually exclusive with `rows` attr.
         pagination: Display a pagination control at the bottom of the table. Set this value using `ui.table_pagination()`.
         events: The events to capture on this table. One of 'search' | 'sort' | 'filter' | 'download' | 'page_change' | 'reset' | 'select'.
-        single: True to allow only on row to be selected at time. Mutually exclusive with `multiple` attr.
+        single: True to allow only one row to be selected at time. Mutually exclusive with `multiple` attr.
         value: The name of the selected row. If this parameter is set, single selection will be allowed (`single` is assumed to be `True`).
     Returns:
         A `h2o_wave.types.Table` instance.

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -1648,7 +1648,7 @@ ui_table_pagination <- function(
 #' @param columns The columns in this table.
 #' @param rows The rows in this table. Mutually exclusive with `groups` attr.
 #' @param multiple True to allow multiple rows to be selected. Mutually exclusive with `single` attr.
-#' @param groupable True to allow group by feature. Not applicable when `pagination` is set.
+#' @param groupable True to allow group by feature.
 #' @param downloadable Indicates whether the table rows can be downloaded as a CSV file. Defaults to False.
 #' @param resettable Indicates whether a Reset button should be displayed to reset search / filter / group-by values to their defaults. Defaults to False.
 #' @param height The height of the table, e.g. '400px', '50%', etc.
@@ -1661,7 +1661,7 @@ ui_table_pagination <- function(
 #' @param groups Creates collapsible / expandable groups of data rows. Mutually exclusive with `rows` attr.
 #' @param pagination Display a pagination control at the bottom of the table. Set this value using `ui.table_pagination()`.
 #' @param events The events to capture on this table. One of 'search' | 'sort' | 'filter' | 'download' | 'page_change' | 'reset' | 'select'.
-#' @param single True to allow only on row to be selected at time. Mutually exclusive with `multiple` attr.
+#' @param single True to allow only one row to be selected at time. Mutually exclusive with `multiple` attr.
 #' @param value The name of the selected row. If this parameter is set, single selection will be allowed (`single` is assumed to be `True`).
 #' @return A Table instance.
 #' @export

--- a/ui/src/table.test.tsx
+++ b/ui/src/table.test.tsx
@@ -77,6 +77,8 @@ describe('Table.tsx', () => {
     expect(getAllByRole('gridcell')[0].textContent).toBe('6/23/2022, 12:50:28 AM')
   })
 
+  // TODO: Add a test to check that no event is emitted on rows update. Would result in infinite loop.
+
   describe('Height compute', () => {
 
     it('Computes properly for simple table - header, rows', () => {

--- a/ui/src/table.tsx
+++ b/ui/src/table.tsx
@@ -956,10 +956,8 @@ export const
     }, [])
 
     useUpdateOnlyEffect(() => {
-      if (!m.pagination) {
-        setFilteredItems(items)
-        reset()
-      }
+      setFilteredItems(items)
+      if (!m.pagination) reset()
     }, [items])
 
     React.useEffect(() => {

--- a/ui/src/table.tsx
+++ b/ui/src/table.tsx
@@ -129,7 +129,7 @@ export interface Table {
   rows?: TableRow[]
   /** True to allow multiple rows to be selected. Mutually exclusive with `single` attr. */
   multiple?: B
-  /** True to allow group by feature. Not applicable when `pagination` is set. */
+  /** True to allow group by feature. */
   groupable?: B
   /** Indicates whether the table rows can be downloaded as a CSV file. Defaults to False. */
   downloadable?: B
@@ -153,7 +153,7 @@ export interface Table {
   pagination?: TablePagination
   /** The events to capture on this table. One of 'search' | 'sort' | 'filter' | 'download' | 'page_change' | 'reset' | 'select'. */
   events?: S[]
-  /** True to allow only on row to be selected at time. Mutually exclusive with `multiple` attr. */
+  /** True to allow only one row to be selected at time. Mutually exclusive with `multiple` attr. */
   single?: B
   /** The name of the selected row. If this parameter is set, single selection will be allowed (`single` is assumed to be `True`). */
   value?: S
@@ -956,8 +956,10 @@ export const
     }, [])
 
     useUpdateOnlyEffect(() => {
-      setFilteredItems(items)
-      reset()
+      if (!m.pagination) {
+        setFilteredItems(items)
+        reset()
+      }
     }, [items])
 
     React.useEffect(() => {


### PR DESCRIPTION
Fixes the regression caused by #1724 when paginated table became frozen after the page change.

Also fixes API description typo for `single` prop and updates the API description for `groupable` to align with the [current implementation](https://github.com/h2oai/wave/commit/294e642b0a0d8071091dc4b4914a05a89b0ed50b).