### PR TITLE
fix: Update wave args of ui.time_picker on every time change #1889

### DIFF
--- a/ui/src/time_picker.test.tsx
+++ b/ui/src/time_picker.test.tsx
@@ -53,6 +53,16 @@ describe('time_picker.tsx', () => {
     expect(wave.args[name]).toBe('10:30')
   })
 
+  it('Update args on time change', async () => {
+    const { getByText, container } = render(<XTimePicker model={{ ...timepickerProps, value: '04:00' }} />)
+    await waitForIdleEventLoop()
+    expect(wave.args[name]).toBe('04:00')
+    fireEvent.click(container.querySelector("input")!)
+    fireEvent.click(getByText('AM')) // switches to PM
+    await waitForIdleEventLoop()
+    expect(wave.args[name]).toBe('16:00')
+  })
+
   it('Show correct input value in 12 hour time format', async () => {
     const { getByDisplayValue } = render(<XTimePicker model={{ ...timepickerProps, value: '14:30' }} />)
     await waitForIdleEventLoop()

--- a/ui/src/time_picker.tsx
+++ b/ui/src/time_picker.tsx
@@ -148,10 +148,11 @@ export const
           return date
         })
       },
-      onSelectTime = (time: D | null) => {
+      onChangeTime = (time: D | null) => {
         wave.args[m.name] = time ? formatDateToTimeString(time, '24') : null
-        if (m.trigger) wave.push()
+        setValue(time)
       },
+      onSelectTime = () => { if (m.trigger) wave.push() },
       // HACK: https://stackoverflow.com/questions/70106353/material-ui-date-time-picker-safari-browser-issue
       onOpen = () => setTimeout(() => (document.activeElement as HTMLElement)?.blur()),
       onBlur = (ev: React.FocusEvent) => {
@@ -212,8 +213,8 @@ export const
                 value={value}
                 label={label}
                 open={isDialogOpen}
-                onChange={value => setValue(value as Date)}
-                onAccept={value => onSelectTime(value as Date)}
+                onChange={value => onChangeTime(value as Date)}
+                onAccept={onSelectTime}
                 onClose={() => setIsDialogOpen(false)}
                 ampm={hour_format === '12'}
                 showToolbar

--- a/ui/src/time_picker.tsx
+++ b/ui/src/time_picker.tsx
@@ -145,12 +145,15 @@ export const
         setValue((prevValue) => {
           const date = new Date(prevValue!)
           date.setTime(date.getTime() + 12 * 60 * 60 * 1000)
+          wave.args[m.name] = formatDateToTimeString(date, '24')
           return date
         })
       },
-      onChangeTime = (time: D | null) => {
-        wave.args[m.name] = time ? formatDateToTimeString(time, '24') : null
-        setValue(time)
+      onChangeTime = (time: unknown) => {
+        if (time instanceof Date) {
+          wave.args[m.name] = formatDateToTimeString(time, '24')
+          setValue(time)
+        }
       },
       onSelectTime = () => { if (m.trigger) wave.push() },
       // HACK: https://stackoverflow.com/questions/70106353/material-ui-date-time-picker-safari-browser-issue
@@ -213,7 +216,7 @@ export const
                 value={value}
                 label={label}
                 open={isDialogOpen}
-                onChange={value => onChangeTime(value as Date)}
+                onChange={onChangeTime}
                 onAccept={onSelectTime}
                 onClose={() => setIsDialogOpen(false)}
                 ampm={hour_format === '12'}


### PR DESCRIPTION
Updating of wave args if now moved from time picker's `onAccept` to `onChange` to make sure it is updated every time user changes the time, not only on popup close.

Closes #1889 