### PR TITLE
feat: Allow specifying '1' for height in copyable text to fill the remaining space

### DIFF
--- a/py/examples/copyable_text.py
+++ b/py/examples/copyable_text.py
@@ -18,10 +18,11 @@ Like having a big height textbox!
 Woohoo!'''
 page = site['/demo']
 
-page['hello'] = ui.form_card(box='1 1 3 6', items=[
+page['hello'] = ui.form_card(box='1 1 3 10', items=[
     ui.copyable_text(label='Copyable text', value='Hello world!'),
     ui.copyable_text(label='Multiline Copyable text', value=multiline_content, multiline=True),
     ui.copyable_text(label='Multiline Copyable text with height=200px', value=big_multiline_content, multiline=True, height='200px'),
+    ui.copyable_text(label='Multiline Copyable text filling remaining card space', value=big_multiline_content, multiline=True, height='1'),
 ])
 
 page.save()

--- a/py/h2o_lightwave/h2o_lightwave/types.py
+++ b/py/h2o_lightwave/h2o_lightwave/types.py
@@ -6870,7 +6870,7 @@ class CopyableText:
         self.multiline = multiline
         """True if the component should allow multi-line text entry."""
         self.height = height
-        """Custom height in px, e.g. '200px'. Requires `multiline` to be set."""
+        """Custom height in px (e.g. '200px') or use '1' to fill the remaining card space. Requires `multiline` to be set."""
 
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""

--- a/py/h2o_lightwave/h2o_lightwave/types.py
+++ b/py/h2o_lightwave/h2o_lightwave/types.py
@@ -6870,7 +6870,7 @@ class CopyableText:
         self.multiline = multiline
         """True if the component should allow multi-line text entry."""
         self.height = height
-        """Custom height in px (e.g. '200px') or use '1' to fill the remaining card space. Requires `multiline` to be set."""
+        """Custom height in px (e.g. '200px') or '1' to fill the remaining card space. Requires `multiline` to be set."""
 
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""

--- a/py/h2o_lightwave/h2o_lightwave/ui.py
+++ b/py/h2o_lightwave/h2o_lightwave/ui.py
@@ -2548,7 +2548,7 @@ def copyable_text(
         label: The text displayed above the textbox.
         name: An identifying name for this component.
         multiline: True if the component should allow multi-line text entry.
-        height: Custom height in px, e.g. '200px'. Requires `multiline` to be set.
+        height: Custom height in px (e.g. '200px') or use '1' to fill the remaining card space. Requires `multiline` to be set.
     Returns:
         A `h2o_wave.types.CopyableText` instance.
     """

--- a/py/h2o_lightwave/h2o_lightwave/ui.py
+++ b/py/h2o_lightwave/h2o_lightwave/ui.py
@@ -2548,7 +2548,7 @@ def copyable_text(
         label: The text displayed above the textbox.
         name: An identifying name for this component.
         multiline: True if the component should allow multi-line text entry.
-        height: Custom height in px (e.g. '200px') or use '1' to fill the remaining card space. Requires `multiline` to be set.
+        height: Custom height in px (e.g. '200px') or '1' to fill the remaining card space. Requires `multiline` to be set.
     Returns:
         A `h2o_wave.types.CopyableText` instance.
     """

--- a/py/h2o_wave/h2o_wave/types.py
+++ b/py/h2o_wave/h2o_wave/types.py
@@ -6870,7 +6870,7 @@ class CopyableText:
         self.multiline = multiline
         """True if the component should allow multi-line text entry."""
         self.height = height
-        """Custom height in px, e.g. '200px'. Requires `multiline` to be set."""
+        """Custom height in px (e.g. '200px') or use '1' to fill the remaining card space. Requires `multiline` to be set."""
 
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""

--- a/py/h2o_wave/h2o_wave/types.py
+++ b/py/h2o_wave/h2o_wave/types.py
@@ -6870,7 +6870,7 @@ class CopyableText:
         self.multiline = multiline
         """True if the component should allow multi-line text entry."""
         self.height = height
-        """Custom height in px (e.g. '200px') or use '1' to fill the remaining card space. Requires `multiline` to be set."""
+        """Custom height in px (e.g. '200px') or '1' to fill the remaining card space. Requires `multiline` to be set."""
 
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""

--- a/py/h2o_wave/h2o_wave/ui.py
+++ b/py/h2o_wave/h2o_wave/ui.py
@@ -2548,7 +2548,7 @@ def copyable_text(
         label: The text displayed above the textbox.
         name: An identifying name for this component.
         multiline: True if the component should allow multi-line text entry.
-        height: Custom height in px, e.g. '200px'. Requires `multiline` to be set.
+        height: Custom height in px (e.g. '200px') or use '1' to fill the remaining card space. Requires `multiline` to be set.
     Returns:
         A `h2o_wave.types.CopyableText` instance.
     """

--- a/py/h2o_wave/h2o_wave/ui.py
+++ b/py/h2o_wave/h2o_wave/ui.py
@@ -2548,7 +2548,7 @@ def copyable_text(
         label: The text displayed above the textbox.
         name: An identifying name for this component.
         multiline: True if the component should allow multi-line text entry.
-        height: Custom height in px (e.g. '200px') or use '1' to fill the remaining card space. Requires `multiline` to be set.
+        height: Custom height in px (e.g. '200px') or '1' to fill the remaining card space. Requires `multiline` to be set.
     Returns:
         A `h2o_wave.types.CopyableText` instance.
     """

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -2956,7 +2956,7 @@ ui_facepile <- function(
 #' @param label The text displayed above the textbox.
 #' @param name An identifying name for this component.
 #' @param multiline True if the component should allow multi-line text entry.
-#' @param height Custom height in px, e.g. '200px'. Requires `multiline` to be set.
+#' @param height Custom height in px (e.g. '200px') or use '1' to fill the remaining card space. Requires `multiline` to be set.
 #' @return A CopyableText instance.
 #' @export
 ui_copyable_text <- function(

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -2956,7 +2956,7 @@ ui_facepile <- function(
 #' @param label The text displayed above the textbox.
 #' @param name An identifying name for this component.
 #' @param multiline True if the component should allow multi-line text entry.
-#' @param height Custom height in px (e.g. '200px') or use '1' to fill the remaining card space. Requires `multiline` to be set.
+#' @param height Custom height in px (e.g. '200px') or '1' to fill the remaining card space. Requires `multiline` to be set.
 #' @return A CopyableText instance.
 #' @export
 ui_copyable_text <- function(

--- a/ui/src/copyable_text.tsx
+++ b/ui/src/copyable_text.tsx
@@ -1,48 +1,48 @@
 import * as Fluent from '@fluentui/react'
 import { B, S, U } from 'h2o-wave'
 import React from 'react'
-import { stylesheet } from 'typestyle'
+import { style, stylesheet } from 'typestyle'
 import { clas, cssVar, pc } from './theme'
 
-const css = stylesheet({
-  multiContainer: {
-    position: 'relative',
-    $nest: {
-      '&:hover > button': {
-        opacity: 1
+const
+  css = stylesheet({
+    multiContainer: {
+      position: 'relative',
+      $nest: {
+        '&:hover > button': {
+          opacity: 1
+        }
+      }
+    },
+    fullHeight: {
+      display: 'flex',
+      flexGrow: 1,
+      flexDirection: 'column',
+    },
+    compactContainer: {
+      position: 'relative',
+    },
+    btnMultiline: {
+      opacity: 0,
+      transition: 'opacity .5s'
+    },
+    btn: {
+      minWidth: 'initial',
+      position: 'absolute',
+      top: 31,
+      right: 4,
+      width: 24,
+      height: 24
+    },
+    copiedBtn: {
+      background: cssVar('$green'),
+      $nest: {
+        '&:hover': {
+          background: cssVar('$green'),
+        }
       }
     }
-  },
-  fullHeight: {
-    display: 'flex',
-    flexGrow: 1,
-    flexDirection: 'column',
-    resize: 'none',
-  },
-  compactContainer: {
-    position: 'relative',
-  },
-  btnMultiline: {
-    opacity: 0,
-    transition: 'opacity .5s'
-  },
-  btn: {
-    minWidth: 'initial',
-    position: 'absolute',
-    top: 31,
-    right: 4,
-    width: 24,
-    height: 24
-  },
-  copiedBtn: {
-    background: cssVar('$green'),
-    $nest: {
-      '&:hover': {
-        background: cssVar('$green'),
-      }
-    }
-  }
-})
+  })
 
 /**
  * Create a copyable text component.
@@ -99,7 +99,7 @@ export const XCopyableText = ({ model }: { model: CopyableText }) => {
         styles={{
           root: { width: pc(100) },
           wrapper: fullHeightStyle,
-          field: isHeightSet ? fullHeightStyle || { height: height } : '',
+          field: clas(style({ resize: 'vertical' }), isHeightSet ? fullHeightStyle || style({ height: height }) : ''),
           fieldGroup: isHeightSet ? fullHeightStyle || { minHeight: height } : ''
         }}
         readOnly

--- a/ui/src/copyable_text.tsx
+++ b/ui/src/copyable_text.tsx
@@ -13,6 +13,17 @@ const css = stylesheet({
       }
     }
   },
+  fullHeight: {
+    display: 'flex',
+    flexGrow: 1,
+    flexDirection: 'column',
+    resize: 'none',
+  },
+  textFieldRoot: {
+    width: pc(100),
+    display: 'flex',
+    flexDirection: 'column'
+  },
   compactContainer: {
     position: 'relative',
   },
@@ -51,13 +62,15 @@ export interface CopyableText {
   name?: S
   /** True if the component should allow multi-line text entry. */
   multiline?: B
-  /** Custom height in px, e.g. '200px'. Requires `multiline` to be set. */
+  /** Custom height in px (e.g. '200px') or use '1' to fill the remaining card space. Requires `multiline` to be set. */
   height?: S
 }
 
 export const XCopyableText = ({ model }: { model: CopyableText }) => {
   const
     { name, multiline, label, value, height } = model,
+    isHeight = multiline && height,
+    fullHeightStyle = isHeight && height === '1' ? css.fullHeight : '',
     ref = React.useRef<Fluent.ITextField>(null),
     timeoutRef = React.useRef<U>(),
     [copied, setCopied] = React.useState(false),
@@ -81,13 +94,19 @@ export const XCopyableText = ({ model }: { model: CopyableText }) => {
   React.useEffect(() => () => window.clearTimeout(timeoutRef.current), [])
 
   return (
-    <div data-test={name} className={multiline ? css.multiContainer : css.compactContainer}>
+    <div data-test={name} className={multiline ? clas(css.multiContainer, fullHeightStyle) : css.compactContainer}>
       <Fluent.TextField
         componentRef={ref}
         value={value}
         label={label}
         multiline={multiline}
-        styles={{ root: { width: pc(100) }, fieldGroup: multiline && height ? { minHeight: height } : undefined }}
+        className={fullHeightStyle}
+        styles={{
+          root: css.textFieldRoot,
+          wrapper: fullHeightStyle,
+          field: isHeight ? fullHeightStyle || { height: height } : '',
+          fieldGroup: isHeight ? fullHeightStyle || { minHeight: height } : ''
+        }}
         readOnly
       />
       <Fluent.PrimaryButton

--- a/ui/src/copyable_text.tsx
+++ b/ui/src/copyable_text.tsx
@@ -62,7 +62,7 @@ export interface CopyableText {
   name?: S
   /** True if the component should allow multi-line text entry. */
   multiline?: B
-  /** Custom height in px (e.g. '200px') or use '1' to fill the remaining card space. Requires `multiline` to be set. */
+  /** Custom height in px (e.g. '200px') or '1' to fill the remaining card space. Requires `multiline` to be set. */
   height?: S
 }
 

--- a/ui/src/copyable_text.tsx
+++ b/ui/src/copyable_text.tsx
@@ -1,7 +1,7 @@
 import * as Fluent from '@fluentui/react'
 import { B, S, U } from 'h2o-wave'
 import React from 'react'
-import { style, stylesheet } from 'typestyle'
+import { stylesheet } from 'typestyle'
 import { clas, cssVar, pc } from './theme'
 
 const
@@ -13,11 +13,6 @@ const
           opacity: 1
         }
       }
-    },
-    fullHeight: {
-      display: 'flex',
-      flexGrow: 1,
-      flexDirection: 'column',
     },
     compactContainer: {
       position: 'relative',
@@ -42,7 +37,12 @@ const
         }
       }
     }
-  })
+  }),
+  fullHeightStyle = {
+    display: 'flex',
+    flexGrow: 1,
+    flexDirection: 'column',
+  }
 
 /**
  * Create a copyable text component.
@@ -64,8 +64,7 @@ export interface CopyableText {
 export const XCopyableText = ({ model }: { model: CopyableText }) => {
   const
     { name, multiline, label, value, height } = model,
-    isHeightSet = multiline && height,
-    fullHeightStyle = isHeightSet && height === '1' ? css.fullHeight : '',
+    heightStyle = multiline && height === '1' ? fullHeightStyle : undefined,
     ref = React.useRef<Fluent.ITextField>(null),
     timeoutRef = React.useRef<U>(),
     [copied, setCopied] = React.useState(false),
@@ -89,18 +88,21 @@ export const XCopyableText = ({ model }: { model: CopyableText }) => {
   React.useEffect(() => () => window.clearTimeout(timeoutRef.current), [])
 
   return (
-    <div data-test={name} className={multiline ? clas(css.multiContainer, fullHeightStyle) : css.compactContainer}>
+    <div
+      data-test={name}
+      className={multiline ? css.multiContainer : css.compactContainer}
+      style={heightStyle as React.CSSProperties}
+    >
       <Fluent.TextField
         componentRef={ref}
         value={value}
         label={label}
         multiline={multiline}
-        className={fullHeightStyle}
         styles={{
-          root: { width: pc(100) },
-          wrapper: fullHeightStyle,
-          field: clas(style({ resize: 'vertical' }), isHeightSet ? fullHeightStyle || style({ height: height }) : ''),
-          fieldGroup: isHeightSet ? fullHeightStyle || { minHeight: height } : ''
+          root: { ...heightStyle, width: pc(100) },
+          wrapper: heightStyle,
+          fieldGroup: heightStyle || { minHeight: height },
+          field: { ...heightStyle, height, resize: multiline ? 'vertical' : 'none', },
         }}
         readOnly
       />

--- a/ui/src/copyable_text.tsx
+++ b/ui/src/copyable_text.tsx
@@ -19,11 +19,6 @@ const css = stylesheet({
     flexDirection: 'column',
     resize: 'none',
   },
-  textFieldRoot: {
-    width: pc(100),
-    display: 'flex',
-    flexDirection: 'column'
-  },
   compactContainer: {
     position: 'relative',
   },
@@ -69,8 +64,8 @@ export interface CopyableText {
 export const XCopyableText = ({ model }: { model: CopyableText }) => {
   const
     { name, multiline, label, value, height } = model,
-    isHeight = multiline && height,
-    fullHeightStyle = isHeight && height === '1' ? css.fullHeight : '',
+    isHeightSet = multiline && height,
+    fullHeightStyle = isHeightSet && height === '1' ? css.fullHeight : '',
     ref = React.useRef<Fluent.ITextField>(null),
     timeoutRef = React.useRef<U>(),
     [copied, setCopied] = React.useState(false),
@@ -102,10 +97,10 @@ export const XCopyableText = ({ model }: { model: CopyableText }) => {
         multiline={multiline}
         className={fullHeightStyle}
         styles={{
-          root: css.textFieldRoot,
+          root: { width: pc(100) },
           wrapper: fullHeightStyle,
-          field: isHeight ? fullHeightStyle || { height: height } : '',
-          fieldGroup: isHeight ? fullHeightStyle || { minHeight: height } : ''
+          field: isHeightSet ? fullHeightStyle || { height: height } : '',
+          fieldGroup: isHeightSet ? fullHeightStyle || { minHeight: height } : ''
         }}
         readOnly
       />

--- a/website/widgets/form/copyable_text.md
+++ b/website/widgets/form/copyable_text.md
@@ -41,10 +41,13 @@ Note: The set height will only take effect if `multiline` is set to `True`.
 ```py
 multiline_content = '''Wave is truly awesome.
 You should try all the features!
