### PR TITLE
fix: Prevent copy button from overlapping multiline labels in ui.copyable_text

### DIFF
--- a/ui/src/copyable_text.test.tsx
+++ b/ui/src/copyable_text.test.tsx
@@ -28,10 +28,10 @@ describe('CopyableText.tsx', () => {
 
   it('Display new value when "value" prop changes', () => {
     const { getByTestId, rerender } = render(<XCopyableText model={{ ...copyableTextProps, value: 'A' }} />)
-    expect(getByTestId(name).querySelector('input')).toHaveValue('A')
+    expect(getByTestId(name)).toHaveValue('A')
 
     rerender(<XCopyableText model={{ ...copyableTextProps, value: 'B' }} />)
-    expect(getByTestId(name).querySelector('input')).toHaveValue('B')
+    expect(getByTestId(name)).toHaveValue('B')
   })
 
 })

--- a/ui/src/copyable_text.tsx
+++ b/ui/src/copyable_text.tsx
@@ -6,17 +6,6 @@ import { clas, cssVar, pc } from './theme'
 
 const
   css = stylesheet({
-    multiContainer: {
-      position: 'relative',
-      $nest: {
-        '&:hover button': {
-          opacity: 1
-        }
-      }
-    },
-    compactContainer: {
-      position: 'relative',
-    },
     btnMultiline: {
       opacity: 0,
       transition: 'opacity .5s'
@@ -37,12 +26,26 @@ const
           background: cssVar('$green'),
         }
       }
+    },
+    labelContainer: {
+      position: 'relative'
     }
   }),
