### PR TITLE
feat: Allow by-name component access. #148

### DIFF
--- a/card.go
+++ b/card.go
@@ -79,9 +79,9 @@ func loadCard(ns *Namespace, c CardD) *Card {
 					}
 				}
 			}
-			ks[0] = k
-			card.set(ks, v)
 		}
+		ks[0] = k
+		card.set(ks, v)
 	}
 	return card
 }

--- a/card.go
+++ b/card.go
@@ -24,9 +24,9 @@ type Buf interface {
 	// get cursor at key k
 	get(k string) (Cur, bool)
 	// overwrite all records
-	put(v interface{})
+	put(v any)
 	// set record at key k
-	set(k string, v interface{})
+	set(k string, v any)
 	// dump contents
 	dump() BufD
 }
@@ -46,14 +46,17 @@ func loadBuf(ns *Namespace, b BufD) Buf {
 
 // Card represents an item on a Page, and holds attributes and data for rendering views.
 type Card struct {
-	data             map[string]interface{}
-	nameComponentMap map[string]interface{} // Cache for cards with items, secondary_items or buttons.
+	data             map[string]any
+	nameComponentMap map[string]any // Cache for cards with items, secondary_items or buttons.
 }
 
 const dataPrefix = "~"
 
 func loadCard(ns *Namespace, c CardD) *Card {
-	card := &Card{make(map[string]interface{}), nil}
+	card := &Card{
+		data:             make(map[string]any),
+		nameComponentMap: nil,
+	}
 	ks := make([]string, 1) // to avoid allocation during card.set() below
 	for k, v := range c.D {
 		if len(k) > 0 && strings.HasPrefix(k, dataPrefix) {
@@ -66,7 +69,7 @@ func loadCard(ns *Namespace, c CardD) *Card {
 		}
 		if k == "items" || k == "secondary_items" || k == "buttons" {
 			if card.nameComponentMap == nil {
-				card.nameComponentMap = make(map[string]interface{})
+				card.nameComponentMap = make(map[string]any)
 			}
 			fillNameComponentMap(card.nameComponentMap, v)
 		}
@@ -76,7 +79,7 @@ func loadCard(ns *Namespace, c CardD) *Card {
 	return card
 }
 
-func (c *Card) set(ks []string, v interface{}) {
+func (c *Card) set(ks []string, v any) {
 	switch len(ks) {
 	case 0: // should not get here; outer interpreter loop will clobber this card.
 		return
@@ -94,7 +97,7 @@ func (c *Card) set(ks []string, v interface{}) {
 			c.data[p] = v
 		}
 	default: // .foo.bar.baz = qux
-		var x interface{} = c.data
+		var x any = c.data
 
 		// By-name access.
 		if v, ok := c.nameComponentMap[ks[0]]; ok && len(ks) == 2 {
@@ -111,19 +114,19 @@ func (c *Card) set(ks []string, v interface{}) {
 	}
 }
 
-func set(ix interface{}, k string, v interface{}) {
+func set(ix any, k string, v any) {
 	switch x := ix.(type) {
 	case Buf:
 		x.set(k, v)
 	case Cur:
 		x.set(k, v)
-	case map[string]interface{}:
+	case map[string]any:
 		if v == nil {
 			delete(x, k)
 		} else {
 			x[k] = v
 		}
-	case []interface{}:
+	case []any:
 		if i, err := strconv.Atoi(k); err == nil {
 			if i >= 0 && i < len(x) {
 				x[i] = v
@@ -132,7 +135,7 @@ func set(ix interface{}, k string, v interface{}) {
 	}
 }
 
-func get(ix interface{}, k string) interface{} {
+func get(ix any, k string) any {
 	switch x := ix.(type) {
 	case Buf:
 		if r, ok := x.get(k); ok {
@@ -140,11 +143,11 @@ func get(ix interface{}, k string) interface{} {
 		}
 	case Cur:
 		return x.get(k)
-	case map[string]interface{}:
+	case map[string]any:
 		if v, ok := x[k]; ok {
 			return v
 		}
-	case []interface{}:
+	case []any:
 		if i, err := strconv.Atoi(k); err == nil {
 			if i >= 0 && i < len(x) {
 				return x[i]
@@ -155,7 +158,7 @@ func get(ix interface{}, k string) interface{} {
 }
 
 func (c *Card) dump() CardD {
-	data := make(map[string]interface{})
+	data := make(map[string]any)
 	var bufs []BufD
 	for k, iv := range c.data {
 		if v, ok := iv.(Buf); ok {
@@ -168,16 +171,16 @@ func (c *Card) dump() CardD {
 	return CardD{data, bufs}
 }
 
-func deepClone(ix interface{}) interface{} {
+func deepClone(ix any) any {
 	switch x := ix.(type) {
-	case map[string]interface{}:
-		m := make(map[string]interface{})
+	case map[string]any:
+		m := make(map[string]any)
 		for k, v := range x {
 			m[k] = deepClone(v)
 		}
 		return m
-	case []interface{}:
-		s := make([]interface{}, len(x))
+	case []any:
+		s := make([]any, len(x))
 		for i, v := range x {
 			s[i] = deepClone(v)
 		}
@@ -186,13 +189,15 @@ func deepClone(ix interface{}) interface{} {
 	return ix
 }
 
-func fillNameComponentMap(m map[string]interface{}, items interface{}) {
-	for _, v := range items.([]interface{}) {
+func fillNameComponentMap(m map[string]any, wrappedItems any) {
+	for _, wrappedItem := range wrappedItems.([]any) {
 		// This map always has a single key - wrapper so this is O(1) not O(n).
-		for _, v := range v.(map[string]interface{}) {
-			component := v.(map[string]interface{})
+		for _, item := range wrappedItem.(map[string]any) {
+			component := item.(map[string]any)
 			if name, ok := component["name"]; ok {
-				m[name.(string)] = v
+				if n, ok := name.(string); ok {
+					m[n] = item
+				}
 			}
 			if items, ok := component["items"]; ok {
 				fillNameComponentMap(m, items)

--- a/card.go
+++ b/card.go
@@ -65,7 +65,9 @@ func loadCard(ns *Namespace, c CardD) *Card {
 			}
 		}
 		if k == "items" || k == "secondary_items" || k == "buttons" {
-			card.nameComponentMap = make(map[string]interface{})
+			if card.nameComponentMap == nil {
+				card.nameComponentMap = make(map[string]interface{})
+			}
 			fillNameComponentMap(card.nameComponentMap, v)
 		}
 		ks[0] = k

--- a/go.mod
+++ b/go.mod
@@ -1,15 +1,22 @@
 module github.com/h2oai/wave
 
-go 1.15
+go 1.19
 
 require (
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/google/uuid v1.1.2
 	github.com/gorilla/websocket v1.4.2
-	github.com/hashicorp/golang-lru v0.5.4 // indirect
-	github.com/lo5/sqlite3 v0.1.0 // indirect
-	github.com/pquerna/cachecontrol v0.0.0-20200921180117-858c6e7e6b7e // indirect
+	github.com/hashicorp/golang-lru v0.5.4
+	github.com/lo5/sqlite3 v0.1.0
 	golang.org/x/crypto v0.0.0-20201012173705-84dcc777aaee
 	golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43
+)
+
+require (
+	github.com/golang/protobuf v1.4.2 // indirect
+	github.com/pquerna/cachecontrol v0.0.0-20200921180117-858c6e7e6b7e // indirect
+	golang.org/x/net v0.0.0-20200822124328-c89045814202 // indirect
+	google.golang.org/appengine v1.6.6 // indirect
+	google.golang.org/protobuf v1.25.0 // indirect
 	gopkg.in/square/go-jose.v2 v2.5.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,7 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/coreos/go-oidc v2.2.1+incompatible h1:mh48q/BqXqgjVHpy2ZY7WnWAbenxRjsz9N1i1YxjHAk=
 github.com/coreos/go-oidc v2.2.1+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHoZ1nMCKZlZ9V6mm3/LKc=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -72,6 +73,7 @@ github.com/golang/protobuf v1.4.0-rc.2/go.mod h1:LlEzMj4AhA7rCAGe4KMBDvJI+AwstrU
 github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0/go.mod h1:WU3c8KckQ9AFe+yFwt9sWVRKCVIyN9cPHBJSNnbL67w=
 github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvqG2KuDX0=
 github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QDs8UjoX8=
+github.com/golang/protobuf v1.4.2 h1:+Z5KGCizgyZCbGh1KZqA0fcLLkwbsjIzS4aV2v7wJX0=
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
@@ -81,6 +83,7 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.1 h1:JFrFEBb2xKufg6XkJsJr+WbKb4FQlURi5RUcBveYu9k=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
@@ -111,6 +114,7 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/lo5/sqlite3 v0.1.0 h1:mjM6n1DPRPKotAN3/DZgN0UOTlU0xL9n4jZ3LliWDGQ=
 github.com/lo5/sqlite3 v0.1.0/go.mod h1:bld1oUU4buWPOuyyJfmLL+t02pmJY9qMCTpYK8PrhOs=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pquerna/cachecontrol v0.0.0-20200921180117-858c6e7e6b7e h1:BLqxdwZ6j771IpSCRx7s/GJjXHUE00Hmu7/YegCGdzA=
 github.com/pquerna/cachecontrol v0.0.0-20200921180117-858c6e7e6b7e/go.mod h1:hoLfEwdY11HjRfKFH6KqnPsfxlo3BP6bJehpDv8t6sQ=
@@ -118,6 +122,7 @@ github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -282,6 +287,7 @@ golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=
@@ -304,6 +310,7 @@ google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.6.1/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
+google.golang.org/appengine v1.6.6 h1:lMO5rYAqUxkmaj76jAkRUvt5JZgFymx/+Q5Mzfivuhc=
 google.golang.org/appengine v1.6.6/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
@@ -355,6 +362,7 @@ google.golang.org/protobuf v1.22.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
+google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4c=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
@@ -362,6 +370,7 @@ gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/square/go-jose.v2 v2.5.1 h1:7odma5RETjNHWJnR32wx8t+Io4djHE1PqxCFx3iiZ2w=
 gopkg.in/square/go-jose.v2 v2.5.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/py/examples/counter_broadcast.py
+++ b/py/examples/counter_broadcast.py
@@ -2,22 +2,22 @@
 # Launch the server in #broadcast #mode to synchronize browser state across users.
 # Open `/demo` in multiple browsers and watch them synchronize in realtime.
 # ---
-from h2o_wave import main, app, Q, ui, pack
+from h2o_wave import main, app, Q, ui
 
 
 @app('/demo', mode='broadcast')
 async def serve(q: Q):
-    count = q.app.count or 0
-    if 'increment' in q.args:
-        count += 1
-        q.app.count = count
+    if not q.client.initialized:
+        if q.app.count is None:
+            q.app.count = 0
 
-    items = pack([ui.button(name='increment', label=f'Count={count}')])
+        q.page['example'] = ui.form_card(box='1 1 2 1', items=[
+            ui.button(name='increment', label=f'Count={q.app.count}')
+        ])
+        q.client.initialized = True
 
-    if count > 0:
-        form = q.page['example']
-        form.items = items
-    else:
-        q.page['example'] = ui.form_card(box='1 1 2 1', items=items)
+    if q.args.increment:
+        q.app.count += 1
+        q.page['example'].increment.label = f'Count={q.app.count}'
 
     await q.page.save()

--- a/py/examples/counter_multicast.py
+++ b/py/examples/counter_multicast.py
@@ -2,22 +2,22 @@
 # Launch the server in #multicast #mode to synchronize browser state across a user's clients.
 # Open `/demo` in multiple browsers and watch them synchronize in realtime.
 # ---
-from h2o_wave import main, app, Q, ui, pack
+from h2o_wave import main, app, Q, ui
 
 
 @app('/demo', mode='multicast')
 async def serve(q: Q):
-    count = q.user.count or 0
-    if 'increment' in q.args:
-        count += 1
-        q.user.count = count
+    if not q.client.initialized:
+        if q.user.count is None:
+            q.user.count = 0
 
-    items = pack([ui.button(name='increment', label=f'Count={count}')])
+        q.page['example'] = ui.form_card(box='1 1 2 1', items=[
+            ui.button(name='increment', label=f'Count={q.user.count}')
+        ])
+        q.client.initialized = True
 
-    if count > 0:
-        form = q.page['example']
-        form.items = items
-    else:
-        q.page['example'] = ui.form_card(box='1 1 2 1', items=items)
+    if q.args.increment:
+        q.user.count += 1
+        q.page['example'].increment.label = f'Count={q.user.count}'
 
     await q.page.save()

--- a/py/examples/counter_unicast.py
+++ b/py/examples/counter_unicast.py
@@ -6,16 +6,15 @@ from h2o_wave import main, app, Q, ui
 
 @app('/demo')
 async def serve(q: Q):
-    count = q.client.count or 0
-
     if not q.client.initialized:
+        q.client.count = 0
         q.page['example'] = ui.form_card(box='1 1 2 1', items=[
-            ui.button(name='increment', label=f'Count={count}')
+            ui.button(name='increment', label=f'Count={q.client.count}')
         ])
         q.client.initialized = True
 
     if q.args.increment:
-        q.client.count = count = count + 1
-        q.page['example'].items[0].button.label = f'Count={count}'
+        q.client.count += 1
+        q.page['example'].increment.label = f'Count={q.client.count}'
 
     await q.page.save()

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -735,8 +735,7 @@ const
     return null
   },
   fillComponentNameMap = (nameComponentMap: Dict<any>, items: any) => {
-    for (let i = 0; i < items.length; i++) {
-      const item = items[i]
+    for (const item of items) {
       const component = item[Object.keys(item)[0]]
       if (component.name) nameComponentMap[component.name] = component
       if (component.items) fillComponentNameMap(nameComponentMap, component.items)

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -698,9 +698,10 @@ const
           default:
             {
               let x: any = data
-              const p = ks[ks.length - 1]
-              for (const k of ks.slice(0, ks.length - 1)) x = gget(x, k)
-              gset(x, p, v)
+              if (ks.length === 2) x = extractFormObj(data, ks[0])
+              if (x === data) for (const k of ks.slice(0, ks.length - 1)) x = gget(x, k)
+              const prop = ks[ks.length - 1]
+              gset(x, prop, v)
               return
             }
         }
@@ -729,6 +730,23 @@ const
       if (!isNaN(i) && i >= 0 && i < x.length) return x[i]
     }
     return null
+  },
+  extractFormObj = (data: any, name: S) => {
+    const items = []
+    if (data['items']) items.push(...data['items'])
+    if (data['secondary_items']) items.push(...data['secondary_items'])
+    if (data['buttons']) items.push(...data['buttons'])
+
+    // Perf: Maybe worth storing a map of name -> component instead of an array.
+    for (let i = 0; i < items.length; i++) {
+      const item = items[i]
+      const component = item[Object.keys(item)[0]]
+      if (component.name === name) return component
+      if (component.items || component.secondary_items || component.buttons) {
+        const result: unknown = extractFormObj(component, name)
+        if (result) return result
+      }
+    }
   },
   newPage = (): XPage => {
     let dirty = false, dirties: Dict<B> = {}

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -701,6 +701,7 @@ const
             {
               let x: any = data
               if (ks.length === 2 && componentCache[ks[0]]) x = componentCache[ks[0]]
+              // DEPRECATED: Access via page.items[idx].wrapper.prop.
               else for (const k of ks.slice(0, ks.length - 1)) x = gget(x, k)
               const prop = ks[ks.length - 1]
               gset(x, prop, v)


### PR DESCRIPTION
Allows for:

```py
from h2o_wave import Q, ui, main, app


@app('/')
async def serve(q: Q):
    q.page['wizard'] = ui.form_card(box='1 1 2 4', items=[
        ui.text_xl(name='text_name', content='Wizard'),
        ui.textbox(name='textbox_name', label='Textbox'),
        ui.inline(items=[
            ui.button(name='back', label='Back'),
        ]),
    ])
    # Instead of q.page['wizard'].items[0].text_xl.content = 'foo'
    q.page['wizard'].text_name.content = 'foo'
    q.page['wizard'].textbox_name.label = 'foo'
    q.page['wizard'].back.label = 'foo'

    q.page['header'] = ui.header_card(box='4 6 4 1', title='Header', subtitle='Subtitle', secondary_items=[
        ui.button(name='button_name', label='Button'),
    ])
    q.page['header'].button_name.label = 'foo'

    q.page['example'] = ui.form_card(box='5 1 4 5', items=[
        ui.buttons([
            ui.button(name='primary_button', label='Primary', primary=True),
        ]),
    ])
    q.page['example'].primary_button.label = 'foo'

    await q.page.save()

```

## Needs discussion

> issue description: Requires modification to server-side interpreter.

@lo5 can you elaborate what you meant here? AFAIU, the whole UI state is stored client-side meaning, there is not much to be done at the server-side interpreter unless I am missing something. Apart from [guarding the accessors](https://github.com/h2oai/wave/blob/82868c1157df4e679d6052cc189c6dc643ec03f8/py/h2o_wave/h2o_wave/core.py#L289).

> page[, 'upload_progress'].caption = 'foo' # Scans all cards on page for upload_progress
page[, 'stats_table', 'search_bar'].caption = 'foo' # Scans all cards on page for search_bar inside stat_table

Wondering whether these would be useful - cc @Far0n @pascal-pfeiffer @vopani @srini-x for feedback.



Closes #148