-Like setting the height to 200px!'''
+Like having a big textbox!'''
 
 q.page['form'] = ui.form_card(
-    box='1 1 2 4',
-    items=[ui.copyable_text(label='Copyable text', value=multiline_content, multiline=True, height='200px')]
+    box='1 1 2 8',
+    items=[
+        ui.copyable_text(label='Copyable text', value=multiline_content, multiline=True, height='200px'),
+        ui.copyable_text(label='Copyable text', value=multiline_content, multiline=True, height='1')
+    ]
 )
 ```

--- a/website/widgets/form/copyable_text.md
+++ b/website/widgets/form/copyable_text.md
@@ -35,7 +35,7 @@ q.page['form'] = ui.form_card(
 
 ## Height of copyable text
 
-If you want to adjust the height of the copyable textbox, set the `height` attribute to your desired height in pixels, e.g. `'200px'`.
+If you want to adjust the height of the copyable textbox, set the `height` attribute to your desired height in pixels (e.g. `'200px'`) or use `1` to fill the remaining card space.
 Note: The set height will only take effect if `multiline` is set to `True`.
 
 ```py

--- a/website/widgets/form/copyable_text.md
+++ b/website/widgets/form/copyable_text.md
@@ -36,7 +36,7 @@ q.page['form'] = ui.form_card(
 ## Height of copyable text
 
 If you want to adjust the height of the copyable textbox, set the `height` attribute to your desired height in pixels (e.g. `'200px'`) or use `1` to fill the remaining card space.
-Note: The set height will only take effect if `multiline` is set to `True`.
+The height will only take effect if `multiline` is set to `True`.
 
 ```py
 multiline_content = '''Wave is truly awesome.


### PR DESCRIPTION
Updated API description:
```ts
export interface CopyableText {
  /** Text to be displayed inside the component. */
  value: S
  /** The text displayed above the textbox. */
  label: S
  /** An identifying name for this component. */
  name?: S
  /** True if the component should allow multi-line text entry. */
  multiline?: B
  /** Custom height in px (e.g. '200px') or use '1' to fill the remaining card space. Requires `multiline` to be set. */
  height?: S
}
```

Closes #1823