-  fullHeightStyle = {
-    display: 'flex',
-    flexGrow: 1,
-    flexDirection: 'column',
+  styles: Fluent.IStyle = {
+    fullHeightStyle: {
+      display: 'flex',
+      flexGrow: 1,
+      flexDirection: 'column',
+    },
+    textFieldRoot: {
+      position: 'relative',
+      width: pc(100)
+    },
+    textFieldMultiline: {
+      '&:hover button': {
+        opacity: 1
+      }
+    }
   }
 
 /**
@@ -65,7 +68,7 @@ export interface CopyableText {
 export const XCopyableText = ({ model }: { model: CopyableText }) => {
   const
     { name, multiline, label, value, height } = model,
-    heightStyle = multiline && height === '1' ? fullHeightStyle : undefined,
+    heightStyle = multiline && height === '1' ? styles.fullHeightStyle : undefined,
     ref = React.useRef<Fluent.ITextField>(null),
     timeoutRef = React.useRef<U>(),
     [copied, setCopied] = React.useState(false),
@@ -96,7 +99,7 @@ export const XCopyableText = ({ model }: { model: CopyableText }) => {
       label={label}
       multiline={multiline}
       onRenderLabel={() =>
-        <div style={{ position: 'relative' }}>
+        <div className={css.labelContainer}>
           <Fluent.Label>{label}</Fluent.Label>
           <Fluent.PrimaryButton
             title='Copy to clipboard'
@@ -106,9 +109,12 @@ export const XCopyableText = ({ model }: { model: CopyableText }) => {
           />
         </div>
       }
-      className={multiline ? css.multiContainer : css.compactContainer}
       styles={{
-        root: { ...heightStyle, width: pc(100) },
+        root: {
+          ...heightStyle,
+          ...styles.textFieldRoot,
+          ...multiline ? styles.textFieldMultiline : undefined
+        },
         wrapper: heightStyle,
         fieldGroup: heightStyle || { minHeight: height },
         field: { ...heightStyle, height, resize: multiline ? 'vertical' : 'none', },

--- a/ui/src/copyable_text.tsx
+++ b/ui/src/copyable_text.tsx
@@ -31,21 +31,10 @@ const
       position: 'relative'
     }
   }),
-  styles: Fluent.IStyle = {
-    fullHeightStyle: {
-      display: 'flex',
-      flexGrow: 1,
-      flexDirection: 'column',
-    },
-    textFieldRoot: {
-      position: 'relative',
-      width: pc(100)
-    },
-    textFieldMultiline: {
-      '&:hover button': {
-        opacity: 1
-      }
-    }
+  fullHeightStyle = {
+    display: 'flex',
+    flexGrow: 1,
+    flexDirection: 'column',
   }
 
 /**
@@ -68,7 +57,7 @@ export interface CopyableText {
 export const XCopyableText = ({ model }: { model: CopyableText }) => {
   const
     { name, multiline, label, value, height } = model,
-    heightStyle = multiline && height === '1' ? styles.fullHeightStyle : undefined,
+    heightStyle = multiline && height === '1' ? fullHeightStyle : undefined,
     ref = React.useRef<Fluent.ITextField>(null),
     timeoutRef = React.useRef<U>(),
     [copied, setCopied] = React.useState(false),
@@ -96,7 +85,6 @@ export const XCopyableText = ({ model }: { model: CopyableText }) => {
       data-test={name}
       componentRef={ref}
       value={value}
-      label={label}
       multiline={multiline}
       onRenderLabel={() =>
         <div className={css.labelContainer}>
@@ -112,8 +100,8 @@ export const XCopyableText = ({ model }: { model: CopyableText }) => {
       styles={{
         root: {
           ...heightStyle,
-          ...styles.textFieldRoot,
-          ...multiline ? styles.textFieldMultiline : undefined
+          textFieldRoot: { position: 'relative', width: pc(100) },
+          textFieldMultiline: multiline ? { '&:hover button': { opacity: 1 } } : undefined
         },
         wrapper: heightStyle,
         fieldGroup: heightStyle || { minHeight: height },

--- a/ui/src/copyable_text.tsx
+++ b/ui/src/copyable_text.tsx
@@ -9,7 +9,7 @@ const
     multiContainer: {
       position: 'relative',
       $nest: {
-        '&:hover > button': {
+        '&:hover button': {
           opacity: 1
         }
       }
@@ -24,10 +24,11 @@ const
     btn: {
       minWidth: 'initial',
       position: 'absolute',
-      top: 31,
-      right: 4,
       width: 24,
-      height: 24
+      height: 24,
+      right: 0,
+      transform: 'translate(-4px, 4px)',
+      zIndex: 1,
     },
     copiedBtn: {
       background: cssVar('$green'),
@@ -88,30 +89,31 @@ export const XCopyableText = ({ model }: { model: CopyableText }) => {
   React.useEffect(() => () => window.clearTimeout(timeoutRef.current), [])
 
   return (
-    <div
+    <Fluent.TextField
       data-test={name}
+      componentRef={ref}
+      value={value}
+      label={label}
+      multiline={multiline}
+      onRenderLabel={() =>
+        <div style={{ position: 'relative' }}>
+          <Fluent.Label>{label}</Fluent.Label>
+          <Fluent.PrimaryButton
+            title='Copy to clipboard'
+            onClick={onClick}
+            iconProps={{ iconName: copied ? 'CheckMark' : 'Copy' }}
+            className={clas(css.btn, copied ? css.copiedBtn : '', multiline ? css.btnMultiline : '')}
+          />
+        </div>
+      }
       className={multiline ? css.multiContainer : css.compactContainer}
-      style={heightStyle as React.CSSProperties}
-    >
-      <Fluent.TextField
-        componentRef={ref}
-        value={value}
-        label={label}
-        multiline={multiline}
-        styles={{
-          root: { ...heightStyle, width: pc(100) },
-          wrapper: heightStyle,
-          fieldGroup: heightStyle || { minHeight: height },
-          field: { ...heightStyle, height, resize: multiline ? 'vertical' : 'none', },
-        }}
-        readOnly
-      />
-      <Fluent.PrimaryButton
-        title='Copy to clipboard'
-        onClick={onClick}
-        iconProps={{ iconName: copied ? 'CheckMark' : 'Copy' }}
-        className={clas(css.btn, copied ? css.copiedBtn : '', multiline ? css.btnMultiline : '')}
-      />
-    </div>
+      styles={{
+        root: { ...heightStyle, width: pc(100) },
+        wrapper: heightStyle,
+        fieldGroup: heightStyle || { minHeight: height },
+        field: { ...heightStyle, height, resize: multiline ? 'vertical' : 'none', },
+      }}
+      readOnly
+    />
   )
 }


### PR DESCRIPTION
This PR positions the copy button relative to label container instead of the textfield component. By this change the button is not overlapping the text in case of multiline labels.

![image](https://user-images.githubusercontent.com/23740173/225135132-bd1f15be-40df-45c5-9719-ca7a183f9de3.png)

Closes #1883