### PR TITLE
feat: Dropdown button #1887

### DIFF
--- a/py/examples/button.py
+++ b/py/examples/button.py
@@ -22,9 +22,9 @@ async def serve(q: Q):
             ui.text(f'button_with_icon={q.args.button_with_icon}'),
             ui.text(f'icon_button={q.args.icon_button}'),
             ui.text(f'external_path_button={q.args.external_path_button}'),
-            ui.text(f'choice_button={q.args.choice_button}'),
-            ui.text(f'choice_button:first_choice={q.args.first_choice}'),
-            ui.text(f'choice_button:second_choice={q.args.second_choice}'),
+            ui.text(f'command_button={q.args.command_button}'),
+            ui.text(f'command_button:first_command={q.args.first_command}'),
+            ui.text(f'command_button:second_command={q.args.second_command}'),
             ui.button(name='show_form', label='Back', primary=True),
         ]
     else:
@@ -44,9 +44,9 @@ async def serve(q: Q):
             ui.button(name='button_with_icon', label='Button with an icon', icon='Search'),
             ui.button(name='icon_button', icon='Heart', caption='Tooltip text'),
             ui.button(name='external_path_button', label='External', path='https://h2o.ai/'),
-            ui.button(name='choice_button', label='Button with choices', primary=True, choices=[
-                    ui.button_choice(name='first_choice', label='First choice'), 
-                    ui.button_choice(name='second_choice', label='Second choice'),
+            ui.button(name='command_button', label='Button with commands', primary=True, commands=[
+                    ui.command(name='first_command', label='First command'), 
+                    ui.command(name='second_command', label='Second command'),
                 ]
             ),
         ])

--- a/py/examples/button.py
+++ b/py/examples/button.py
@@ -44,9 +44,13 @@ async def serve(q: Q):
             ui.button(name='button_with_icon', label='Button with an icon', icon='Search'),
             ui.button(name='icon_button', icon='Heart', caption='Tooltip text'),
             ui.button(name='external_path_button', label='External', path='https://h2o.ai/'),
+            # TODO: Edit 
             ui.button(name='command_button', label='Button with commands', primary=True, commands=[
                     ui.command(name='first_command', label='First command'), 
-                    ui.command(name='second_command', label='Second command'),
+                    ui.command(name='second_command', label='Second command', icon="Heart", items=[
+                        ui.command(name='third_command', label='Third command'),
+                        ui.command(name='fourth_command', label='Fourth command', icon="Like"),  
+                    ]),
                 ]
             ),
         ])

--- a/py/examples/button.py
+++ b/py/examples/button.py
@@ -22,12 +22,13 @@ async def serve(q: Q):
             ui.text(f'button_with_icon={q.args.button_with_icon}'),
             ui.text(f'icon_button={q.args.icon_button}'),
             ui.text(f'external_path_button={q.args.external_path_button}'),
-            ui.text(f'command_button first_command={q.args.first_command}'),
-            ui.text(f'command_button second_command={q.args.second_command}'),
+            ui.text(f'choice_button={q.args.choice_button}'),
+            ui.text(f'choice_button:first_choice={q.args.first_choice}'),
+            ui.text(f'choice_button:second_choice={q.args.second_choice}'),
             ui.button(name='show_form', label='Back', primary=True),
         ]
     else:
-        q.page['example'] = ui.form_card(box='1 1 4 9', items=[
+        q.page['example'] = ui.form_card(box='1 1 4 10', items=[
             ui.button(name='basic_button', label='Basic'),
             ui.button(name='primary_button', label='Primary', primary=True),
             ui.button(name='link_button', label='Link', link=True),
@@ -43,9 +44,9 @@ async def serve(q: Q):
             ui.button(name='button_with_icon', label='Button with an icon', icon='Search'),
             ui.button(name='icon_button', icon='Heart', caption='Tooltip text'),
             ui.button(name='external_path_button', label='External', path='https://h2o.ai/'),
-            ui.button(name='command_button', label='Button with commands', primary=True, commands=[
-                    ui.button_command(name='first_command', label='First command'), 
-                    ui.button_command(name='second_command', label='Second command'),
+            ui.button(name='choice_button', label='Button with choices', primary=True, icon='Like', choices=[
+                    ui.button_choice(name='first_choice', label='First choice', icon='Heart'), 
+                    ui.button_choice(name='second_choice', label='Second choice', icon='Dislike'),
                 ]
             ),
         ])

--- a/py/examples/button.py
+++ b/py/examples/button.py
@@ -22,10 +22,12 @@ async def serve(q: Q):
             ui.text(f'button_with_icon={q.args.button_with_icon}'),
             ui.text(f'icon_button={q.args.icon_button}'),
             ui.text(f'external_path_button={q.args.external_path_button}'),
+            ui.text(f'command_button first_command={q.args.first_command}'),
+            ui.text(f'command_button second_command={q.args.second_command}'),
             ui.button(name='show_form', label='Back', primary=True),
         ]
     else:
-        q.page['example'] = ui.form_card(box='1 1 4 8', items=[
+        q.page['example'] = ui.form_card(box='1 1 4 9', items=[
             ui.button(name='basic_button', label='Basic'),
             ui.button(name='primary_button', label='Primary', primary=True),
             ui.button(name='link_button', label='Link', link=True),
@@ -41,5 +43,10 @@ async def serve(q: Q):
             ui.button(name='button_with_icon', label='Button with an icon', icon='Search'),
             ui.button(name='icon_button', icon='Heart', caption='Tooltip text'),
             ui.button(name='external_path_button', label='External', path='https://h2o.ai/'),
+            ui.button(name='command_button', label='Button with commands', primary=True, commands=[
+                    ui.button_command(name='first_command', label='First command'), 
+                    ui.button_command(name='second_command', label='Second command'),
+                ]
+            ),
         ])
     await q.page.save()

--- a/py/examples/button.py
+++ b/py/examples/button.py
@@ -44,13 +44,9 @@ async def serve(q: Q):
             ui.button(name='button_with_icon', label='Button with an icon', icon='Search'),
             ui.button(name='icon_button', icon='Heart', caption='Tooltip text'),
             ui.button(name='external_path_button', label='External', path='https://h2o.ai/'),
-            # TODO: Edit 
             ui.button(name='command_button', label='Button with commands', primary=True, commands=[
                     ui.command(name='first_command', label='First command'), 
-                    ui.command(name='second_command', label='Second command', icon="Heart", items=[
-                        ui.command(name='third_command', label='Third command'),
-                        ui.command(name='fourth_command', label='Fourth command', icon="Like"),  
-                    ]),
+                    ui.command(name='second_command', label='Second command'),
                 ]
             ),
         ])

--- a/py/examples/button.py
+++ b/py/examples/button.py
@@ -44,9 +44,9 @@ async def serve(q: Q):
             ui.button(name='button_with_icon', label='Button with an icon', icon='Search'),
             ui.button(name='icon_button', icon='Heart', caption='Tooltip text'),
             ui.button(name='external_path_button', label='External', path='https://h2o.ai/'),
-            ui.button(name='choice_button', label='Button with choices', primary=True, icon='Like', choices=[
-                    ui.button_choice(name='first_choice', label='First choice', icon='Heart'), 
-                    ui.button_choice(name='second_choice', label='Second choice', icon='Dislike'),
+            ui.button(name='choice_button', label='Button with choices', primary=True, choices=[
+                    ui.button_choice(name='first_choice', label='First choice'), 
+                    ui.button_choice(name='second_choice', label='Second choice'),
                 ]
             ),
         ])

--- a/py/h2o_lightwave/h2o_lightwave/types.py
+++ b/py/h2o_lightwave/h2o_lightwave/types.py
@@ -2722,7 +2722,7 @@ class Button:
         self.path = path
         """The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab."""
         self.commands = commands
-        """The menu with button actions."""
+        """The menu with button actions. Ignored if `link` is True."""
 
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""

--- a/py/h2o_lightwave/h2o_lightwave/types.py
+++ b/py/h2o_lightwave/h2o_lightwave/types.py
@@ -2571,6 +2571,85 @@ class ColorPicker:
         )
 
 
+class ButtonCommand:
+    """No documentation available.
+    """
+    def __init__(
+            self,
+            name: str,
+            label: Optional[str] = None,
+            caption: Optional[str] = None,
+            icon: Optional[str] = None,
+            value: Optional[str] = None,
+            path: Optional[str] = None,
+    ):
+        _guard_scalar('ButtonCommand.name', name, (str,), True, False, False)
+        _guard_scalar('ButtonCommand.label', label, (str,), False, True, False)
+        _guard_scalar('ButtonCommand.caption', caption, (str,), False, True, False)
+        _guard_scalar('ButtonCommand.icon', icon, (str,), False, True, False)
+        _guard_scalar('ButtonCommand.value', value, (str,), False, True, False)
+        _guard_scalar('ButtonCommand.path', path, (str,), False, True, False)
+        self.name = name
+        """An identifying name for this component. If the name is prefixed with a '#', the command sets the location hash to the name when executed."""
+        self.label = label
+        """The text displayed for this command."""
+        self.caption = caption
+        """The caption for this command (typically a tooltip)."""
+        self.icon = icon
+        """The icon to be displayed for this command."""
+        self.value = value
+        """Data associated with this command, if any."""
+        self.path = path
+        """The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab."""
+
+    def dump(self) -> Dict:
+        """Returns the contents of this object as a dict."""
+        _guard_scalar('ButtonCommand.name', self.name, (str,), True, False, False)
+        _guard_scalar('ButtonCommand.label', self.label, (str,), False, True, False)
+        _guard_scalar('ButtonCommand.caption', self.caption, (str,), False, True, False)
+        _guard_scalar('ButtonCommand.icon', self.icon, (str,), False, True, False)
+        _guard_scalar('ButtonCommand.value', self.value, (str,), False, True, False)
+        _guard_scalar('ButtonCommand.path', self.path, (str,), False, True, False)
+        return _dump(
+            name=self.name,
+            label=self.label,
+            caption=self.caption,
+            icon=self.icon,
+            value=self.value,
+            path=self.path,
+        )
+
+    @staticmethod
+    def load(__d: Dict) -> 'ButtonCommand':
+        """Creates an instance of this class using the contents of a dict."""
+        __d_name: Any = __d.get('name')
+        _guard_scalar('ButtonCommand.name', __d_name, (str,), True, False, False)
+        __d_label: Any = __d.get('label')
+        _guard_scalar('ButtonCommand.label', __d_label, (str,), False, True, False)
+        __d_caption: Any = __d.get('caption')
+        _guard_scalar('ButtonCommand.caption', __d_caption, (str,), False, True, False)
+        __d_icon: Any = __d.get('icon')
+        _guard_scalar('ButtonCommand.icon', __d_icon, (str,), False, True, False)
+        __d_value: Any = __d.get('value')
+        _guard_scalar('ButtonCommand.value', __d_value, (str,), False, True, False)
+        __d_path: Any = __d.get('path')
+        _guard_scalar('ButtonCommand.path', __d_path, (str,), False, True, False)
+        name: str = __d_name
+        label: Optional[str] = __d_label
+        caption: Optional[str] = __d_caption
+        icon: Optional[str] = __d_icon
+        value: Optional[str] = __d_value
+        path: Optional[str] = __d_path
+        return ButtonCommand(
+            name,
+            label,
+            caption,
+            icon,
+            value,
+            path,
+        )
+
+
 class Button:
     """Create a button.
 
@@ -2603,6 +2682,7 @@ class Button:
             visible: Optional[bool] = None,
             tooltip: Optional[str] = None,
             path: Optional[str] = None,
+            commands: Optional[List[ButtonCommand]] = None,
     ):
         _guard_scalar('Button.name', name, (str,), True, False, False)
         _guard_scalar('Button.label', label, (str,), False, True, False)
@@ -2616,6 +2696,7 @@ class Button:
         _guard_scalar('Button.visible', visible, (bool,), False, True, False)
         _guard_scalar('Button.tooltip', tooltip, (str,), False, True, False)
         _guard_scalar('Button.path', path, (str,), False, True, False)
+        _guard_vector('Button.commands', commands, (ButtonCommand,), False, True, False)
         self.name = name
         """An identifying name for this component. If the name is prefixed with a '#', the button sets the location hash to the name when clicked."""
         self.label = label
@@ -2640,6 +2721,8 @@ class Button:
         """An optional tooltip message displayed when a user clicks the help icon to the right of the component."""
         self.path = path
         """The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab."""
+        self.commands = commands
+        """The menu with button actions."""
 
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""
@@ -2655,6 +2738,7 @@ class Button:
         _guard_scalar('Button.visible', self.visible, (bool,), False, True, False)
         _guard_scalar('Button.tooltip', self.tooltip, (str,), False, True, False)
         _guard_scalar('Button.path', self.path, (str,), False, True, False)
+        _guard_vector('Button.commands', self.commands, (ButtonCommand,), False, True, False)
         return _dump(
             name=self.name,
             label=self.label,
@@ -2668,6 +2752,7 @@ class Button:
             visible=self.visible,
             tooltip=self.tooltip,
             path=self.path,
+            commands=None if self.commands is None else [__e.dump() for __e in self.commands],
         )
 
     @staticmethod
@@ -2697,6 +2782,8 @@ class Button:
         _guard_scalar('Button.tooltip', __d_tooltip, (str,), False, True, False)
         __d_path: Any = __d.get('path')
         _guard_scalar('Button.path', __d_path, (str,), False, True, False)
+        __d_commands: Any = __d.get('commands')
+        _guard_vector('Button.commands', __d_commands, (dict,), False, True, False)
         name: str = __d_name
         label: Optional[str] = __d_label
         caption: Optional[str] = __d_caption
@@ -2709,6 +2796,7 @@ class Button:
         visible: Optional[bool] = __d_visible
         tooltip: Optional[str] = __d_tooltip
         path: Optional[str] = __d_path
+        commands: Optional[List[ButtonCommand]] = None if __d_commands is None else [ButtonCommand.load(__e) for __e in __d_commands]
         return Button(
             name,
             label,
@@ -2722,6 +2810,7 @@ class Button:
             visible,
             tooltip,
             path,
+            commands,
         )
 
 

--- a/py/h2o_lightwave/h2o_lightwave/types.py
+++ b/py/h2o_lightwave/h2o_lightwave/types.py
@@ -2571,7 +2571,7 @@ class ColorPicker:
         )
 
 
-class ButtonCommand:
+class ButtonChoice:
     """No documentation available.
     """
     def __init__(
@@ -2582,13 +2582,15 @@ class ButtonCommand:
             icon: Optional[str] = None,
             value: Optional[str] = None,
             path: Optional[str] = None,
+            disabled: Optional[bool] = None,
     ):
-        _guard_scalar('ButtonCommand.name', name, (str,), True, False, False)
-        _guard_scalar('ButtonCommand.label', label, (str,), False, True, False)
-        _guard_scalar('ButtonCommand.caption', caption, (str,), False, True, False)
-        _guard_scalar('ButtonCommand.icon', icon, (str,), False, True, False)
-        _guard_scalar('ButtonCommand.value', value, (str,), False, True, False)
-        _guard_scalar('ButtonCommand.path', path, (str,), False, True, False)
+        _guard_scalar('ButtonChoice.name', name, (str,), True, False, False)
+        _guard_scalar('ButtonChoice.label', label, (str,), False, True, False)
+        _guard_scalar('ButtonChoice.caption', caption, (str,), False, True, False)
+        _guard_scalar('ButtonChoice.icon', icon, (str,), False, True, False)
+        _guard_scalar('ButtonChoice.value', value, (str,), False, True, False)
+        _guard_scalar('ButtonChoice.path', path, (str,), False, True, False)
+        _guard_scalar('ButtonChoice.disabled', disabled, (bool,), False, True, False)
         self.name = name
         """An identifying name for this component. If the name is prefixed with a '#', the command sets the location hash to the name when executed."""
         self.label = label
@@ -2601,15 +2603,18 @@ class ButtonCommand:
         """Data associated with this command, if any."""
         self.path = path
         """The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab."""
+        self.disabled = disabled
+        """True if the command should be disabled."""
 
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""
-        _guard_scalar('ButtonCommand.name', self.name, (str,), True, False, False)
-        _guard_scalar('ButtonCommand.label', self.label, (str,), False, True, False)
-        _guard_scalar('ButtonCommand.caption', self.caption, (str,), False, True, False)
-        _guard_scalar('ButtonCommand.icon', self.icon, (str,), False, True, False)
-        _guard_scalar('ButtonCommand.value', self.value, (str,), False, True, False)
-        _guard_scalar('ButtonCommand.path', self.path, (str,), False, True, False)
+        _guard_scalar('ButtonChoice.name', self.name, (str,), True, False, False)
+        _guard_scalar('ButtonChoice.label', self.label, (str,), False, True, False)
+        _guard_scalar('ButtonChoice.caption', self.caption, (str,), False, True, False)
+        _guard_scalar('ButtonChoice.icon', self.icon, (str,), False, True, False)
+        _guard_scalar('ButtonChoice.value', self.value, (str,), False, True, False)
+        _guard_scalar('ButtonChoice.path', self.path, (str,), False, True, False)
+        _guard_scalar('ButtonChoice.disabled', self.disabled, (bool,), False, True, False)
         return _dump(
             name=self.name,
             label=self.label,
@@ -2617,36 +2622,41 @@ class ButtonCommand:
             icon=self.icon,
             value=self.value,
             path=self.path,
+            disabled=self.disabled,
         )
 
     @staticmethod
-    def load(__d: Dict) -> 'ButtonCommand':
+    def load(__d: Dict) -> 'ButtonChoice':
         """Creates an instance of this class using the contents of a dict."""
         __d_name: Any = __d.get('name')
-        _guard_scalar('ButtonCommand.name', __d_name, (str,), True, False, False)
+        _guard_scalar('ButtonChoice.name', __d_name, (str,), True, False, False)
         __d_label: Any = __d.get('label')
-        _guard_scalar('ButtonCommand.label', __d_label, (str,), False, True, False)
+        _guard_scalar('ButtonChoice.label', __d_label, (str,), False, True, False)
         __d_caption: Any = __d.get('caption')
-        _guard_scalar('ButtonCommand.caption', __d_caption, (str,), False, True, False)
+        _guard_scalar('ButtonChoice.caption', __d_caption, (str,), False, True, False)
         __d_icon: Any = __d.get('icon')
-        _guard_scalar('ButtonCommand.icon', __d_icon, (str,), False, True, False)
+        _guard_scalar('ButtonChoice.icon', __d_icon, (str,), False, True, False)
         __d_value: Any = __d.get('value')
-        _guard_scalar('ButtonCommand.value', __d_value, (str,), False, True, False)
+        _guard_scalar('ButtonChoice.value', __d_value, (str,), False, True, False)
         __d_path: Any = __d.get('path')
-        _guard_scalar('ButtonCommand.path', __d_path, (str,), False, True, False)
+        _guard_scalar('ButtonChoice.path', __d_path, (str,), False, True, False)
+        __d_disabled: Any = __d.get('disabled')
+        _guard_scalar('ButtonChoice.disabled', __d_disabled, (bool,), False, True, False)
         name: str = __d_name
         label: Optional[str] = __d_label
         caption: Optional[str] = __d_caption
         icon: Optional[str] = __d_icon
         value: Optional[str] = __d_value
         path: Optional[str] = __d_path
-        return ButtonCommand(
+        disabled: Optional[bool] = __d_disabled
+        return ButtonChoice(
             name,
             label,
             caption,
             icon,
             value,
             path,
+            disabled,
         )
 
 
@@ -2682,7 +2692,7 @@ class Button:
             visible: Optional[bool] = None,
             tooltip: Optional[str] = None,
             path: Optional[str] = None,
-            commands: Optional[List[ButtonCommand]] = None,
+            choices: Optional[List[ButtonChoice]] = None,
     ):
         _guard_scalar('Button.name', name, (str,), True, False, False)
         _guard_scalar('Button.label', label, (str,), False, True, False)
@@ -2696,7 +2706,7 @@ class Button:
         _guard_scalar('Button.visible', visible, (bool,), False, True, False)
         _guard_scalar('Button.tooltip', tooltip, (str,), False, True, False)
         _guard_scalar('Button.path', path, (str,), False, True, False)
-        _guard_vector('Button.commands', commands, (ButtonCommand,), False, True, False)
+        _guard_vector('Button.choices', choices, (ButtonChoice,), False, True, False)
         self.name = name
         """An identifying name for this component. If the name is prefixed with a '#', the button sets the location hash to the name when clicked."""
         self.label = label
@@ -2721,7 +2731,7 @@ class Button:
         """An optional tooltip message displayed when a user clicks the help icon to the right of the component."""
         self.path = path
         """The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab."""
-        self.commands = commands
+        self.choices = choices
         """The menu with button actions. Ignored if `link` is True."""
 
     def dump(self) -> Dict:
@@ -2738,7 +2748,7 @@ class Button:
         _guard_scalar('Button.visible', self.visible, (bool,), False, True, False)
         _guard_scalar('Button.tooltip', self.tooltip, (str,), False, True, False)
         _guard_scalar('Button.path', self.path, (str,), False, True, False)
-        _guard_vector('Button.commands', self.commands, (ButtonCommand,), False, True, False)
+        _guard_vector('Button.choices', self.choices, (ButtonChoice,), False, True, False)
         return _dump(
             name=self.name,
             label=self.label,
@@ -2752,7 +2762,7 @@ class Button:
             visible=self.visible,
             tooltip=self.tooltip,
             path=self.path,
-            commands=None if self.commands is None else [__e.dump() for __e in self.commands],
+            choices=None if self.choices is None else [__e.dump() for __e in self.choices],
         )
 
     @staticmethod
@@ -2782,8 +2792,8 @@ class Button:
         _guard_scalar('Button.tooltip', __d_tooltip, (str,), False, True, False)
         __d_path: Any = __d.get('path')
         _guard_scalar('Button.path', __d_path, (str,), False, True, False)
-        __d_commands: Any = __d.get('commands')
-        _guard_vector('Button.commands', __d_commands, (dict,), False, True, False)
+        __d_choices: Any = __d.get('choices')
+        _guard_vector('Button.choices', __d_choices, (dict,), False, True, False)
         name: str = __d_name
         label: Optional[str] = __d_label
         caption: Optional[str] = __d_caption
@@ -2796,7 +2806,7 @@ class Button:
         visible: Optional[bool] = __d_visible
         tooltip: Optional[str] = __d_tooltip
         path: Optional[str] = __d_path
-        commands: Optional[List[ButtonCommand]] = None if __d_commands is None else [ButtonCommand.load(__e) for __e in __d_commands]
+        choices: Optional[List[ButtonChoice]] = None if __d_choices is None else [ButtonChoice.load(__e) for __e in __d_choices]
         return Button(
             name,
             label,
@@ -2810,7 +2820,7 @@ class Button:
             visible,
             tooltip,
             path,
-            commands,
+            choices,
         )
 
 

--- a/py/h2o_lightwave/h2o_lightwave/types.py
+++ b/py/h2o_lightwave/h2o_lightwave/types.py
@@ -2643,7 +2643,7 @@ class Button:
         self.path = path
         """The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab."""
         self.commands = commands
-        """The menu with button actions. Ignored if `link` is True."""
+        """When specified, a split button is rendered with extra actions tied to it within a context menu. Mutually exclusive with `link` attribute."""
 
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""

--- a/py/h2o_lightwave/h2o_lightwave/types.py
+++ b/py/h2o_lightwave/h2o_lightwave/types.py
@@ -2581,30 +2581,30 @@ class ButtonChoice:
             caption: Optional[str] = None,
             icon: Optional[str] = None,
             value: Optional[str] = None,
-            path: Optional[str] = None,
             disabled: Optional[bool] = None,
+            path: Optional[str] = None,
     ):
         _guard_scalar('ButtonChoice.name', name, (str,), True, False, False)
         _guard_scalar('ButtonChoice.label', label, (str,), False, True, False)
         _guard_scalar('ButtonChoice.caption', caption, (str,), False, True, False)
         _guard_scalar('ButtonChoice.icon', icon, (str,), False, True, False)
         _guard_scalar('ButtonChoice.value', value, (str,), False, True, False)
-        _guard_scalar('ButtonChoice.path', path, (str,), False, True, False)
         _guard_scalar('ButtonChoice.disabled', disabled, (bool,), False, True, False)
+        _guard_scalar('ButtonChoice.path', path, (str,), False, True, False)
         self.name = name
-        """An identifying name for this component. If the name is prefixed with a '#', the command sets the location hash to the name when executed."""
+        """An identifying name for this choice. If the name is prefixed with a '#', the location hash is changed to the name when executed."""
         self.label = label
-        """The text displayed for this command."""
+        """The text displayed for this choice."""
         self.caption = caption
-        """The caption for this command (typically a tooltip)."""
+        """The caption for this choice (typically a tooltip)."""
         self.icon = icon
-        """The icon to be displayed for this command."""
+        """The icon to be displayed for this choice."""
         self.value = value
-        """Data associated with this command, if any."""
+        """A value for this choice. If a value is set, it is used for the choice's submitted instead of a boolean True."""
+        self.disabled = disabled
+        """True if the choice should be disabled."""
         self.path = path
         """The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab."""
-        self.disabled = disabled
-        """True if the command should be disabled."""
 
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""
@@ -2613,16 +2613,16 @@ class ButtonChoice:
         _guard_scalar('ButtonChoice.caption', self.caption, (str,), False, True, False)
         _guard_scalar('ButtonChoice.icon', self.icon, (str,), False, True, False)
         _guard_scalar('ButtonChoice.value', self.value, (str,), False, True, False)
-        _guard_scalar('ButtonChoice.path', self.path, (str,), False, True, False)
         _guard_scalar('ButtonChoice.disabled', self.disabled, (bool,), False, True, False)
+        _guard_scalar('ButtonChoice.path', self.path, (str,), False, True, False)
         return _dump(
             name=self.name,
             label=self.label,
             caption=self.caption,
             icon=self.icon,
             value=self.value,
-            path=self.path,
             disabled=self.disabled,
+            path=self.path,
         )
 
     @staticmethod
@@ -2638,25 +2638,25 @@ class ButtonChoice:
         _guard_scalar('ButtonChoice.icon', __d_icon, (str,), False, True, False)
         __d_value: Any = __d.get('value')
         _guard_scalar('ButtonChoice.value', __d_value, (str,), False, True, False)
-        __d_path: Any = __d.get('path')
-        _guard_scalar('ButtonChoice.path', __d_path, (str,), False, True, False)
         __d_disabled: Any = __d.get('disabled')
         _guard_scalar('ButtonChoice.disabled', __d_disabled, (bool,), False, True, False)
+        __d_path: Any = __d.get('path')
+        _guard_scalar('ButtonChoice.path', __d_path, (str,), False, True, False)
         name: str = __d_name
         label: Optional[str] = __d_label
         caption: Optional[str] = __d_caption
         icon: Optional[str] = __d_icon
         value: Optional[str] = __d_value
-        path: Optional[str] = __d_path
         disabled: Optional[bool] = __d_disabled
+        path: Optional[str] = __d_path
         return ButtonChoice(
             name,
             label,
             caption,
             icon,
             value,
-            path,
             disabled,
+            path,
         )
 
 

--- a/py/h2o_lightwave/h2o_lightwave/types.py
+++ b/py/h2o_lightwave/h2o_lightwave/types.py
@@ -2571,95 +2571,6 @@ class ColorPicker:
         )
 
 
-class ButtonChoice:
-    """No documentation available.
-    """
-    def __init__(
-            self,
-            name: str,
-            label: Optional[str] = None,
-            caption: Optional[str] = None,
-            icon: Optional[str] = None,
-            value: Optional[str] = None,
-            disabled: Optional[bool] = None,
-            path: Optional[str] = None,
-    ):
-        _guard_scalar('ButtonChoice.name', name, (str,), True, False, False)
-        _guard_scalar('ButtonChoice.label', label, (str,), False, True, False)
-        _guard_scalar('ButtonChoice.caption', caption, (str,), False, True, False)
-        _guard_scalar('ButtonChoice.icon', icon, (str,), False, True, False)
-        _guard_scalar('ButtonChoice.value', value, (str,), False, True, False)
-        _guard_scalar('ButtonChoice.disabled', disabled, (bool,), False, True, False)
-        _guard_scalar('ButtonChoice.path', path, (str,), False, True, False)
-        self.name = name
-        """An identifying name for this choice. If the name is prefixed with a '#', the location hash is changed to the name when executed."""
-        self.label = label
-        """The text displayed for this choice."""
-        self.caption = caption
-        """The caption for this choice (typically a tooltip)."""
-        self.icon = icon
-        """An optional icon to display next to the choice label"""
-        self.value = value
-        """A value for this choice. If a value is set, it is used for the choice's submitted instead of a boolean True."""
-        self.disabled = disabled
-        """True if the choice should be disabled."""
-        self.path = path
-        """The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab."""
-
-    def dump(self) -> Dict:
-        """Returns the contents of this object as a dict."""
-        _guard_scalar('ButtonChoice.name', self.name, (str,), True, False, False)
-        _guard_scalar('ButtonChoice.label', self.label, (str,), False, True, False)
-        _guard_scalar('ButtonChoice.caption', self.caption, (str,), False, True, False)
-        _guard_scalar('ButtonChoice.icon', self.icon, (str,), False, True, False)
-        _guard_scalar('ButtonChoice.value', self.value, (str,), False, True, False)
-        _guard_scalar('ButtonChoice.disabled', self.disabled, (bool,), False, True, False)
-        _guard_scalar('ButtonChoice.path', self.path, (str,), False, True, False)
-        return _dump(
-            name=self.name,
-            label=self.label,
-            caption=self.caption,
-            icon=self.icon,
-            value=self.value,
-            disabled=self.disabled,
-            path=self.path,
-        )
-
-    @staticmethod
-    def load(__d: Dict) -> 'ButtonChoice':
-        """Creates an instance of this class using the contents of a dict."""
-        __d_name: Any = __d.get('name')
-        _guard_scalar('ButtonChoice.name', __d_name, (str,), True, False, False)
-        __d_label: Any = __d.get('label')
-        _guard_scalar('ButtonChoice.label', __d_label, (str,), False, True, False)
-        __d_caption: Any = __d.get('caption')
-        _guard_scalar('ButtonChoice.caption', __d_caption, (str,), False, True, False)
-        __d_icon: Any = __d.get('icon')
-        _guard_scalar('ButtonChoice.icon', __d_icon, (str,), False, True, False)
-        __d_value: Any = __d.get('value')
-        _guard_scalar('ButtonChoice.value', __d_value, (str,), False, True, False)
-        __d_disabled: Any = __d.get('disabled')
-        _guard_scalar('ButtonChoice.disabled', __d_disabled, (bool,), False, True, False)
-        __d_path: Any = __d.get('path')
-        _guard_scalar('ButtonChoice.path', __d_path, (str,), False, True, False)
-        name: str = __d_name
-        label: Optional[str] = __d_label
-        caption: Optional[str] = __d_caption
-        icon: Optional[str] = __d_icon
-        value: Optional[str] = __d_value
-        disabled: Optional[bool] = __d_disabled
-        path: Optional[str] = __d_path
-        return ButtonChoice(
-            name,
-            label,
-            caption,
-            icon,
-            value,
-            disabled,
-            path,
-        )
-
-
 class Button:
     """Create a button.
 
@@ -2692,7 +2603,7 @@ class Button:
             visible: Optional[bool] = None,
             tooltip: Optional[str] = None,
             path: Optional[str] = None,
-            choices: Optional[List[ButtonChoice]] = None,
+            commands: Optional[List[Command]] = None,
     ):
         _guard_scalar('Button.name', name, (str,), True, False, False)
         _guard_scalar('Button.label', label, (str,), False, True, False)
@@ -2706,7 +2617,7 @@ class Button:
         _guard_scalar('Button.visible', visible, (bool,), False, True, False)
         _guard_scalar('Button.tooltip', tooltip, (str,), False, True, False)
         _guard_scalar('Button.path', path, (str,), False, True, False)
-        _guard_vector('Button.choices', choices, (ButtonChoice,), False, True, False)
+        _guard_vector('Button.commands', commands, (Command,), False, True, False)
         self.name = name
         """An identifying name for this component. If the name is prefixed with a '#', the button sets the location hash to the name when clicked."""
         self.label = label
@@ -2731,7 +2642,7 @@ class Button:
         """An optional tooltip message displayed when a user clicks the help icon to the right of the component."""
         self.path = path
         """The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab."""
-        self.choices = choices
+        self.commands = commands
         """The menu with button actions. Ignored if `link` is True."""
 
     def dump(self) -> Dict:
@@ -2748,7 +2659,7 @@ class Button:
         _guard_scalar('Button.visible', self.visible, (bool,), False, True, False)
         _guard_scalar('Button.tooltip', self.tooltip, (str,), False, True, False)
         _guard_scalar('Button.path', self.path, (str,), False, True, False)
-        _guard_vector('Button.choices', self.choices, (ButtonChoice,), False, True, False)
+        _guard_vector('Button.commands', self.commands, (Command,), False, True, False)
         return _dump(
             name=self.name,
             label=self.label,
@@ -2762,7 +2673,7 @@ class Button:
             visible=self.visible,
             tooltip=self.tooltip,
             path=self.path,
-            choices=None if self.choices is None else [__e.dump() for __e in self.choices],
+            commands=None if self.commands is None else [__e.dump() for __e in self.commands],
         )
 
     @staticmethod
@@ -2792,8 +2703,8 @@ class Button:
         _guard_scalar('Button.tooltip', __d_tooltip, (str,), False, True, False)
         __d_path: Any = __d.get('path')
         _guard_scalar('Button.path', __d_path, (str,), False, True, False)
-        __d_choices: Any = __d.get('choices')
-        _guard_vector('Button.choices', __d_choices, (dict,), False, True, False)
+        __d_commands: Any = __d.get('commands')
+        _guard_vector('Button.commands', __d_commands, (dict,), False, True, False)
         name: str = __d_name
         label: Optional[str] = __d_label
         caption: Optional[str] = __d_caption
@@ -2806,7 +2717,7 @@ class Button:
         visible: Optional[bool] = __d_visible
         tooltip: Optional[str] = __d_tooltip
         path: Optional[str] = __d_path
-        choices: Optional[List[ButtonChoice]] = None if __d_choices is None else [ButtonChoice.load(__e) for __e in __d_choices]
+        commands: Optional[List[Command]] = None if __d_commands is None else [Command.load(__e) for __e in __d_commands]
         return Button(
             name,
             label,
@@ -2820,7 +2731,7 @@ class Button:
             visible,
             tooltip,
             path,
-            choices,
+            commands,
         )
 
 

--- a/py/h2o_lightwave/h2o_lightwave/types.py
+++ b/py/h2o_lightwave/h2o_lightwave/types.py
@@ -2598,7 +2598,7 @@ class ButtonChoice:
         self.caption = caption
         """The caption for this choice (typically a tooltip)."""
         self.icon = icon
-        """The icon to be displayed for this choice."""
+        """An optional icon to display next to the choice label"""
         self.value = value
         """A value for this choice. If a value is set, it is used for the choice's submitted instead of a boolean True."""
         self.disabled = disabled

--- a/py/h2o_lightwave/h2o_lightwave/ui.py
+++ b/py/h2o_lightwave/h2o_lightwave/ui.py
@@ -985,6 +985,36 @@ def color_picker(
     ))
 
 
+def button_command(
+        name: str,
+        label: Optional[str] = None,
+        caption: Optional[str] = None,
+        icon: Optional[str] = None,
+        value: Optional[str] = None,
+        path: Optional[str] = None,
+) -> ButtonCommand:
+    """No documentation available.
+
+    Args:
+        name: An identifying name for this component. If the name is prefixed with a '#', the command sets the location hash to the name when executed.
+        label: The text displayed for this command.
+        caption: The caption for this command (typically a tooltip).
+        icon: The icon to be displayed for this command.
+        value: Data associated with this command, if any.
+        path: The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab.
+    Returns:
+        A `h2o_wave.types.ButtonCommand` instance.
+    """
+    return ButtonCommand(
+        name,
+        label,
+        caption,
+        icon,
+        value,
+        path,
+    )
+
+
 def button(
         name: str,
         label: Optional[str] = None,
@@ -998,6 +1028,7 @@ def button(
         visible: Optional[bool] = None,
         tooltip: Optional[str] = None,
         path: Optional[str] = None,
+        commands: Optional[List[ButtonCommand]] = None,
 ) -> Component:
     """Create a button.
 
@@ -1029,6 +1060,7 @@ def button(
         visible: True if the component should be visible. Defaults to True.
         tooltip: An optional tooltip message displayed when a user clicks the help icon to the right of the component.
         path: The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab.
+        commands: The menu with button actions.
     Returns:
         A `h2o_wave.types.Button` instance.
     """
@@ -1045,6 +1077,7 @@ def button(
         visible,
         tooltip,
         path,
+        commands,
     ))
 
 

--- a/py/h2o_lightwave/h2o_lightwave/ui.py
+++ b/py/h2o_lightwave/h2o_lightwave/ui.py
@@ -985,39 +985,6 @@ def color_picker(
     ))
 
 
-def button_choice(
-        name: str,
-        label: Optional[str] = None,
-        caption: Optional[str] = None,
-        icon: Optional[str] = None,
-        value: Optional[str] = None,
-        disabled: Optional[bool] = None,
-        path: Optional[str] = None,
-) -> ButtonChoice:
-    """No documentation available.
-
-    Args:
-        name: An identifying name for this choice. If the name is prefixed with a '#', the location hash is changed to the name when executed.
-        label: The text displayed for this choice.
-        caption: The caption for this choice (typically a tooltip).
-        icon: An optional icon to display next to the choice label
-        value: A value for this choice. If a value is set, it is used for the choice's submitted instead of a boolean True.
-        disabled: True if the choice should be disabled.
-        path: The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab.
-    Returns:
-        A `h2o_wave.types.ButtonChoice` instance.
-    """
-    return ButtonChoice(
-        name,
-        label,
-        caption,
-        icon,
-        value,
-        disabled,
-        path,
-    )
-
-
 def button(
         name: str,
         label: Optional[str] = None,
@@ -1031,7 +998,7 @@ def button(
         visible: Optional[bool] = None,
         tooltip: Optional[str] = None,
         path: Optional[str] = None,
-        choices: Optional[List[ButtonChoice]] = None,
+        commands: Optional[List[Command]] = None,
 ) -> Component:
     """Create a button.
 
@@ -1063,7 +1030,7 @@ def button(
         visible: True if the component should be visible. Defaults to True.
         tooltip: An optional tooltip message displayed when a user clicks the help icon to the right of the component.
         path: The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab.
-        choices: The menu with button actions. Ignored if `link` is True.
+        commands: The menu with button actions. Ignored if `link` is True.
     Returns:
         A `h2o_wave.types.Button` instance.
     """
@@ -1080,7 +1047,7 @@ def button(
         visible,
         tooltip,
         path,
-        choices,
+        commands,
     ))
 
 

--- a/py/h2o_lightwave/h2o_lightwave/ui.py
+++ b/py/h2o_lightwave/h2o_lightwave/ui.py
@@ -991,19 +991,19 @@ def button_choice(
         caption: Optional[str] = None,
         icon: Optional[str] = None,
         value: Optional[str] = None,
-        path: Optional[str] = None,
         disabled: Optional[bool] = None,
+        path: Optional[str] = None,
 ) -> ButtonChoice:
     """No documentation available.
 
     Args:
-        name: An identifying name for this component. If the name is prefixed with a '#', the command sets the location hash to the name when executed.
-        label: The text displayed for this command.
-        caption: The caption for this command (typically a tooltip).
-        icon: The icon to be displayed for this command.
-        value: Data associated with this command, if any.
+        name: An identifying name for this choice. If the name is prefixed with a '#', the location hash is changed to the name when executed.
+        label: The text displayed for this choice.
+        caption: The caption for this choice (typically a tooltip).
+        icon: The icon to be displayed for this choice.
+        value: A value for this choice. If a value is set, it is used for the choice's submitted instead of a boolean True.
+        disabled: True if the choice should be disabled.
         path: The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab.
-        disabled: True if the command should be disabled.
     Returns:
         A `h2o_wave.types.ButtonChoice` instance.
     """
@@ -1013,8 +1013,8 @@ def button_choice(
         caption,
         icon,
         value,
-        path,
         disabled,
+        path,
     )
 
 

--- a/py/h2o_lightwave/h2o_lightwave/ui.py
+++ b/py/h2o_lightwave/h2o_lightwave/ui.py
@@ -1000,7 +1000,7 @@ def button_choice(
         name: An identifying name for this choice. If the name is prefixed with a '#', the location hash is changed to the name when executed.
         label: The text displayed for this choice.
         caption: The caption for this choice (typically a tooltip).
-        icon: The icon to be displayed for this choice.
+        icon: An optional icon to display next to the choice label
         value: A value for this choice. If a value is set, it is used for the choice's submitted instead of a boolean True.
         disabled: True if the choice should be disabled.
         path: The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab.

--- a/py/h2o_lightwave/h2o_lightwave/ui.py
+++ b/py/h2o_lightwave/h2o_lightwave/ui.py
@@ -985,14 +985,15 @@ def color_picker(
     ))
 
 
-def button_command(
+def button_choice(
         name: str,
         label: Optional[str] = None,
         caption: Optional[str] = None,
         icon: Optional[str] = None,
         value: Optional[str] = None,
         path: Optional[str] = None,
-) -> ButtonCommand:
+        disabled: Optional[bool] = None,
+) -> ButtonChoice:
     """No documentation available.
 
     Args:
@@ -1002,16 +1003,18 @@ def button_command(
         icon: The icon to be displayed for this command.
         value: Data associated with this command, if any.
         path: The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab.
+        disabled: True if the command should be disabled.
     Returns:
-        A `h2o_wave.types.ButtonCommand` instance.
+        A `h2o_wave.types.ButtonChoice` instance.
     """
-    return ButtonCommand(
+    return ButtonChoice(
         name,
         label,
         caption,
         icon,
         value,
         path,
+        disabled,
     )
 
 
@@ -1028,7 +1031,7 @@ def button(
         visible: Optional[bool] = None,
         tooltip: Optional[str] = None,
         path: Optional[str] = None,
-        commands: Optional[List[ButtonCommand]] = None,
+        choices: Optional[List[ButtonChoice]] = None,
 ) -> Component:
     """Create a button.
 
@@ -1060,7 +1063,7 @@ def button(
         visible: True if the component should be visible. Defaults to True.
         tooltip: An optional tooltip message displayed when a user clicks the help icon to the right of the component.
         path: The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab.
-        commands: The menu with button actions. Ignored if `link` is True.
+        choices: The menu with button actions. Ignored if `link` is True.
     Returns:
         A `h2o_wave.types.Button` instance.
     """
@@ -1077,7 +1080,7 @@ def button(
         visible,
         tooltip,
         path,
-        commands,
+        choices,
     ))
 
 

--- a/py/h2o_lightwave/h2o_lightwave/ui.py
+++ b/py/h2o_lightwave/h2o_lightwave/ui.py
@@ -1030,7 +1030,7 @@ def button(
         visible: True if the component should be visible. Defaults to True.
         tooltip: An optional tooltip message displayed when a user clicks the help icon to the right of the component.
         path: The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab.
-        commands: The menu with button actions. Ignored if `link` is True.
+        commands: When specified, a split button is rendered with extra actions tied to it within a context menu. Mutually exclusive with `link` attribute.
     Returns:
         A `h2o_wave.types.Button` instance.
     """

--- a/py/h2o_lightwave/h2o_lightwave/ui.py
+++ b/py/h2o_lightwave/h2o_lightwave/ui.py
@@ -1060,7 +1060,7 @@ def button(
         visible: True if the component should be visible. Defaults to True.
         tooltip: An optional tooltip message displayed when a user clicks the help icon to the right of the component.
         path: The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab.
-        commands: The menu with button actions.
+        commands: The menu with button actions. Ignored if `link` is True.
     Returns:
         A `h2o_wave.types.Button` instance.
     """

--- a/py/h2o_wave/h2o_wave/types.py
+++ b/py/h2o_wave/h2o_wave/types.py
@@ -2722,7 +2722,7 @@ class Button:
         self.path = path
         """The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab."""
         self.commands = commands
-        """The menu with button actions."""
+        """The menu with button actions. Ignored if `link` is True."""
 
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""

--- a/py/h2o_wave/h2o_wave/types.py
+++ b/py/h2o_wave/h2o_wave/types.py
@@ -2571,6 +2571,85 @@ class ColorPicker:
         )
 
 
+class ButtonCommand:
+    """No documentation available.
+    """
+    def __init__(
+            self,
+            name: str,
+            label: Optional[str] = None,
+            caption: Optional[str] = None,
+            icon: Optional[str] = None,
+            value: Optional[str] = None,
+            path: Optional[str] = None,
+    ):
+        _guard_scalar('ButtonCommand.name', name, (str,), True, False, False)
+        _guard_scalar('ButtonCommand.label', label, (str,), False, True, False)
+        _guard_scalar('ButtonCommand.caption', caption, (str,), False, True, False)
+        _guard_scalar('ButtonCommand.icon', icon, (str,), False, True, False)
+        _guard_scalar('ButtonCommand.value', value, (str,), False, True, False)
+        _guard_scalar('ButtonCommand.path', path, (str,), False, True, False)
+        self.name = name
+        """An identifying name for this component. If the name is prefixed with a '#', the command sets the location hash to the name when executed."""
+        self.label = label
+        """The text displayed for this command."""
+        self.caption = caption
+        """The caption for this command (typically a tooltip)."""
+        self.icon = icon
+        """The icon to be displayed for this command."""
+        self.value = value
+        """Data associated with this command, if any."""
+        self.path = path
+        """The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab."""
+
+    def dump(self) -> Dict:
+        """Returns the contents of this object as a dict."""
+        _guard_scalar('ButtonCommand.name', self.name, (str,), True, False, False)
+        _guard_scalar('ButtonCommand.label', self.label, (str,), False, True, False)
+        _guard_scalar('ButtonCommand.caption', self.caption, (str,), False, True, False)
+        _guard_scalar('ButtonCommand.icon', self.icon, (str,), False, True, False)
+        _guard_scalar('ButtonCommand.value', self.value, (str,), False, True, False)
+        _guard_scalar('ButtonCommand.path', self.path, (str,), False, True, False)
+        return _dump(
+            name=self.name,
+            label=self.label,
+            caption=self.caption,
+            icon=self.icon,
+            value=self.value,
+            path=self.path,
+        )
+
+    @staticmethod
+    def load(__d: Dict) -> 'ButtonCommand':
+        """Creates an instance of this class using the contents of a dict."""
+        __d_name: Any = __d.get('name')
+        _guard_scalar('ButtonCommand.name', __d_name, (str,), True, False, False)
+        __d_label: Any = __d.get('label')
+        _guard_scalar('ButtonCommand.label', __d_label, (str,), False, True, False)
+        __d_caption: Any = __d.get('caption')
+        _guard_scalar('ButtonCommand.caption', __d_caption, (str,), False, True, False)
+        __d_icon: Any = __d.get('icon')
+        _guard_scalar('ButtonCommand.icon', __d_icon, (str,), False, True, False)
+        __d_value: Any = __d.get('value')
+        _guard_scalar('ButtonCommand.value', __d_value, (str,), False, True, False)
+        __d_path: Any = __d.get('path')
+        _guard_scalar('ButtonCommand.path', __d_path, (str,), False, True, False)
+        name: str = __d_name
+        label: Optional[str] = __d_label
+        caption: Optional[str] = __d_caption
+        icon: Optional[str] = __d_icon
+        value: Optional[str] = __d_value
+        path: Optional[str] = __d_path
+        return ButtonCommand(
+            name,
+            label,
+            caption,
+            icon,
+            value,
+            path,
+        )
+
+
 class Button:
     """Create a button.
 
@@ -2603,6 +2682,7 @@ class Button:
             visible: Optional[bool] = None,
             tooltip: Optional[str] = None,
             path: Optional[str] = None,
+            commands: Optional[List[ButtonCommand]] = None,
     ):
         _guard_scalar('Button.name', name, (str,), True, False, False)
         _guard_scalar('Button.label', label, (str,), False, True, False)
@@ -2616,6 +2696,7 @@ class Button:
         _guard_scalar('Button.visible', visible, (bool,), False, True, False)
         _guard_scalar('Button.tooltip', tooltip, (str,), False, True, False)
         _guard_scalar('Button.path', path, (str,), False, True, False)
+        _guard_vector('Button.commands', commands, (ButtonCommand,), False, True, False)
         self.name = name
         """An identifying name for this component. If the name is prefixed with a '#', the button sets the location hash to the name when clicked."""
         self.label = label
@@ -2640,6 +2721,8 @@ class Button:
         """An optional tooltip message displayed when a user clicks the help icon to the right of the component."""
         self.path = path
         """The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab."""
+        self.commands = commands
+        """The menu with button actions."""
 
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""
@@ -2655,6 +2738,7 @@ class Button:
         _guard_scalar('Button.visible', self.visible, (bool,), False, True, False)
         _guard_scalar('Button.tooltip', self.tooltip, (str,), False, True, False)
         _guard_scalar('Button.path', self.path, (str,), False, True, False)
+        _guard_vector('Button.commands', self.commands, (ButtonCommand,), False, True, False)
         return _dump(
             name=self.name,
             label=self.label,
@@ -2668,6 +2752,7 @@ class Button:
             visible=self.visible,
             tooltip=self.tooltip,
             path=self.path,
+            commands=None if self.commands is None else [__e.dump() for __e in self.commands],
         )
 
     @staticmethod
@@ -2697,6 +2782,8 @@ class Button:
         _guard_scalar('Button.tooltip', __d_tooltip, (str,), False, True, False)
         __d_path: Any = __d.get('path')
         _guard_scalar('Button.path', __d_path, (str,), False, True, False)
+        __d_commands: Any = __d.get('commands')
+        _guard_vector('Button.commands', __d_commands, (dict,), False, True, False)
         name: str = __d_name
         label: Optional[str] = __d_label
         caption: Optional[str] = __d_caption
@@ -2709,6 +2796,7 @@ class Button:
         visible: Optional[bool] = __d_visible
         tooltip: Optional[str] = __d_tooltip
         path: Optional[str] = __d_path
+        commands: Optional[List[ButtonCommand]] = None if __d_commands is None else [ButtonCommand.load(__e) for __e in __d_commands]
         return Button(
             name,
             label,
@@ -2722,6 +2810,7 @@ class Button:
             visible,
             tooltip,
             path,
+            commands,
         )
 
 

--- a/py/h2o_wave/h2o_wave/types.py
+++ b/py/h2o_wave/h2o_wave/types.py
@@ -2571,7 +2571,7 @@ class ColorPicker:
         )
 
 
-class ButtonCommand:
+class ButtonChoice:
     """No documentation available.
     """
     def __init__(
@@ -2582,13 +2582,15 @@ class ButtonCommand:
             icon: Optional[str] = None,
             value: Optional[str] = None,
             path: Optional[str] = None,
+            disabled: Optional[bool] = None,
     ):
-        _guard_scalar('ButtonCommand.name', name, (str,), True, False, False)
-        _guard_scalar('ButtonCommand.label', label, (str,), False, True, False)
-        _guard_scalar('ButtonCommand.caption', caption, (str,), False, True, False)
-        _guard_scalar('ButtonCommand.icon', icon, (str,), False, True, False)
-        _guard_scalar('ButtonCommand.value', value, (str,), False, True, False)
-        _guard_scalar('ButtonCommand.path', path, (str,), False, True, False)
+        _guard_scalar('ButtonChoice.name', name, (str,), True, False, False)
+        _guard_scalar('ButtonChoice.label', label, (str,), False, True, False)
+        _guard_scalar('ButtonChoice.caption', caption, (str,), False, True, False)
+        _guard_scalar('ButtonChoice.icon', icon, (str,), False, True, False)
+        _guard_scalar('ButtonChoice.value', value, (str,), False, True, False)
+        _guard_scalar('ButtonChoice.path', path, (str,), False, True, False)
+        _guard_scalar('ButtonChoice.disabled', disabled, (bool,), False, True, False)
         self.name = name
         """An identifying name for this component. If the name is prefixed with a '#', the command sets the location hash to the name when executed."""
         self.label = label
@@ -2601,15 +2603,18 @@ class ButtonCommand:
         """Data associated with this command, if any."""
         self.path = path
         """The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab."""
+        self.disabled = disabled
+        """True if the command should be disabled."""
 
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""
-        _guard_scalar('ButtonCommand.name', self.name, (str,), True, False, False)
-        _guard_scalar('ButtonCommand.label', self.label, (str,), False, True, False)
-        _guard_scalar('ButtonCommand.caption', self.caption, (str,), False, True, False)
-        _guard_scalar('ButtonCommand.icon', self.icon, (str,), False, True, False)
-        _guard_scalar('ButtonCommand.value', self.value, (str,), False, True, False)
-        _guard_scalar('ButtonCommand.path', self.path, (str,), False, True, False)
+        _guard_scalar('ButtonChoice.name', self.name, (str,), True, False, False)
+        _guard_scalar('ButtonChoice.label', self.label, (str,), False, True, False)
+        _guard_scalar('ButtonChoice.caption', self.caption, (str,), False, True, False)
+        _guard_scalar('ButtonChoice.icon', self.icon, (str,), False, True, False)
+        _guard_scalar('ButtonChoice.value', self.value, (str,), False, True, False)
+        _guard_scalar('ButtonChoice.path', self.path, (str,), False, True, False)
+        _guard_scalar('ButtonChoice.disabled', self.disabled, (bool,), False, True, False)
         return _dump(
             name=self.name,
             label=self.label,
@@ -2617,36 +2622,41 @@ class ButtonCommand:
             icon=self.icon,
             value=self.value,
             path=self.path,
+            disabled=self.disabled,
         )
 
     @staticmethod
-    def load(__d: Dict) -> 'ButtonCommand':
+    def load(__d: Dict) -> 'ButtonChoice':
         """Creates an instance of this class using the contents of a dict."""
         __d_name: Any = __d.get('name')
-        _guard_scalar('ButtonCommand.name', __d_name, (str,), True, False, False)
+        _guard_scalar('ButtonChoice.name', __d_name, (str,), True, False, False)
         __d_label: Any = __d.get('label')
-        _guard_scalar('ButtonCommand.label', __d_label, (str,), False, True, False)
+        _guard_scalar('ButtonChoice.label', __d_label, (str,), False, True, False)
         __d_caption: Any = __d.get('caption')
-        _guard_scalar('ButtonCommand.caption', __d_caption, (str,), False, True, False)
+        _guard_scalar('ButtonChoice.caption', __d_caption, (str,), False, True, False)
         __d_icon: Any = __d.get('icon')
-        _guard_scalar('ButtonCommand.icon', __d_icon, (str,), False, True, False)
+        _guard_scalar('ButtonChoice.icon', __d_icon, (str,), False, True, False)
         __d_value: Any = __d.get('value')
-        _guard_scalar('ButtonCommand.value', __d_value, (str,), False, True, False)
+        _guard_scalar('ButtonChoice.value', __d_value, (str,), False, True, False)
         __d_path: Any = __d.get('path')
-        _guard_scalar('ButtonCommand.path', __d_path, (str,), False, True, False)
+        _guard_scalar('ButtonChoice.path', __d_path, (str,), False, True, False)
+        __d_disabled: Any = __d.get('disabled')
+        _guard_scalar('ButtonChoice.disabled', __d_disabled, (bool,), False, True, False)
         name: str = __d_name
         label: Optional[str] = __d_label
         caption: Optional[str] = __d_caption
         icon: Optional[str] = __d_icon
         value: Optional[str] = __d_value
         path: Optional[str] = __d_path
-        return ButtonCommand(
+        disabled: Optional[bool] = __d_disabled
+        return ButtonChoice(
             name,
             label,
             caption,
             icon,
             value,
             path,
+            disabled,
         )
 
 
@@ -2682,7 +2692,7 @@ class Button:
             visible: Optional[bool] = None,
             tooltip: Optional[str] = None,
             path: Optional[str] = None,
-            commands: Optional[List[ButtonCommand]] = None,
+            choices: Optional[List[ButtonChoice]] = None,
     ):
         _guard_scalar('Button.name', name, (str,), True, False, False)
         _guard_scalar('Button.label', label, (str,), False, True, False)
@@ -2696,7 +2706,7 @@ class Button:
         _guard_scalar('Button.visible', visible, (bool,), False, True, False)
         _guard_scalar('Button.tooltip', tooltip, (str,), False, True, False)
         _guard_scalar('Button.path', path, (str,), False, True, False)
-        _guard_vector('Button.commands', commands, (ButtonCommand,), False, True, False)
+        _guard_vector('Button.choices', choices, (ButtonChoice,), False, True, False)
         self.name = name
         """An identifying name for this component. If the name is prefixed with a '#', the button sets the location hash to the name when clicked."""
         self.label = label
@@ -2721,7 +2731,7 @@ class Button:
         """An optional tooltip message displayed when a user clicks the help icon to the right of the component."""
         self.path = path
         """The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab."""
-        self.commands = commands
+        self.choices = choices
         """The menu with button actions. Ignored if `link` is True."""
 
     def dump(self) -> Dict:
@@ -2738,7 +2748,7 @@ class Button:
         _guard_scalar('Button.visible', self.visible, (bool,), False, True, False)
         _guard_scalar('Button.tooltip', self.tooltip, (str,), False, True, False)
         _guard_scalar('Button.path', self.path, (str,), False, True, False)
-        _guard_vector('Button.commands', self.commands, (ButtonCommand,), False, True, False)
+        _guard_vector('Button.choices', self.choices, (ButtonChoice,), False, True, False)
         return _dump(
             name=self.name,
             label=self.label,
@@ -2752,7 +2762,7 @@ class Button:
             visible=self.visible,
             tooltip=self.tooltip,
             path=self.path,
-            commands=None if self.commands is None else [__e.dump() for __e in self.commands],
+            choices=None if self.choices is None else [__e.dump() for __e in self.choices],
         )
 
     @staticmethod
@@ -2782,8 +2792,8 @@ class Button:
         _guard_scalar('Button.tooltip', __d_tooltip, (str,), False, True, False)
         __d_path: Any = __d.get('path')
         _guard_scalar('Button.path', __d_path, (str,), False, True, False)
-        __d_commands: Any = __d.get('commands')
-        _guard_vector('Button.commands', __d_commands, (dict,), False, True, False)
+        __d_choices: Any = __d.get('choices')
+        _guard_vector('Button.choices', __d_choices, (dict,), False, True, False)
         name: str = __d_name
         label: Optional[str] = __d_label
         caption: Optional[str] = __d_caption
@@ -2796,7 +2806,7 @@ class Button:
         visible: Optional[bool] = __d_visible
         tooltip: Optional[str] = __d_tooltip
         path: Optional[str] = __d_path
-        commands: Optional[List[ButtonCommand]] = None if __d_commands is None else [ButtonCommand.load(__e) for __e in __d_commands]
+        choices: Optional[List[ButtonChoice]] = None if __d_choices is None else [ButtonChoice.load(__e) for __e in __d_choices]
         return Button(
             name,
             label,
@@ -2810,7 +2820,7 @@ class Button:
             visible,
             tooltip,
             path,
-            commands,
+            choices,
         )
 
 

--- a/py/h2o_wave/h2o_wave/types.py
+++ b/py/h2o_wave/h2o_wave/types.py
@@ -2643,7 +2643,7 @@ class Button:
         self.path = path
         """The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab."""
         self.commands = commands
-        """The menu with button actions. Ignored if `link` is True."""
+        """When specified, a split button is rendered with extra actions tied to it within a context menu. Mutually exclusive with `link` attribute."""
 
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""

--- a/py/h2o_wave/h2o_wave/types.py
+++ b/py/h2o_wave/h2o_wave/types.py
@@ -2581,30 +2581,30 @@ class ButtonChoice:
             caption: Optional[str] = None,
             icon: Optional[str] = None,
             value: Optional[str] = None,
-            path: Optional[str] = None,
             disabled: Optional[bool] = None,
+            path: Optional[str] = None,
     ):
         _guard_scalar('ButtonChoice.name', name, (str,), True, False, False)
         _guard_scalar('ButtonChoice.label', label, (str,), False, True, False)
         _guard_scalar('ButtonChoice.caption', caption, (str,), False, True, False)
         _guard_scalar('ButtonChoice.icon', icon, (str,), False, True, False)
         _guard_scalar('ButtonChoice.value', value, (str,), False, True, False)
-        _guard_scalar('ButtonChoice.path', path, (str,), False, True, False)
         _guard_scalar('ButtonChoice.disabled', disabled, (bool,), False, True, False)
+        _guard_scalar('ButtonChoice.path', path, (str,), False, True, False)
         self.name = name
-        """An identifying name for this component. If the name is prefixed with a '#', the command sets the location hash to the name when executed."""
+        """An identifying name for this choice. If the name is prefixed with a '#', the location hash is changed to the name when executed."""
         self.label = label
-        """The text displayed for this command."""
+        """The text displayed for this choice."""
         self.caption = caption
-        """The caption for this command (typically a tooltip)."""
+        """The caption for this choice (typically a tooltip)."""
         self.icon = icon
-        """The icon to be displayed for this command."""
+        """The icon to be displayed for this choice."""
         self.value = value
-        """Data associated with this command, if any."""
+        """A value for this choice. If a value is set, it is used for the choice's submitted instead of a boolean True."""
+        self.disabled = disabled
+        """True if the choice should be disabled."""
         self.path = path
         """The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab."""
-        self.disabled = disabled
-        """True if the command should be disabled."""
 
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""
@@ -2613,16 +2613,16 @@ class ButtonChoice:
         _guard_scalar('ButtonChoice.caption', self.caption, (str,), False, True, False)
         _guard_scalar('ButtonChoice.icon', self.icon, (str,), False, True, False)
         _guard_scalar('ButtonChoice.value', self.value, (str,), False, True, False)
-        _guard_scalar('ButtonChoice.path', self.path, (str,), False, True, False)
         _guard_scalar('ButtonChoice.disabled', self.disabled, (bool,), False, True, False)
+        _guard_scalar('ButtonChoice.path', self.path, (str,), False, True, False)
         return _dump(
             name=self.name,
             label=self.label,
             caption=self.caption,
             icon=self.icon,
             value=self.value,
-            path=self.path,
             disabled=self.disabled,
+            path=self.path,
         )
 
     @staticmethod
@@ -2638,25 +2638,25 @@ class ButtonChoice:
         _guard_scalar('ButtonChoice.icon', __d_icon, (str,), False, True, False)
         __d_value: Any = __d.get('value')
         _guard_scalar('ButtonChoice.value', __d_value, (str,), False, True, False)
-        __d_path: Any = __d.get('path')
-        _guard_scalar('ButtonChoice.path', __d_path, (str,), False, True, False)
         __d_disabled: Any = __d.get('disabled')
         _guard_scalar('ButtonChoice.disabled', __d_disabled, (bool,), False, True, False)
+        __d_path: Any = __d.get('path')
+        _guard_scalar('ButtonChoice.path', __d_path, (str,), False, True, False)
         name: str = __d_name
         label: Optional[str] = __d_label
         caption: Optional[str] = __d_caption
         icon: Optional[str] = __d_icon
         value: Optional[str] = __d_value
-        path: Optional[str] = __d_path
         disabled: Optional[bool] = __d_disabled
+        path: Optional[str] = __d_path
         return ButtonChoice(
             name,
             label,
             caption,
             icon,
             value,
-            path,
             disabled,
+            path,
         )
 
 

--- a/py/h2o_wave/h2o_wave/types.py
+++ b/py/h2o_wave/h2o_wave/types.py
@@ -2571,95 +2571,6 @@ class ColorPicker:
         )
 
 
-class ButtonChoice:
-    """No documentation available.
-    """
-    def __init__(
-            self,
-            name: str,
-            label: Optional[str] = None,
-            caption: Optional[str] = None,
-            icon: Optional[str] = None,
-            value: Optional[str] = None,
-            disabled: Optional[bool] = None,
-            path: Optional[str] = None,
-    ):
-        _guard_scalar('ButtonChoice.name', name, (str,), True, False, False)
-        _guard_scalar('ButtonChoice.label', label, (str,), False, True, False)
-        _guard_scalar('ButtonChoice.caption', caption, (str,), False, True, False)
-        _guard_scalar('ButtonChoice.icon', icon, (str,), False, True, False)
-        _guard_scalar('ButtonChoice.value', value, (str,), False, True, False)
-        _guard_scalar('ButtonChoice.disabled', disabled, (bool,), False, True, False)
-        _guard_scalar('ButtonChoice.path', path, (str,), False, True, False)
-        self.name = name
-        """An identifying name for this choice. If the name is prefixed with a '#', the location hash is changed to the name when executed."""
-        self.label = label
-        """The text displayed for this choice."""
-        self.caption = caption
-        """The caption for this choice (typically a tooltip)."""
-        self.icon = icon
-        """An optional icon to display next to the choice label"""
-        self.value = value
-        """A value for this choice. If a value is set, it is used for the choice's submitted instead of a boolean True."""
-        self.disabled = disabled
-        """True if the choice should be disabled."""
-        self.path = path
-        """The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab."""
-
-    def dump(self) -> Dict:
-        """Returns the contents of this object as a dict."""
-        _guard_scalar('ButtonChoice.name', self.name, (str,), True, False, False)
-        _guard_scalar('ButtonChoice.label', self.label, (str,), False, True, False)
-        _guard_scalar('ButtonChoice.caption', self.caption, (str,), False, True, False)
-        _guard_scalar('ButtonChoice.icon', self.icon, (str,), False, True, False)
-        _guard_scalar('ButtonChoice.value', self.value, (str,), False, True, False)
-        _guard_scalar('ButtonChoice.disabled', self.disabled, (bool,), False, True, False)
-        _guard_scalar('ButtonChoice.path', self.path, (str,), False, True, False)
-        return _dump(
-            name=self.name,
-            label=self.label,
-            caption=self.caption,
-            icon=self.icon,
-            value=self.value,
-            disabled=self.disabled,
-            path=self.path,
-        )
-
-    @staticmethod
-    def load(__d: Dict) -> 'ButtonChoice':
-        """Creates an instance of this class using the contents of a dict."""
-        __d_name: Any = __d.get('name')
-        _guard_scalar('ButtonChoice.name', __d_name, (str,), True, False, False)
-        __d_label: Any = __d.get('label')
-        _guard_scalar('ButtonChoice.label', __d_label, (str,), False, True, False)
-        __d_caption: Any = __d.get('caption')
-        _guard_scalar('ButtonChoice.caption', __d_caption, (str,), False, True, False)
-        __d_icon: Any = __d.get('icon')
-        _guard_scalar('ButtonChoice.icon', __d_icon, (str,), False, True, False)
-        __d_value: Any = __d.get('value')
-        _guard_scalar('ButtonChoice.value', __d_value, (str,), False, True, False)
-        __d_disabled: Any = __d.get('disabled')
-        _guard_scalar('ButtonChoice.disabled', __d_disabled, (bool,), False, True, False)
-        __d_path: Any = __d.get('path')
-        _guard_scalar('ButtonChoice.path', __d_path, (str,), False, True, False)
-        name: str = __d_name
-        label: Optional[str] = __d_label
-        caption: Optional[str] = __d_caption
-        icon: Optional[str] = __d_icon
-        value: Optional[str] = __d_value
-        disabled: Optional[bool] = __d_disabled
-        path: Optional[str] = __d_path
-        return ButtonChoice(
-            name,
-            label,
-            caption,
-            icon,
-            value,
-            disabled,
-            path,
-        )
-
-
 class Button:
     """Create a button.
 
@@ -2692,7 +2603,7 @@ class Button:
             visible: Optional[bool] = None,
             tooltip: Optional[str] = None,
             path: Optional[str] = None,
-            choices: Optional[List[ButtonChoice]] = None,
+            commands: Optional[List[Command]] = None,
     ):
         _guard_scalar('Button.name', name, (str,), True, False, False)
         _guard_scalar('Button.label', label, (str,), False, True, False)
@@ -2706,7 +2617,7 @@ class Button:
         _guard_scalar('Button.visible', visible, (bool,), False, True, False)
         _guard_scalar('Button.tooltip', tooltip, (str,), False, True, False)
         _guard_scalar('Button.path', path, (str,), False, True, False)
-        _guard_vector('Button.choices', choices, (ButtonChoice,), False, True, False)
+        _guard_vector('Button.commands', commands, (Command,), False, True, False)
         self.name = name
         """An identifying name for this component. If the name is prefixed with a '#', the button sets the location hash to the name when clicked."""
         self.label = label
@@ -2731,7 +2642,7 @@ class Button:
         """An optional tooltip message displayed when a user clicks the help icon to the right of the component."""
         self.path = path
         """The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab."""
-        self.choices = choices
+        self.commands = commands
         """The menu with button actions. Ignored if `link` is True."""
 
     def dump(self) -> Dict:
@@ -2748,7 +2659,7 @@ class Button:
         _guard_scalar('Button.visible', self.visible, (bool,), False, True, False)
         _guard_scalar('Button.tooltip', self.tooltip, (str,), False, True, False)
         _guard_scalar('Button.path', self.path, (str,), False, True, False)
-        _guard_vector('Button.choices', self.choices, (ButtonChoice,), False, True, False)
+        _guard_vector('Button.commands', self.commands, (Command,), False, True, False)
         return _dump(
             name=self.name,
             label=self.label,
@@ -2762,7 +2673,7 @@ class Button:
             visible=self.visible,
             tooltip=self.tooltip,
             path=self.path,
-            choices=None if self.choices is None else [__e.dump() for __e in self.choices],
+            commands=None if self.commands is None else [__e.dump() for __e in self.commands],
         )
 
     @staticmethod
@@ -2792,8 +2703,8 @@ class Button:
         _guard_scalar('Button.tooltip', __d_tooltip, (str,), False, True, False)
         __d_path: Any = __d.get('path')
         _guard_scalar('Button.path', __d_path, (str,), False, True, False)
-        __d_choices: Any = __d.get('choices')
-        _guard_vector('Button.choices', __d_choices, (dict,), False, True, False)
+        __d_commands: Any = __d.get('commands')
+        _guard_vector('Button.commands', __d_commands, (dict,), False, True, False)
         name: str = __d_name
         label: Optional[str] = __d_label
         caption: Optional[str] = __d_caption
@@ -2806,7 +2717,7 @@ class Button:
         visible: Optional[bool] = __d_visible
         tooltip: Optional[str] = __d_tooltip
         path: Optional[str] = __d_path
-        choices: Optional[List[ButtonChoice]] = None if __d_choices is None else [ButtonChoice.load(__e) for __e in __d_choices]
+        commands: Optional[List[Command]] = None if __d_commands is None else [Command.load(__e) for __e in __d_commands]
         return Button(
             name,
             label,
@@ -2820,7 +2731,7 @@ class Button:
             visible,
             tooltip,
             path,
-            choices,
+            commands,
         )
 
 

--- a/py/h2o_wave/h2o_wave/types.py
+++ b/py/h2o_wave/h2o_wave/types.py
@@ -2598,7 +2598,7 @@ class ButtonChoice:
         self.caption = caption
         """The caption for this choice (typically a tooltip)."""
         self.icon = icon
-        """The icon to be displayed for this choice."""
+        """An optional icon to display next to the choice label"""
         self.value = value
         """A value for this choice. If a value is set, it is used for the choice's submitted instead of a boolean True."""
         self.disabled = disabled

--- a/py/h2o_wave/h2o_wave/ui.py
+++ b/py/h2o_wave/h2o_wave/ui.py
@@ -985,6 +985,36 @@ def color_picker(
     ))
 
 
+def button_command(
+        name: str,
+        label: Optional[str] = None,
+        caption: Optional[str] = None,
+        icon: Optional[str] = None,
+        value: Optional[str] = None,
+        path: Optional[str] = None,
+) -> ButtonCommand:
+    """No documentation available.
+
+    Args:
+        name: An identifying name for this component. If the name is prefixed with a '#', the command sets the location hash to the name when executed.
+        label: The text displayed for this command.
+        caption: The caption for this command (typically a tooltip).
+        icon: The icon to be displayed for this command.
+        value: Data associated with this command, if any.
+        path: The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab.
+    Returns:
+        A `h2o_wave.types.ButtonCommand` instance.
+    """
+    return ButtonCommand(
+        name,
+        label,
+        caption,
+        icon,
+        value,
+        path,
+    )
+
+
 def button(
         name: str,
         label: Optional[str] = None,
@@ -998,6 +1028,7 @@ def button(
         visible: Optional[bool] = None,
         tooltip: Optional[str] = None,
         path: Optional[str] = None,
+        commands: Optional[List[ButtonCommand]] = None,
 ) -> Component:
     """Create a button.
 
@@ -1029,6 +1060,7 @@ def button(
         visible: True if the component should be visible. Defaults to True.
         tooltip: An optional tooltip message displayed when a user clicks the help icon to the right of the component.
         path: The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab.
+        commands: The menu with button actions.
     Returns:
         A `h2o_wave.types.Button` instance.
     """
@@ -1045,6 +1077,7 @@ def button(
         visible,
         tooltip,
         path,
+        commands,
     ))
 
 

--- a/py/h2o_wave/h2o_wave/ui.py
+++ b/py/h2o_wave/h2o_wave/ui.py
@@ -985,39 +985,6 @@ def color_picker(
     ))
 
 
-def button_choice(
-        name: str,
-        label: Optional[str] = None,
-        caption: Optional[str] = None,
-        icon: Optional[str] = None,
-        value: Optional[str] = None,
-        disabled: Optional[bool] = None,
-        path: Optional[str] = None,
-) -> ButtonChoice:
-    """No documentation available.
-
-    Args:
-        name: An identifying name for this choice. If the name is prefixed with a '#', the location hash is changed to the name when executed.
-        label: The text displayed for this choice.
-        caption: The caption for this choice (typically a tooltip).
-        icon: An optional icon to display next to the choice label
-        value: A value for this choice. If a value is set, it is used for the choice's submitted instead of a boolean True.
-        disabled: True if the choice should be disabled.
-        path: The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab.
-    Returns:
-        A `h2o_wave.types.ButtonChoice` instance.
-    """
-    return ButtonChoice(
-        name,
-        label,
-        caption,
-        icon,
-        value,
-        disabled,
-        path,
-    )
-
-
 def button(
         name: str,
         label: Optional[str] = None,
@@ -1031,7 +998,7 @@ def button(
         visible: Optional[bool] = None,
         tooltip: Optional[str] = None,
         path: Optional[str] = None,
-        choices: Optional[List[ButtonChoice]] = None,
+        commands: Optional[List[Command]] = None,
 ) -> Component:
     """Create a button.
 
@@ -1063,7 +1030,7 @@ def button(
         visible: True if the component should be visible. Defaults to True.
         tooltip: An optional tooltip message displayed when a user clicks the help icon to the right of the component.
         path: The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab.
-        choices: The menu with button actions. Ignored if `link` is True.
+        commands: The menu with button actions. Ignored if `link` is True.
     Returns:
         A `h2o_wave.types.Button` instance.
     """
@@ -1080,7 +1047,7 @@ def button(
         visible,
         tooltip,
         path,
-        choices,
+        commands,
     ))
 
 

--- a/py/h2o_wave/h2o_wave/ui.py
+++ b/py/h2o_wave/h2o_wave/ui.py
@@ -991,19 +991,19 @@ def button_choice(
         caption: Optional[str] = None,
         icon: Optional[str] = None,
         value: Optional[str] = None,
-        path: Optional[str] = None,
         disabled: Optional[bool] = None,
+        path: Optional[str] = None,
 ) -> ButtonChoice:
     """No documentation available.
 
     Args:
-        name: An identifying name for this component. If the name is prefixed with a '#', the command sets the location hash to the name when executed.
-        label: The text displayed for this command.
-        caption: The caption for this command (typically a tooltip).
-        icon: The icon to be displayed for this command.
-        value: Data associated with this command, if any.
+        name: An identifying name for this choice. If the name is prefixed with a '#', the location hash is changed to the name when executed.
+        label: The text displayed for this choice.
+        caption: The caption for this choice (typically a tooltip).
+        icon: The icon to be displayed for this choice.
+        value: A value for this choice. If a value is set, it is used for the choice's submitted instead of a boolean True.
+        disabled: True if the choice should be disabled.
         path: The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab.
-        disabled: True if the command should be disabled.
     Returns:
         A `h2o_wave.types.ButtonChoice` instance.
     """
@@ -1013,8 +1013,8 @@ def button_choice(
         caption,
         icon,
         value,
-        path,
         disabled,
+        path,
     )
 
 

--- a/py/h2o_wave/h2o_wave/ui.py
+++ b/py/h2o_wave/h2o_wave/ui.py
@@ -1000,7 +1000,7 @@ def button_choice(
         name: An identifying name for this choice. If the name is prefixed with a '#', the location hash is changed to the name when executed.
         label: The text displayed for this choice.
         caption: The caption for this choice (typically a tooltip).
-        icon: The icon to be displayed for this choice.
+        icon: An optional icon to display next to the choice label
         value: A value for this choice. If a value is set, it is used for the choice's submitted instead of a boolean True.
         disabled: True if the choice should be disabled.
         path: The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab.

--- a/py/h2o_wave/h2o_wave/ui.py
+++ b/py/h2o_wave/h2o_wave/ui.py
@@ -985,14 +985,15 @@ def color_picker(
     ))
 
 
-def button_command(
+def button_choice(
         name: str,
         label: Optional[str] = None,
         caption: Optional[str] = None,
         icon: Optional[str] = None,
         value: Optional[str] = None,
         path: Optional[str] = None,
-) -> ButtonCommand:
+        disabled: Optional[bool] = None,
+) -> ButtonChoice:
     """No documentation available.
 
     Args:
@@ -1002,16 +1003,18 @@ def button_command(
         icon: The icon to be displayed for this command.
         value: Data associated with this command, if any.
         path: The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab.
+        disabled: True if the command should be disabled.
     Returns:
-        A `h2o_wave.types.ButtonCommand` instance.
+        A `h2o_wave.types.ButtonChoice` instance.
     """
-    return ButtonCommand(
+    return ButtonChoice(
         name,
         label,
         caption,
         icon,
         value,
         path,
+        disabled,
     )
 
 
@@ -1028,7 +1031,7 @@ def button(
         visible: Optional[bool] = None,
         tooltip: Optional[str] = None,
         path: Optional[str] = None,
-        commands: Optional[List[ButtonCommand]] = None,
+        choices: Optional[List[ButtonChoice]] = None,
 ) -> Component:
     """Create a button.
 
@@ -1060,7 +1063,7 @@ def button(
         visible: True if the component should be visible. Defaults to True.
         tooltip: An optional tooltip message displayed when a user clicks the help icon to the right of the component.
         path: The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab.
-        commands: The menu with button actions. Ignored if `link` is True.
+        choices: The menu with button actions. Ignored if `link` is True.
     Returns:
         A `h2o_wave.types.Button` instance.
     """
@@ -1077,7 +1080,7 @@ def button(
         visible,
         tooltip,
         path,
-        commands,
+        choices,
     ))
 
 

--- a/py/h2o_wave/h2o_wave/ui.py
+++ b/py/h2o_wave/h2o_wave/ui.py
@@ -1030,7 +1030,7 @@ def button(
         visible: True if the component should be visible. Defaults to True.
         tooltip: An optional tooltip message displayed when a user clicks the help icon to the right of the component.
         path: The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab.
-        commands: The menu with button actions. Ignored if `link` is True.
+        commands: When specified, a split button is rendered with extra actions tied to it within a context menu. Mutually exclusive with `link` attribute.
     Returns:
         A `h2o_wave.types.Button` instance.
     """

--- a/py/h2o_wave/h2o_wave/ui.py
+++ b/py/h2o_wave/h2o_wave/ui.py
@@ -1060,7 +1060,7 @@ def button(
         visible: True if the component should be visible. Defaults to True.
         tooltip: An optional tooltip message displayed when a user clicks the help icon to the right of the component.
         path: The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab.
-        commands: The menu with button actions.
+        commands: The menu with button actions. Ignored if `link` is True.
     Returns:
         A `h2o_wave.types.Button` instance.
     """

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -1173,13 +1173,13 @@ ui_color_picker <- function(
 
 #' No documentation available.
 #'
-#' @param name An identifying name for this component. If the name is prefixed with a '#', the command sets the location hash to the name when executed.
-#' @param label The text displayed for this command.
-#' @param caption The caption for this command (typically a tooltip).
-#' @param icon The icon to be displayed for this command.
-#' @param value Data associated with this command, if any.
+#' @param name An identifying name for this choice. If the name is prefixed with a '#', the location hash is changed to the name when executed.
+#' @param label The text displayed for this choice.
+#' @param caption The caption for this choice (typically a tooltip).
+#' @param icon The icon to be displayed for this choice.
+#' @param value A value for this choice. If a value is set, it is used for the choice's submitted instead of a boolean True.
+#' @param disabled True if the choice should be disabled.
 #' @param path The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab.
-#' @param disabled True if the command should be disabled.
 #' @return A ButtonChoice instance.
 #' @export
 ui_button_choice <- function(
@@ -1188,23 +1188,23 @@ ui_button_choice <- function(
   caption = NULL,
   icon = NULL,
   value = NULL,
-  path = NULL,
-  disabled = NULL) {
+  disabled = NULL,
+  path = NULL) {
   .guard_scalar("name", "character", name)
   .guard_scalar("label", "character", label)
   .guard_scalar("caption", "character", caption)
   .guard_scalar("icon", "character", icon)
   .guard_scalar("value", "character", value)
-  .guard_scalar("path", "character", path)
   .guard_scalar("disabled", "logical", disabled)
+  .guard_scalar("path", "character", path)
   .o <- list(
     name=name,
     label=label,
     caption=caption,
     icon=icon,
     value=value,
-    path=path,
-    disabled=disabled)
+    disabled=disabled,
+    path=path)
   class(.o) <- append(class(.o), c(.wave_obj, "WaveButtonChoice"))
   return(.o)
 }

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -1171,44 +1171,6 @@ ui_color_picker <- function(
   return(.o)
 }
 
-#' No documentation available.
-#'
-#' @param name An identifying name for this choice. If the name is prefixed with a '#', the location hash is changed to the name when executed.
-#' @param label The text displayed for this choice.
-#' @param caption The caption for this choice (typically a tooltip).
-#' @param icon An optional icon to display next to the choice label
-#' @param value A value for this choice. If a value is set, it is used for the choice's submitted instead of a boolean True.
-#' @param disabled True if the choice should be disabled.
-#' @param path The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab.
-#' @return A ButtonChoice instance.
-#' @export
-ui_button_choice <- function(
-  name,
-  label = NULL,
-  caption = NULL,
-  icon = NULL,
-  value = NULL,
-  disabled = NULL,
-  path = NULL) {
-  .guard_scalar("name", "character", name)
-  .guard_scalar("label", "character", label)
-  .guard_scalar("caption", "character", caption)
-  .guard_scalar("icon", "character", icon)
-  .guard_scalar("value", "character", value)
-  .guard_scalar("disabled", "logical", disabled)
-  .guard_scalar("path", "character", path)
-  .o <- list(
-    name=name,
-    label=label,
-    caption=caption,
-    icon=icon,
-    value=value,
-    disabled=disabled,
-    path=path)
-  class(.o) <- append(class(.o), c(.wave_obj, "WaveButtonChoice"))
-  return(.o)
-}
-
 #' Create a button.
 #' 
 #' Buttons are best used to enable a user to commit a change or complete steps in a task.
@@ -1238,7 +1200,7 @@ ui_button_choice <- function(
 #' @param visible True if the component should be visible. Defaults to True.
 #' @param tooltip An optional tooltip message displayed when a user clicks the help icon to the right of the component.
 #' @param path The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab.
-#' @param choices The menu with button actions. Ignored if `link` is True.
+#' @param commands The menu with button actions. Ignored if `link` is True.
 #' @return A Button instance.
 #' @export
 ui_button <- function(
@@ -1254,7 +1216,7 @@ ui_button <- function(
   visible = NULL,
   tooltip = NULL,
   path = NULL,
-  choices = NULL) {
+  commands = NULL) {
   .guard_scalar("name", "character", name)
   .guard_scalar("label", "character", label)
   .guard_scalar("caption", "character", caption)
@@ -1267,7 +1229,7 @@ ui_button <- function(
   .guard_scalar("visible", "logical", visible)
   .guard_scalar("tooltip", "character", tooltip)
   .guard_scalar("path", "character", path)
-  .guard_vector("choices", "WaveButtonChoice", choices)
+  .guard_vector("commands", "WaveCommand", commands)
   .o <- list(button=list(
     name=name,
     label=label,
@@ -1281,7 +1243,7 @@ ui_button <- function(
     visible=visible,
     tooltip=tooltip,
     path=path,
-    choices=choices))
+    commands=commands))
   class(.o) <- append(class(.o), c(.wave_obj, "WaveComponent"))
   return(.o)
 }

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -1176,7 +1176,7 @@ ui_color_picker <- function(
 #' @param name An identifying name for this choice. If the name is prefixed with a '#', the location hash is changed to the name when executed.
 #' @param label The text displayed for this choice.
 #' @param caption The caption for this choice (typically a tooltip).
-#' @param icon The icon to be displayed for this choice.
+#' @param icon An optional icon to display next to the choice label
 #' @param value A value for this choice. If a value is set, it is used for the choice's submitted instead of a boolean True.
 #' @param disabled True if the choice should be disabled.
 #' @param path The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab.

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -1234,7 +1234,7 @@ ui_button_command <- function(
 #' @param visible True if the component should be visible. Defaults to True.
 #' @param tooltip An optional tooltip message displayed when a user clicks the help icon to the right of the component.
 #' @param path The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab.
-#' @param commands The menu with button actions.
+#' @param commands The menu with button actions. Ignored if `link` is True.
 #' @return A Button instance.
 #' @export
 ui_button <- function(

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -1200,7 +1200,7 @@ ui_color_picker <- function(
 #' @param visible True if the component should be visible. Defaults to True.
 #' @param tooltip An optional tooltip message displayed when a user clicks the help icon to the right of the component.
 #' @param path The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab.
-#' @param commands The menu with button actions. Ignored if `link` is True.
+#' @param commands When specified, a split button is rendered with extra actions tied to it within a context menu. Mutually exclusive with `link` attribute.
 #' @return A Button instance.
 #' @export
 ui_button <- function(

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -1179,29 +1179,33 @@ ui_color_picker <- function(
 #' @param icon The icon to be displayed for this command.
 #' @param value Data associated with this command, if any.
 #' @param path The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab.
-#' @return A ButtonCommand instance.
+#' @param disabled True if the command should be disabled.
+#' @return A ButtonChoice instance.
 #' @export
-ui_button_command <- function(
+ui_button_choice <- function(
   name,
   label = NULL,
   caption = NULL,
   icon = NULL,
   value = NULL,
-  path = NULL) {
+  path = NULL,
+  disabled = NULL) {
   .guard_scalar("name", "character", name)
   .guard_scalar("label", "character", label)
   .guard_scalar("caption", "character", caption)
   .guard_scalar("icon", "character", icon)
   .guard_scalar("value", "character", value)
   .guard_scalar("path", "character", path)
+  .guard_scalar("disabled", "logical", disabled)
   .o <- list(
     name=name,
     label=label,
     caption=caption,
     icon=icon,
     value=value,
-    path=path)
-  class(.o) <- append(class(.o), c(.wave_obj, "WaveButtonCommand"))
+    path=path,
+    disabled=disabled)
+  class(.o) <- append(class(.o), c(.wave_obj, "WaveButtonChoice"))
   return(.o)
 }
 
@@ -1234,7 +1238,7 @@ ui_button_command <- function(
 #' @param visible True if the component should be visible. Defaults to True.
 #' @param tooltip An optional tooltip message displayed when a user clicks the help icon to the right of the component.
 #' @param path The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab.
-#' @param commands The menu with button actions. Ignored if `link` is True.
+#' @param choices The menu with button actions. Ignored if `link` is True.
 #' @return A Button instance.
 #' @export
 ui_button <- function(
@@ -1250,7 +1254,7 @@ ui_button <- function(
   visible = NULL,
   tooltip = NULL,
   path = NULL,
-  commands = NULL) {
+  choices = NULL) {
   .guard_scalar("name", "character", name)
   .guard_scalar("label", "character", label)
   .guard_scalar("caption", "character", caption)
@@ -1263,7 +1267,7 @@ ui_button <- function(
   .guard_scalar("visible", "logical", visible)
   .guard_scalar("tooltip", "character", tooltip)
   .guard_scalar("path", "character", path)
-  .guard_vector("commands", "WaveButtonCommand", commands)
+  .guard_vector("choices", "WaveButtonChoice", choices)
   .o <- list(button=list(
     name=name,
     label=label,
@@ -1277,7 +1281,7 @@ ui_button <- function(
     visible=visible,
     tooltip=tooltip,
     path=path,
-    commands=commands))
+    choices=choices))
   class(.o) <- append(class(.o), c(.wave_obj, "WaveComponent"))
   return(.o)
 }

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -1171,6 +1171,40 @@ ui_color_picker <- function(
   return(.o)
 }
 
+#' No documentation available.
+#'
+#' @param name An identifying name for this component. If the name is prefixed with a '#', the command sets the location hash to the name when executed.
+#' @param label The text displayed for this command.
+#' @param caption The caption for this command (typically a tooltip).
+#' @param icon The icon to be displayed for this command.
+#' @param value Data associated with this command, if any.
+#' @param path The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab.
+#' @return A ButtonCommand instance.
+#' @export
+ui_button_command <- function(
+  name,
+  label = NULL,
+  caption = NULL,
+  icon = NULL,
+  value = NULL,
+  path = NULL) {
+  .guard_scalar("name", "character", name)
+  .guard_scalar("label", "character", label)
+  .guard_scalar("caption", "character", caption)
+  .guard_scalar("icon", "character", icon)
+  .guard_scalar("value", "character", value)
+  .guard_scalar("path", "character", path)
+  .o <- list(
+    name=name,
+    label=label,
+    caption=caption,
+    icon=icon,
+    value=value,
+    path=path)
+  class(.o) <- append(class(.o), c(.wave_obj, "WaveButtonCommand"))
+  return(.o)
+}
+
 #' Create a button.
 #' 
 #' Buttons are best used to enable a user to commit a change or complete steps in a task.
@@ -1200,6 +1234,7 @@ ui_color_picker <- function(
 #' @param visible True if the component should be visible. Defaults to True.
 #' @param tooltip An optional tooltip message displayed when a user clicks the help icon to the right of the component.
 #' @param path The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab.
+#' @param commands The menu with button actions.
 #' @return A Button instance.
 #' @export
 ui_button <- function(
@@ -1214,7 +1249,8 @@ ui_button <- function(
   width = NULL,
   visible = NULL,
   tooltip = NULL,
-  path = NULL) {
+  path = NULL,
+  commands = NULL) {
   .guard_scalar("name", "character", name)
   .guard_scalar("label", "character", label)
   .guard_scalar("caption", "character", caption)
@@ -1227,6 +1263,7 @@ ui_button <- function(
   .guard_scalar("visible", "logical", visible)
   .guard_scalar("tooltip", "character", tooltip)
   .guard_scalar("path", "character", path)
+  .guard_vector("commands", "WaveButtonCommand", commands)
   .o <- list(button=list(
     name=name,
     label=label,
@@ -1239,7 +1276,8 @@ ui_button <- function(
     width=width,
     visible=visible,
     tooltip=tooltip,
-    path=path))
+    path=path,
+    commands=commands))
   class(.o) <- append(class(.o), c(.wave_obj, "WaveComponent"))
   return(.o)
 }

--- a/tools/intellij-plugin/src/main/resources/templates/wave-components.xml
+++ b/tools/intellij-plugin/src/main/resources/templates/wave-components.xml
@@ -998,14 +998,14 @@
       <option name="Python" value="true"/>
     </context>
   </template>
-  <template name="w_full_button_choice" value="ui.button_choice(name='$name$',label='$label$',caption='$caption$',icon='$icon$',value='$value$',path='$path$',disabled=$disabled$),$END$" description="Create Wave ButtonChoice with full attributes." toReformat="true" toShortenFQNames="true">
+  <template name="w_full_button_choice" value="ui.button_choice(name='$name$',label='$label$',caption='$caption$',icon='$icon$',value='$value$',disabled=$disabled$,path='$path$'),$END$" description="Create Wave ButtonChoice with full attributes." toReformat="true" toShortenFQNames="true">
     <variable name="name" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="label" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="caption" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="icon" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="value" expression="" defaultValue="" alwaysStopAt="true"/>
-    <variable name="path" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="disabled" expression="" defaultValue="&quot;False&quot;" alwaysStopAt="true"/>
+    <variable name="path" expression="" defaultValue="" alwaysStopAt="true"/>
     <context>
       <option name="Python" value="true"/>
     </context>

--- a/tools/intellij-plugin/src/main/resources/templates/wave-components.xml
+++ b/tools/intellij-plugin/src/main/resources/templates/wave-components.xml
@@ -20,12 +20,6 @@
       <option name="Python" value="true"/>
     </context>
   </template>
-  <template name="w_button_choice" value="ui.button_choice(name='$name$'),$END$" description="Create a minimal Wave ButtonChoice." toReformat="true" toShortenFQNames="true">
-    <variable name="name" expression="" defaultValue="" alwaysStopAt="true"/>
-    <context>
-      <option name="Python" value="true"/>
-    </context>
-  </template>
   <template name="w_button" value="ui.button(name='$name$'),$END$" description="Create a minimal Wave Button." toReformat="true" toShortenFQNames="true">
     <variable name="name" expression="" defaultValue="" alwaysStopAt="true"/>
     <context>
@@ -998,19 +992,7 @@
       <option name="Python" value="true"/>
     </context>
   </template>
-  <template name="w_full_button_choice" value="ui.button_choice(name='$name$',label='$label$',caption='$caption$',icon='$icon$',value='$value$',disabled=$disabled$,path='$path$'),$END$" description="Create Wave ButtonChoice with full attributes." toReformat="true" toShortenFQNames="true">
-    <variable name="name" expression="" defaultValue="" alwaysStopAt="true"/>
-    <variable name="label" expression="" defaultValue="" alwaysStopAt="true"/>
-    <variable name="caption" expression="" defaultValue="" alwaysStopAt="true"/>
-    <variable name="icon" expression="" defaultValue="" alwaysStopAt="true"/>
-    <variable name="value" expression="" defaultValue="" alwaysStopAt="true"/>
-    <variable name="disabled" expression="" defaultValue="&quot;False&quot;" alwaysStopAt="true"/>
-    <variable name="path" expression="" defaultValue="" alwaysStopAt="true"/>
-    <context>
-      <option name="Python" value="true"/>
-    </context>
-  </template>
-  <template name="w_full_button" value="ui.button(name='$name$',label='$label$',caption='$caption$',value='$value$',primary=$primary$,disabled=$disabled$,link=$link$,icon='$icon$',width='$width$',visible=$visible$,tooltip='$tooltip$',path='$path$',choices=[&#10;	$choices$	&#10;]),$END$" description="Create Wave Button with full attributes." toReformat="true" toShortenFQNames="true">
+  <template name="w_full_button" value="ui.button(name='$name$',label='$label$',caption='$caption$',value='$value$',primary=$primary$,disabled=$disabled$,link=$link$,icon='$icon$',width='$width$',visible=$visible$,tooltip='$tooltip$',path='$path$',commands=[&#10;	$commands$	&#10;]),$END$" description="Create Wave Button with full attributes." toReformat="true" toShortenFQNames="true">
     <variable name="name" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="label" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="caption" expression="" defaultValue="" alwaysStopAt="true"/>
@@ -1023,7 +1005,7 @@
     <variable name="visible" expression="" defaultValue="&quot;True&quot;" alwaysStopAt="true"/>
     <variable name="tooltip" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="path" expression="" defaultValue="" alwaysStopAt="true"/>
-    <variable name="choices" expression="" defaultValue="" alwaysStopAt="true"/>
+    <variable name="commands" expression="" defaultValue="" alwaysStopAt="true"/>
     <context>
       <option name="Python" value="true"/>
     </context>

--- a/tools/intellij-plugin/src/main/resources/templates/wave-components.xml
+++ b/tools/intellij-plugin/src/main/resources/templates/wave-components.xml
@@ -20,6 +20,12 @@
       <option name="Python" value="true"/>
     </context>
   </template>
+  <template name="w_button_command" value="ui.button_command(name='$name$'),$END$" description="Create a minimal Wave ButtonCommand." toReformat="true" toShortenFQNames="true">
+    <variable name="name" expression="" defaultValue="" alwaysStopAt="true"/>
+    <context>
+      <option name="Python" value="true"/>
+    </context>
+  </template>
   <template name="w_button" value="ui.button(name='$name$'),$END$" description="Create a minimal Wave Button." toReformat="true" toShortenFQNames="true">
     <variable name="name" expression="" defaultValue="" alwaysStopAt="true"/>
     <context>
@@ -992,7 +998,18 @@
       <option name="Python" value="true"/>
     </context>
   </template>
-  <template name="w_full_button" value="ui.button(name='$name$',label='$label$',caption='$caption$',value='$value$',primary=$primary$,disabled=$disabled$,link=$link$,icon='$icon$',width='$width$',visible=$visible$,tooltip='$tooltip$',path='$path$'),$END$" description="Create Wave Button with full attributes." toReformat="true" toShortenFQNames="true">
+  <template name="w_full_button_command" value="ui.button_command(name='$name$',label='$label$',caption='$caption$',icon='$icon$',value='$value$',path='$path$'),$END$" description="Create Wave ButtonCommand with full attributes." toReformat="true" toShortenFQNames="true">
+    <variable name="name" expression="" defaultValue="" alwaysStopAt="true"/>
+    <variable name="label" expression="" defaultValue="" alwaysStopAt="true"/>
+    <variable name="caption" expression="" defaultValue="" alwaysStopAt="true"/>
+    <variable name="icon" expression="" defaultValue="" alwaysStopAt="true"/>
+    <variable name="value" expression="" defaultValue="" alwaysStopAt="true"/>
+    <variable name="path" expression="" defaultValue="" alwaysStopAt="true"/>
+    <context>
+      <option name="Python" value="true"/>
+    </context>
+  </template>
+  <template name="w_full_button" value="ui.button(name='$name$',label='$label$',caption='$caption$',value='$value$',primary=$primary$,disabled=$disabled$,link=$link$,icon='$icon$',width='$width$',visible=$visible$,tooltip='$tooltip$',path='$path$',commands=[&#10;	$commands$	&#10;]),$END$" description="Create Wave Button with full attributes." toReformat="true" toShortenFQNames="true">
     <variable name="name" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="label" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="caption" expression="" defaultValue="" alwaysStopAt="true"/>
@@ -1005,6 +1022,7 @@
     <variable name="visible" expression="" defaultValue="&quot;True&quot;" alwaysStopAt="true"/>
     <variable name="tooltip" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="path" expression="" defaultValue="" alwaysStopAt="true"/>
+    <variable name="commands" expression="" defaultValue="" alwaysStopAt="true"/>
     <context>
       <option name="Python" value="true"/>
     </context>

--- a/tools/intellij-plugin/src/main/resources/templates/wave-components.xml
+++ b/tools/intellij-plugin/src/main/resources/templates/wave-components.xml
@@ -20,7 +20,7 @@
       <option name="Python" value="true"/>
     </context>
   </template>
-  <template name="w_button_command" value="ui.button_command(name='$name$'),$END$" description="Create a minimal Wave ButtonCommand." toReformat="true" toShortenFQNames="true">
+  <template name="w_button_choice" value="ui.button_choice(name='$name$'),$END$" description="Create a minimal Wave ButtonChoice." toReformat="true" toShortenFQNames="true">
     <variable name="name" expression="" defaultValue="" alwaysStopAt="true"/>
     <context>
       <option name="Python" value="true"/>
@@ -998,18 +998,19 @@
       <option name="Python" value="true"/>
     </context>
   </template>
-  <template name="w_full_button_command" value="ui.button_command(name='$name$',label='$label$',caption='$caption$',icon='$icon$',value='$value$',path='$path$'),$END$" description="Create Wave ButtonCommand with full attributes." toReformat="true" toShortenFQNames="true">
+  <template name="w_full_button_choice" value="ui.button_choice(name='$name$',label='$label$',caption='$caption$',icon='$icon$',value='$value$',path='$path$',disabled=$disabled$),$END$" description="Create Wave ButtonChoice with full attributes." toReformat="true" toShortenFQNames="true">
     <variable name="name" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="label" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="caption" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="icon" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="value" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="path" expression="" defaultValue="" alwaysStopAt="true"/>
+    <variable name="disabled" expression="" defaultValue="&quot;False&quot;" alwaysStopAt="true"/>
     <context>
       <option name="Python" value="true"/>
     </context>
   </template>
-  <template name="w_full_button" value="ui.button(name='$name$',label='$label$',caption='$caption$',value='$value$',primary=$primary$,disabled=$disabled$,link=$link$,icon='$icon$',width='$width$',visible=$visible$,tooltip='$tooltip$',path='$path$',commands=[&#10;	$commands$	&#10;]),$END$" description="Create Wave Button with full attributes." toReformat="true" toShortenFQNames="true">
+  <template name="w_full_button" value="ui.button(name='$name$',label='$label$',caption='$caption$',value='$value$',primary=$primary$,disabled=$disabled$,link=$link$,icon='$icon$',width='$width$',visible=$visible$,tooltip='$tooltip$',path='$path$',choices=[&#10;	$choices$	&#10;]),$END$" description="Create Wave Button with full attributes." toReformat="true" toShortenFQNames="true">
     <variable name="name" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="label" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="caption" expression="" defaultValue="" alwaysStopAt="true"/>
@@ -1022,7 +1023,7 @@
     <variable name="visible" expression="" defaultValue="&quot;True&quot;" alwaysStopAt="true"/>
     <variable name="tooltip" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="path" expression="" defaultValue="" alwaysStopAt="true"/>
-    <variable name="commands" expression="" defaultValue="" alwaysStopAt="true"/>
+    <variable name="choices" expression="" defaultValue="" alwaysStopAt="true"/>
     <context>
       <option name="Python" value="true"/>
     </context>

--- a/tools/vscode-extension/component-snippets.json
+++ b/tools/vscode-extension/component-snippets.json
@@ -968,7 +968,7 @@
   "Wave Full ButtonChoice": {
     "prefix": "w_full_button_choice",
     "body": [
-      "ui.button_choice(name='$1', label='$2', caption='$3', icon='$4', value='$5', path='$6', disabled=${7:False}),$0"
+      "ui.button_choice(name='$1', label='$2', caption='$3', icon='$4', value='$5', disabled=${6:False}, path='$7'),$0"
     ],
     "description": "Create a full Wave ButtonChoice."
   },

--- a/tools/vscode-extension/component-snippets.json
+++ b/tools/vscode-extension/component-snippets.json
@@ -20,13 +20,6 @@
     ],
     "description": "Create a minimal Wave BreadcrumbsCard."
   },
-  "Wave ButtonChoice": {
-    "prefix": "w_button_choice",
-    "body": [
-      "ui.button_choice(name='$1'),$0"
-    ],
-    "description": "Create a minimal Wave ButtonChoice."
-  },
   "Wave Button": {
     "prefix": "w_button",
     "body": [
@@ -965,17 +958,10 @@
     ],
     "description": "Create a full Wave BreadcrumbsCard."
   },
-  "Wave Full ButtonChoice": {
-    "prefix": "w_full_button_choice",
-    "body": [
-      "ui.button_choice(name='$1', label='$2', caption='$3', icon='$4', value='$5', disabled=${6:False}, path='$7'),$0"
-    ],
-    "description": "Create a full Wave ButtonChoice."
-  },
   "Wave Full Button": {
     "prefix": "w_full_button",
     "body": [
-      "ui.button(name='$1', label='$2', caption='$3', value='$4', primary=${5:False}, disabled=${6:False}, link=${7:False}, icon='$8', width='$9', visible=${10:True}, tooltip='$11', path='$12', choices=[\n\t\t$13\t\t\n]),$0"
+      "ui.button(name='$1', label='$2', caption='$3', value='$4', primary=${5:False}, disabled=${6:False}, link=${7:False}, icon='$8', width='$9', visible=${10:True}, tooltip='$11', path='$12', commands=[\n\t\t$13\t\t\n]),$0"
     ],
     "description": "Create a full Wave Button."
   },

--- a/tools/vscode-extension/component-snippets.json
+++ b/tools/vscode-extension/component-snippets.json
@@ -20,6 +20,13 @@
     ],
     "description": "Create a minimal Wave BreadcrumbsCard."
   },
+  "Wave ButtonCommand": {
+    "prefix": "w_button_command",
+    "body": [
+      "ui.button_command(name='$1'),$0"
+    ],
+    "description": "Create a minimal Wave ButtonCommand."
+  },
   "Wave Button": {
     "prefix": "w_button",
     "body": [
@@ -958,10 +965,17 @@
     ],
     "description": "Create a full Wave BreadcrumbsCard."
   },
+  "Wave Full ButtonCommand": {
+    "prefix": "w_full_button_command",
+    "body": [
+      "ui.button_command(name='$1', label='$2', caption='$3', icon='$4', value='$5', path='$6'),$0"
+    ],
+    "description": "Create a full Wave ButtonCommand."
+  },
   "Wave Full Button": {
     "prefix": "w_full_button",
     "body": [
-      "ui.button(name='$1', label='$2', caption='$3', value='$4', primary=${5:False}, disabled=${6:False}, link=${7:False}, icon='$8', width='$9', visible=${10:True}, tooltip='$11', path='$12'),$0"
+      "ui.button(name='$1', label='$2', caption='$3', value='$4', primary=${5:False}, disabled=${6:False}, link=${7:False}, icon='$8', width='$9', visible=${10:True}, tooltip='$11', path='$12', commands=[\n\t\t$13\t\t\n]),$0"
     ],
     "description": "Create a full Wave Button."
   },

--- a/tools/vscode-extension/component-snippets.json
+++ b/tools/vscode-extension/component-snippets.json
@@ -20,12 +20,12 @@
     ],
     "description": "Create a minimal Wave BreadcrumbsCard."
   },
-  "Wave ButtonCommand": {
-    "prefix": "w_button_command",
+  "Wave ButtonChoice": {
+    "prefix": "w_button_choice",
     "body": [
-      "ui.button_command(name='$1'),$0"
+      "ui.button_choice(name='$1'),$0"
     ],
-    "description": "Create a minimal Wave ButtonCommand."
+    "description": "Create a minimal Wave ButtonChoice."
   },
   "Wave Button": {
     "prefix": "w_button",
@@ -965,17 +965,17 @@
     ],
     "description": "Create a full Wave BreadcrumbsCard."
   },
-  "Wave Full ButtonCommand": {
-    "prefix": "w_full_button_command",
+  "Wave Full ButtonChoice": {
+    "prefix": "w_full_button_choice",
     "body": [
-      "ui.button_command(name='$1', label='$2', caption='$3', icon='$4', value='$5', path='$6'),$0"
+      "ui.button_choice(name='$1', label='$2', caption='$3', icon='$4', value='$5', path='$6', disabled=${7:False}),$0"
     ],
-    "description": "Create a full Wave ButtonCommand."
+    "description": "Create a full Wave ButtonChoice."
   },
   "Wave Full Button": {
     "prefix": "w_full_button",
     "body": [
-      "ui.button(name='$1', label='$2', caption='$3', value='$4', primary=${5:False}, disabled=${6:False}, link=${7:False}, icon='$8', width='$9', visible=${10:True}, tooltip='$11', path='$12', commands=[\n\t\t$13\t\t\n]),$0"
+      "ui.button(name='$1', label='$2', caption='$3', value='$4', primary=${5:False}, disabled=${6:False}, link=${7:False}, icon='$8', width='$9', visible=${10:True}, tooltip='$11', path='$12', choices=[\n\t\t$13\t\t\n]),$0"
     ],
     "description": "Create a full Wave Button."
   },

--- a/ui/src/button.test.tsx
+++ b/ui/src/button.test.tsx
@@ -129,19 +129,13 @@ describe('Button.tsx', () => {
         button: {
           name,
           label: name,
-          value: 'val',
           choices: [
-            { name: 'choice1', label: 'Choice 1', value: 'choiceVal1' },
-            { name: 'choice2', label: 'Choice 2', value: 'choiceVal2' },
+            { name: 'choice1', label: 'Choice 1' },
+            { name: 'choice2', label: 'Choice 2' },
           ]
         }
       }]
     }
-
-    beforeEach(() => {
-      wave.args['choice1'] = null
-      wave.args['choice2 '] = null
-    })
 
     it('Renders the context menu with specified items', () => {
       const { container, queryByText, queryByRole } = render(<XButtons model={buttonProps} />)
@@ -150,15 +144,49 @@ describe('Button.tsx', () => {
       expect(queryByText('Choice 1')).not.toBeInTheDocument()
       expect(queryByText('Choice 2')).not.toBeInTheDocument()
 
-      fireEvent.click(container.querySelector('i[data-icon-name="ChevronDown"]') as HTMLLIElement)
+      const contextMenuButton = container.querySelector('i[data-icon-name="ChevronDown"]') as HTMLLIElement
+      fireEvent.click(contextMenuButton)
 
       expect(queryByRole('menu')).toBeInTheDocument()
       expect(queryByText('Choice 1')).toBeInTheDocument()
       expect(queryByText('Choice 2')).toBeInTheDocument()
     })
 
-    it('Sets args after click - specified value', () => {
+    it('Sets args after click', () => {
       const { container, getByText } = render(<XButtons model={buttonProps} />)
+
+      expect(wave.args[name]).toBe(false)
+      fireEvent.click(getByText(name))
+      expect(wave.args[name]).toBe(true)
+
+      const contextMenuButton = container.querySelector('i[data-icon-name="ChevronDown"]') as HTMLLIElement
+
+      expect(wave.args['choice1']).toBe(false)
+      fireEvent.click(contextMenuButton)
+      fireEvent.click(getByText('Choice 1'))
+      expect(wave.args['choice1']).toBe(true)
+
+      expect(wave.args['choice2']).toBe(false)
+      fireEvent.click(contextMenuButton)
+      fireEvent.click(getByText('Choice 2'))
+      expect(wave.args['choice2']).toBe(true)
+    })
+
+    it('Sets args after click - specified value', () => {
+      const buttonValueProps = {
+        items: [{
+          button: {
+            name,
+            label: name,
+            value: 'val',
+            choices: [
+              { name: 'choice1', label: 'Choice 1', value: 'choiceVal1' },
+              { name: 'choice2', label: 'Choice 2', value: 'choiceVal2' },
+            ]
+          }
+        }]
+      }
+      const { container, getByText } = render(<XButtons model={buttonValueProps} />)
 
       expect(wave.args[name]).toBe(false)
       fireEvent.click(getByText(name))
@@ -178,7 +206,7 @@ describe('Button.tsx', () => {
     })
 
     it('Sets correct state when name starts with #', () => {
-      const btnPropsNameHash = {
+      const btnNameHashProps = {
         items: [{
           button: {
             name: hashName,
@@ -191,28 +219,26 @@ describe('Button.tsx', () => {
           }
         }]
       }
+      const { getByText, container } = render(<XButtons model={btnNameHashProps} />)
 
-      wave.args['#choice1'] = null
-      wave.args['#choice2 '] = null
-
-      const { getByText, container } = render(<XButtons model={btnPropsNameHash} />)
       fireEvent.click(getByText(name))
       expect(window.location.hash).toBe(hashName)
       expect(pushMock).toHaveBeenCalledTimes(0)
       expect(wave.args[name]).toBe(null)
 
       const contextMenuButton = container.querySelector('i[data-icon-name="ChevronDown"]') as HTMLLIElement
+      wave.args['#choice1'] = null
 
       fireEvent.click(contextMenuButton)
       fireEvent.click(getByText('Choice 1'))
       expect(window.location.hash).toBe('#choice1')
       expect(pushMock).toHaveBeenCalledTimes(0)
-      expect(wave.args['#choice1']).toBe(null) // TODO: Why is it false??
+      expect(wave.args['#choice1']).toBe(null)
     })
 
     it('Does redirect if the choice has path specified', () => {
       const
-        btnPropsPath = {
+        btnPathProps = {
           items: [{
             button: {
               name: name,
@@ -226,7 +252,7 @@ describe('Button.tsx', () => {
           }]
         },
         windowOpenMock = jest.fn(),
-        { getByText, container } = render(<XButtons model={btnPropsPath} />)
+        { getByText, container } = render(<XButtons model={btnPathProps} />)
 
       window.open = windowOpenMock
       const contextMenuButton = container.querySelector('i[data-icon-name="ChevronDown"]') as HTMLLIElement
@@ -238,6 +264,26 @@ describe('Button.tsx', () => {
       fireEvent.click(contextMenuButton)
       fireEvent.click(getByText('Choice 2'))
       expect(windowOpenMock).toHaveBeenCalled()
+    })
+
+    it('Does not render choices when link specified', () => {
+      const btnLinkProps: Buttons = {
+        items: [{
+          button: {
+            name,
+            label: name,
+            link: true,
+            choices: [
+              { name: 'choice1', label: 'Choice 1' },
+              { name: 'choice2', label: 'Choice 2' },
+            ]
+          }
+        }]
+      }
+      const { container, getByTestId } = render(<XButtons model={btnLinkProps} />)
+
+      expect(getByTestId(name)).toHaveClass('ms-Link')
+      expect(container.querySelector('i[data-icon-name="ChevronDown"]') as HTMLLIElement).not.toBeInTheDocument()
     })
   })
 })

--- a/ui/src/button.test.tsx
+++ b/ui/src/button.test.tsx
@@ -123,15 +123,15 @@ describe('Button.tsx', () => {
     })
   })
 
-  describe('Choices button', () => {
+  describe('Commands button', () => {
     const buttonProps = {
       items: [{
         button: {
           name,
           label: name,
-          choices: [
-            { name: 'choice1', label: 'Choice 1' },
-            { name: 'choice2', label: 'Choice 2' },
+          commands: [
+            { name: 'command1', label: 'Command 1' },
+            { name: 'command2', label: 'Command 2' },
           ]
         }
       }]
@@ -141,15 +141,15 @@ describe('Button.tsx', () => {
       const { container, queryByText, queryByRole } = render(<XButtons model={buttonProps} />)
 
       expect(queryByRole('menu')).not.toBeInTheDocument()
-      expect(queryByText('Choice 1')).not.toBeInTheDocument()
-      expect(queryByText('Choice 2')).not.toBeInTheDocument()
+      expect(queryByText('Command 1')).not.toBeInTheDocument()
+      expect(queryByText('Command 2')).not.toBeInTheDocument()
 
       const contextMenuButton = container.querySelector('i[data-icon-name="ChevronDown"]') as HTMLLIElement
       fireEvent.click(contextMenuButton)
 
       expect(queryByRole('menu')).toBeInTheDocument()
-      expect(queryByText('Choice 1')).toBeInTheDocument()
-      expect(queryByText('Choice 2')).toBeInTheDocument()
+      expect(queryByText('Command 1')).toBeInTheDocument()
+      expect(queryByText('Command 2')).toBeInTheDocument()
     })
 
     it('Sets args after click', () => {
@@ -161,15 +161,15 @@ describe('Button.tsx', () => {
 
       const contextMenuButton = container.querySelector('i[data-icon-name="ChevronDown"]') as HTMLLIElement
 
-      expect(wave.args['choice1']).toBe(false)
+      expect(wave.args['command1']).toBe(false)
       fireEvent.click(contextMenuButton)
-      fireEvent.click(getByText('Choice 1'))
-      expect(wave.args['choice1']).toBe(true)
+      fireEvent.click(getByText('Command 1'))
+      expect(wave.args['command1']).toBe(true)
 
-      expect(wave.args['choice2']).toBe(false)
+      expect(wave.args['command2']).toBe(false)
       fireEvent.click(contextMenuButton)
-      fireEvent.click(getByText('Choice 2'))
-      expect(wave.args['choice2']).toBe(true)
+      fireEvent.click(getByText('Command 2'))
+      expect(wave.args['command2']).toBe(true)
     })
 
     it('Sets args after click - specified value', () => {
@@ -179,9 +179,9 @@ describe('Button.tsx', () => {
             name,
             label: name,
             value: 'val',
-            choices: [
-              { name: 'choice1', label: 'Choice 1', value: 'choiceVal1' },
-              { name: 'choice2', label: 'Choice 2', value: 'choiceVal2' },
+            commands: [
+              { name: 'command1', label: 'Command 1', value: 'commandVal1' },
+              { name: 'command2', label: 'Command 2', value: 'commandVal2' },
             ]
           }
         }]
@@ -194,15 +194,15 @@ describe('Button.tsx', () => {
 
       const contextMenuButton = container.querySelector('i[data-icon-name="ChevronDown"]') as HTMLLIElement
 
-      expect(wave.args['choice1']).toBe(false)
+      expect(wave.args['command1']).toBe(false)
       fireEvent.click(contextMenuButton)
-      fireEvent.click(getByText('Choice 1'))
-      expect(wave.args['choice1']).toBe('choiceVal1')
+      fireEvent.click(getByText('Command 1'))
+      expect(wave.args['command1']).toBe('commandVal1')
 
-      expect(wave.args['choice2']).toBe(false)
+      expect(wave.args['command2']).toBe(false)
       fireEvent.click(contextMenuButton)
-      fireEvent.click(getByText('Choice 2'))
-      expect(wave.args['choice2']).toBe('choiceVal2')
+      fireEvent.click(getByText('Command 2'))
+      expect(wave.args['command2']).toBe('commandVal2')
     })
 
     it('Sets correct state when name starts with #', () => {
@@ -212,9 +212,9 @@ describe('Button.tsx', () => {
             name: hashName,
             label: name,
             value: 'val',
-            choices: [
-              { name: '#choice1', label: 'Choice 1', value: 'choiceVal1' },
-              { name: '#choice2', label: 'Choice 2', value: 'choiceVal2' },
+            commands: [
+              { name: '#command1', label: 'Command 1', value: 'commandVal1' },
+              { name: '#command2', label: 'Command 2', value: 'commandVal2' },
             ]
           }
         }]
@@ -229,52 +229,22 @@ describe('Button.tsx', () => {
       const contextMenuButton = container.querySelector('i[data-icon-name="ChevronDown"]') as HTMLLIElement
 
       fireEvent.click(contextMenuButton)
-      fireEvent.click(getByText('Choice 1'))
-      expect(window.location.hash).toBe('#choice1')
+      fireEvent.click(getByText('Command 1'))
+      expect(window.location.hash).toBe('#command1')
       expect(pushMock).toHaveBeenCalledTimes(0)
-      expect(wave.args['#choice1']).toBe(false)
+      expect(wave.args['#command1']).toBe(false)
     })
 
-    it('Does redirect if the choice has path specified', () => {
-      const
-        btnPathProps = {
-          items: [{
-            button: {
-              name: name,
-              label: name,
-              value: 'val',
-              choices: [
-                { name: 'choice1', label: 'Choice 1', value: 'choiceVal1' },
-                { name: 'choice2', label: 'Choice 2', value: 'choiceVal2', path: 'https://h2o.ai/' },
-              ]
-            }
-          }]
-        },
-        windowOpenMock = jest.fn(),
-        { getByText, container } = render(<XButtons model={btnPathProps} />)
-
-      window.open = windowOpenMock
-      const contextMenuButton = container.querySelector('i[data-icon-name="ChevronDown"]') as HTMLLIElement
-
-      fireEvent.click(contextMenuButton)
-      fireEvent.click(getByText('Choice 1'))
-      expect(windowOpenMock).not.toHaveBeenCalled()
-
-      fireEvent.click(contextMenuButton)
-      fireEvent.click(getByText('Choice 2'))
-      expect(windowOpenMock).toHaveBeenCalled()
-    })
-
-    it('Does not render choices when link specified', () => {
+    it('Does not render commands when link specified', () => {
       const btnLinkProps: Buttons = {
         items: [{
           button: {
             name,
             label: name,
             link: true,
-            choices: [
-              { name: 'choice1', label: 'Choice 1' },
-              { name: 'choice2', label: 'Choice 2' },
+            commands: [
+              { name: 'command1', label: 'Command 1' },
+              { name: 'command2', label: 'Command 2' },
             ]
           }
         }]

--- a/ui/src/button.test.tsx
+++ b/ui/src/button.test.tsx
@@ -227,13 +227,12 @@ describe('Button.tsx', () => {
       expect(wave.args[name]).toBe(null)
 
       const contextMenuButton = container.querySelector('i[data-icon-name="ChevronDown"]') as HTMLLIElement
-      wave.args['#choice1'] = null
 
       fireEvent.click(contextMenuButton)
       fireEvent.click(getByText('Choice 1'))
       expect(window.location.hash).toBe('#choice1')
       expect(pushMock).toHaveBeenCalledTimes(0)
-      expect(wave.args['#choice1']).toBe(null)
+      expect(wave.args['#choice1']).toBe(false)
     })
 
     it('Does redirect if the choice has path specified', () => {

--- a/ui/src/button.tsx
+++ b/ui/src/button.tsx
@@ -114,6 +114,13 @@ const
     center: 'center',
     between: 'space-between',
     around: 'space-around',
+  },
+  // Fixes the vertical scrollbar for menu items with icons.
+  subComponentStyles: Partial<Fluent.IContextualMenuSubComponentStyles> = {
+    menuItem: {
+      icon: { lineHeight: 'initial' },
+      subMenuIcon: { lineHeight: 'initial', height: 'auto' },
+    }
   }
 
 const
@@ -141,6 +148,7 @@ const
             ? { items: getItemProps(items), styles: { subComponentStyles } }
             : undefined
         })),
+      isIconOnly = !label && icon,
       // HACK: Our visibility logic in XComponents doesn't count with nested components, e.g. Butttons > Button.
       styles: Fluent.IButtonStyles = {
         root: {
@@ -152,14 +160,10 @@ const
           fontSize: 20,
           display: 'flex',
           alignItems: 'center'
-        }
-      },
-      // Fixes the vertical scrollbar for menu items with icons.
-      subComponentStyles: Partial<Fluent.IContextualMenuSubComponentStyles> = {
-        menuItem: {
-          icon: { lineHeight: 'initial' },
-          subMenuIcon: { lineHeight: 'initial', height: 'auto' }
-        }
+        },
+        splitButtonMenuButton: isIconOnly
+          ? { backgroundColor: cssVar('$card'), border: 'none' }
+          : undefined
       }
 
 
@@ -184,7 +188,7 @@ const
       } : undefined,
       split: !!commands
     }
-    if (!label && icon) return <Fluent.IconButton {...btnProps} data-test={name} title={caption} />
+    if (isIconOnly) return <Fluent.IconButton {...btnProps} data-test={name} title={caption} />
 
     return caption?.length
       ? primary

--- a/ui/src/button.tsx
+++ b/ui/src/button.tsx
@@ -21,7 +21,7 @@ import { cssVar, formItemWidth, padding } from './theme'
 import { XToolTip } from './tooltip'
 import { wave } from './ui'
 
-interface ButtonCommand {
+interface ButtonChoice {
   /** An identifying name for this component. If the name is prefixed with a '#', the command sets the location hash to the name when executed. */
   name: Id
   /** The text displayed for this command. */
@@ -34,6 +34,8 @@ interface ButtonCommand {
   value?: S
   /** The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab. */
   path?: S
+  /** True if the command should be disabled. */
+  disabled?: B
 }
 
 /**
@@ -80,7 +82,7 @@ export interface Button {
   /** The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab. */
   path?: S
   /** The menu with button actions. Ignored if `link` is True. */
-  commands?: ButtonCommand[]
+  choices?: ButtonChoice[]
 }
 
 /** Create a set of buttons laid out horizontally. */
@@ -131,7 +133,7 @@ const
   }
 
 const
-  XButton = ({ model: { name, visible = true, link, label, disabled, icon, caption, value, primary, width, path, commands } }: { model: Button }) => {
+  XButton = ({ model: { name, visible = true, link, label, disabled, icon, caption, value, primary, width, path, choices } }: { model: Button }) => {
     const
       handleOnClick = (name: Id, value?: S, path?: S) => (ev: any) => {
         ev.stopPropagation()
@@ -156,9 +158,9 @@ const
           alignItems: 'center'
         }
       },
-      menuItems = commands
-        ? commands.map(({ name, label, caption, icon, value, path }) =>
-          ({ key: name, text: label, title: caption, iconProps: { iconName: icon }, data: value, onClick: handleOnClick(name, value, path) })
+      menuItems = choices
+        ? choices.map(({ name, label, caption, icon, value, path, disabled }) =>
+          ({ key: name, text: label, title: caption, iconProps: { iconName: icon }, data: value, disabled, onClick: handleOnClick(name, value, path) })
         )
         : undefined
 
@@ -174,7 +176,8 @@ const
       onClick,
       styles,
       iconProps: { iconName: icon },
-      menuProps: menuItems ? { items: menuItems } : undefined
+      menuProps: menuItems ? { items: menuItems } : undefined,
+      split: !!menuItems
     }
     if (!label && icon) return <Fluent.IconButton {...btnProps} data-test={name} title={caption} />
 

--- a/ui/src/button.tsx
+++ b/ui/src/button.tsx
@@ -142,10 +142,13 @@ const
           alignItems: 'center'
         }
       },
-      menuItems = commands
-        ? commands.map(({ name, label, caption, icon, value, data }) => // TODO: add items
-          ({ key: name, text: label, title: caption, iconProps: { iconName: icon }, data: value ?? data, disabled, onClick: handleOnClick(name, value, path) })
+      getItemProps = (commands: Command[]) => {
+        return commands.map(({ name, label, caption, icon, value, data, items }) => // TODO: add items
+          ({ key: name, text: label, title: caption, iconProps: { iconName: icon }, data: value ?? data, disabled, onClick: handleOnClick(name, value), subMenuProps: items ? { items: getItemProps(items) } : undefined })
         )
+      },
+      menuItems = commands
+        ? getItemProps(commands)
         : undefined
 
     React.useEffect(() => {
@@ -165,7 +168,8 @@ const
       iconProps: { iconName: icon },
       menuProps: menuItems ? {
         items: menuItems,
-        styles: { subComponentStyles: { menuItem: { icon: { lineHeight: 24 } } } }
+        // TODO: Add style for sub-items with an icon.
+        styles: { subComponentStyles: { menuItem: { icon: { lineHeight: 'initial' }, subMenuIcon: { lineHeight: 'initial', height: 'auto' } } } }
       } : undefined,
       split: !!menuItems
     }

--- a/ui/src/button.tsx
+++ b/ui/src/button.tsx
@@ -17,7 +17,7 @@ import { B, Dict, Id, S } from 'h2o-wave'
 import React from 'react'
 import { stylesheet } from 'typestyle'
 import { Component } from './form'
-import { cssVar, formItemWidth, padding } from './theme'
+import { border, cssVar, formItemWidth, padding } from './theme'
 import { Command, toCommands } from './toolbar'
 import { XToolTip } from './tooltip'
 import { wave } from './ui'
@@ -165,9 +165,12 @@ const
       iconProps: { iconName: icon },
       menuProps: commands ? {
         items: toCommands(commands),
-        styles: fixMenuOverflowStyles
+        styles: fixMenuOverflowStyles,
+        isBeakVisible: true,
+        directionalHint: Fluent.DirectionalHint.bottomRightEdge,
+        calloutProps: { styles: { beak: { border: border(1, cssVar('$neutralQuaternaryAlt')) } } }
       } : undefined,
-      split: !!commands
+      split: !!commands,
     }
     if (isIconOnly) return <Fluent.IconButton {...btnProps} data-test={name} title={caption} />
 

--- a/ui/src/button.tsx
+++ b/ui/src/button.tsx
@@ -18,7 +18,7 @@ import React from 'react'
 import { stylesheet } from 'typestyle'
 import { Component } from './form'
 import { cssVar, formItemWidth, padding } from './theme'
-import { Command } from './toolbar'
+import { Command, toCommands } from './toolbar'
 import { XToolTip } from './tooltip'
 import { wave } from './ui'
 
@@ -126,7 +126,7 @@ const
 const
   XButton = ({ model: { name, visible = true, link, label, disabled, icon, caption, value, primary, width, path, commands } }: { model: Button }) => {
     const
-      handleOnClick = (name: Id, value?: S, path?: S) => (ev: any) => {
+      onClick = (ev: any) => {
         ev.stopPropagation()
         if (path) window.open(path, "_blank")
         else if (name.startsWith('#')) window.location.hash = name.substring(1)
@@ -135,19 +135,6 @@ const
           wave.push()
         }
       },
-      onClick = handleOnClick(name, value, path),
-      getItemProps: (commands: Command[]) => Fluent.IContextualMenuItem[] = commands =>
-        commands.map(({ name, label, caption, icon, value, items }) => ({
-          key: name,
-          text: label,
-          title: caption,
-          iconProps: { iconName: icon },
-          disabled,
-          onClick: handleOnClick(name, value),
-          subMenuProps: items
-            ? { items: getItemProps(items), styles: { subComponentStyles } }
-            : undefined
-        })),
       isIconOnly = !label && icon,
       // HACK: Our visibility logic in XComponents doesn't count with nested components, e.g. Butttons > Button.
       styles: Fluent.IButtonStyles = {
@@ -183,7 +170,7 @@ const
       styles,
       iconProps: { iconName: icon },
       menuProps: commands ? {
-        items: getItemProps(commands),
+        items: toCommands(commands),
         styles: { subComponentStyles }
       } : undefined,
       split: !!commands

--- a/ui/src/button.tsx
+++ b/ui/src/button.tsx
@@ -22,20 +22,20 @@ import { XToolTip } from './tooltip'
 import { wave } from './ui'
 
 interface ButtonChoice {
-  /** An identifying name for this component. If the name is prefixed with a '#', the command sets the location hash to the name when executed. */
+  /** An identifying name for this choice. If the name is prefixed with a '#', the location hash is changed to the name when executed. */
   name: Id
-  /** The text displayed for this command. */
+  /** The text displayed for this choice. */
   label?: S
-  /** The caption for this command (typically a tooltip). */
+  /** The caption for this choice (typically a tooltip). */
   caption?: S
-  /** The icon to be displayed for this command. */
+  /** The icon to be displayed for this choice. */
   icon?: S
-  /** Data associated with this command, if any. */
+  /** A value for this choice. If a value is set, it is used for the choice's submitted instead of a boolean True. */
   value?: S
+  /** True if the choice should be disabled. */
+  disabled?: B
   /** The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab. */
   path?: S
-  /** True if the command should be disabled. */
-  disabled?: B
 }
 
 /**
@@ -164,8 +164,11 @@ const
         )
         : undefined
 
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    React.useEffect(() => { wave.args[name] = false }, [])
+    React.useEffect(() => {
+      wave.args[name] = false
+      choices?.forEach(({ name }) => wave.args[name] = false)
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [])
 
     if (link) {
       return <Fluent.Link data-test={name} disabled={disabled} onClick={onClick} styles={styles}>{label}</Fluent.Link>
@@ -176,7 +179,10 @@ const
       onClick,
       styles,
       iconProps: { iconName: icon },
-      menuProps: menuItems ? { items: menuItems } : undefined,
+      menuProps: menuItems ? {
+        items: menuItems,
+        styles: { subComponentStyles: { menuItem: { icon: { lineHeight: 24 } } } }
+      } : undefined,
       split: !!menuItems
     }
     if (!label && icon) return <Fluent.IconButton {...btnProps} data-test={name} title={caption} />

--- a/ui/src/button.tsx
+++ b/ui/src/button.tsx
@@ -65,7 +65,7 @@ export interface Button {
   tooltip?: S
   /** The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab. */
   path?: S
-  /** The menu with button actions. Ignored if `link` is True. */
+  /** When specified, a split button is rendered with extra actions tied to it within a context menu. Mutually exclusive with `link` attribute. */
   commands?: Command[]
 }
 

--- a/ui/src/button.tsx
+++ b/ui/src/button.tsx
@@ -129,6 +129,18 @@ const
         }
       },
       onClick = handleOnClick(name, value, path),
+      getItemProps: (commands: Command[]) => Fluent.IContextualMenuItem[] = commands =>
+        commands.map(({ name, label, caption, icon, value, data, items }) => ({
+          key: name,
+          text: label,
+          title: caption,
+          iconProps: { iconName: icon },
+          data: value ?? data, disabled,
+          onClick: handleOnClick(name, value),
+          subMenuProps: items
+            ? { items: getItemProps(items), styles: { subComponentStyles } }
+            : undefined
+        })),
       // HACK: Our visibility logic in XComponents doesn't count with nested components, e.g. Butttons > Button.
       styles: Fluent.IButtonStyles = {
         root: {
@@ -142,27 +154,14 @@ const
           alignItems: 'center'
         }
       },
-      menuStyles: Fluent.IContextualMenuStyles = {
-        subComponentStyles: { // TODO: Fix missing 'callout' from Fluent.IContextualMenuSubComponentStyles; Partial<> not working
-          menuItem: {
-            icon: { lineHeight: 'initial' },
-            subMenuIcon: { lineHeight: 'initial', height: 'auto' }
-          },
+      // Fixes the vertical scrollbar for menu items with icons.
+      subComponentStyles: Partial<Fluent.IContextualMenuSubComponentStyles> = {
+        menuItem: {
+          icon: { lineHeight: 'initial' },
+          subMenuIcon: { lineHeight: 'initial', height: 'auto' }
         }
-      },
-      getItemProps: (commands: Command[]) => Fluent.IContextualMenuItem[] = commands => {
-        return commands.map(({ name, label, caption, icon, value, data, items }) => ({
-          key: name,
-          text: label,
-          title: caption,
-          iconProps: { iconName: icon },
-          data: value ?? data, disabled,
-          onClick: handleOnClick(name, value),
-          subMenuProps: items
-            ? { items: getItemProps(items), styles: menuStyles }
-            : undefined
-        }))
       }
+
 
     React.useEffect(() => {
       wave.args[name] = false
@@ -181,7 +180,7 @@ const
       iconProps: { iconName: icon },
       menuProps: commands ? {
         items: getItemProps(commands),
-        styles: menuStyles
+        styles: { subComponentStyles }
       } : undefined,
       split: !!commands
     }

--- a/ui/src/button.tsx
+++ b/ui/src/button.tsx
@@ -167,7 +167,7 @@ const
         items: toCommands(commands),
         styles: fixMenuOverflowStyles,
         isBeakVisible: true,
-        directionalHint: Fluent.DirectionalHint.bottomRightEdge,
+        directionalHint: Fluent.DirectionalHint.bottomLeftEdge,
         calloutProps: { styles: { beak: { border: border(1, cssVar('$neutralQuaternaryAlt')) } } }
       } : undefined,
       split: !!commands,

--- a/ui/src/button.tsx
+++ b/ui/src/button.tsx
@@ -21,6 +21,7 @@ import { cssVar, formItemWidth, padding } from './theme'
 import { Command, toCommands } from './toolbar'
 import { XToolTip } from './tooltip'
 import { wave } from './ui'
+import { fixMenuOverflowStyles } from './parts/utils'
 
 /**
  * Create a button.
@@ -114,13 +115,6 @@ const
     center: 'center',
     between: 'space-between',
     around: 'space-around',
-  },
-  // Fixes the vertical scrollbar for menu items with icons.
-  subComponentStyles: Partial<Fluent.IContextualMenuSubComponentStyles> = {
-    menuItem: {
-      icon: { lineHeight: 'initial' },
-      subMenuIcon: { lineHeight: 'initial', height: 'auto' },
-    }
   }
 
 const
@@ -171,7 +165,7 @@ const
       iconProps: { iconName: icon },
       menuProps: commands ? {
         items: toCommands(commands),
-        styles: { subComponentStyles }
+        styles: fixMenuOverflowStyles
       } : undefined,
       split: !!commands
     }

--- a/ui/src/button.tsx
+++ b/ui/src/button.tsx
@@ -137,12 +137,12 @@ const
       },
       onClick = handleOnClick(name, value, path),
       getItemProps: (commands: Command[]) => Fluent.IContextualMenuItem[] = commands =>
-        commands.map(({ name, label, caption, icon, value, data, items }) => ({
+        commands.map(({ name, label, caption, icon, value, items }) => ({
           key: name,
           text: label,
           title: caption,
           iconProps: { iconName: icon },
-          data: value ?? data, disabled,
+          disabled,
           onClick: handleOnClick(name, value),
           subMenuProps: items
             ? { items: getItemProps(items), styles: { subComponentStyles } }

--- a/ui/src/button.tsx
+++ b/ui/src/button.tsx
@@ -28,7 +28,7 @@ interface ButtonChoice {
   label?: S
   /** The caption for this choice (typically a tooltip). */
   caption?: S
-  /** The icon to be displayed for this choice. */
+  /** An optional icon to display next to the choice label */
   icon?: S
   /** A value for this choice. If a value is set, it is used for the choice's submitted instead of a boolean True. */
   value?: S

--- a/ui/src/button.tsx
+++ b/ui/src/button.tsx
@@ -142,10 +142,28 @@ const
           alignItems: 'center'
         }
       },
+      menuStyles: any = { // TODO: fix type
+        subComponentStyles: {
+          menuItem: {
+            icon: { lineHeight: 'initial' },
+            subMenuIcon: { lineHeight: 'initial', height: 'auto' }
+          },
+        }
+      },
       getItemProps = (commands: Command[]) => {
-        return commands.map(({ name, label, caption, icon, value, data, items }) => // TODO: add items
-          ({ key: name, text: label, title: caption, iconProps: { iconName: icon }, data: value ?? data, disabled, onClick: handleOnClick(name, value), subMenuProps: items ? { items: getItemProps(items) } : undefined })
-        )
+        return commands.map(({ name, label, caption, icon, value, data, items }) =>
+        ({
+          key: name,
+          text: label,
+          title: caption,
+          iconProps: { iconName: icon },
+          data: value ?? data, disabled,
+          onClick: handleOnClick(name, value),
+          subMenuProps: items
+            ? { items: getItemProps(items) as Fluent.IContextualMenuItem[], styles: menuStyles } as Fluent.IContextualMenuProps
+            : undefined
+        })
+        ) as Fluent.IContextualMenuItem[]
       },
       menuItems = commands
         ? getItemProps(commands)
@@ -168,8 +186,7 @@ const
       iconProps: { iconName: icon },
       menuProps: menuItems ? {
         items: menuItems,
-        // TODO: Add style for sub-items with an icon.
-        styles: { subComponentStyles: { menuItem: { icon: { lineHeight: 'initial' }, subMenuIcon: { lineHeight: 'initial', height: 'auto' } } } }
+        styles: menuStyles
       } : undefined,
       split: !!menuItems
     }

--- a/ui/src/button.tsx
+++ b/ui/src/button.tsx
@@ -150,7 +150,6 @@ const
 
     React.useEffect(() => {
       wave.args[name] = false
-      commands?.forEach(({ name }) => wave.args[name] = false)
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 

--- a/ui/src/button.tsx
+++ b/ui/src/button.tsx
@@ -79,7 +79,7 @@ export interface Button {
   tooltip?: S
   /** The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab. */
   path?: S
-  /** The menu with button actions. */
+  /** The menu with button actions. Ignored if `link` is True. */
   commands?: ButtonCommand[]
 }
 

--- a/ui/src/button.tsx
+++ b/ui/src/button.tsx
@@ -18,25 +18,9 @@ import React from 'react'
 import { stylesheet } from 'typestyle'
 import { Component } from './form'
 import { cssVar, formItemWidth, padding } from './theme'
+import { Command } from './toolbar'
 import { XToolTip } from './tooltip'
 import { wave } from './ui'
-
-interface ButtonChoice {
-  /** An identifying name for this choice. If the name is prefixed with a '#', the location hash is changed to the name when executed. */
-  name: Id
-  /** The text displayed for this choice. */
-  label?: S
-  /** The caption for this choice (typically a tooltip). */
-  caption?: S
-  /** An optional icon to display next to the choice label */
-  icon?: S
-  /** A value for this choice. If a value is set, it is used for the choice's submitted instead of a boolean True. */
-  value?: S
-  /** True if the choice should be disabled. */
-  disabled?: B
-  /** The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab. */
-  path?: S
-}
 
 /**
  * Create a button.
@@ -82,7 +66,7 @@ export interface Button {
   /** The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab. */
   path?: S
   /** The menu with button actions. Ignored if `link` is True. */
-  choices?: ButtonChoice[]
+  commands?: Command[]
 }
 
 /** Create a set of buttons laid out horizontally. */
@@ -133,7 +117,7 @@ const
   }
 
 const
-  XButton = ({ model: { name, visible = true, link, label, disabled, icon, caption, value, primary, width, path, choices } }: { model: Button }) => {
+  XButton = ({ model: { name, visible = true, link, label, disabled, icon, caption, value, primary, width, path, commands } }: { model: Button }) => {
     const
       handleOnClick = (name: Id, value?: S, path?: S) => (ev: any) => {
         ev.stopPropagation()
@@ -158,15 +142,15 @@ const
           alignItems: 'center'
         }
       },
-      menuItems = choices
-        ? choices.map(({ name, label, caption, icon, value, path, disabled }) =>
-          ({ key: name, text: label, title: caption, iconProps: { iconName: icon }, data: value, disabled, onClick: handleOnClick(name, value, path) })
+      menuItems = commands
+        ? commands.map(({ name, label, caption, icon, value, data }) => // TODO: add items
+          ({ key: name, text: label, title: caption, iconProps: { iconName: icon }, data: value ?? data, disabled, onClick: handleOnClick(name, value, path) })
         )
         : undefined
 
     React.useEffect(() => {
       wave.args[name] = false
-      choices?.forEach(({ name }) => wave.args[name] = false)
+      commands?.forEach(({ name }) => wave.args[name] = false)
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 

--- a/ui/src/button.tsx
+++ b/ui/src/button.tsx
@@ -142,17 +142,16 @@ const
           alignItems: 'center'
         }
       },
-      menuStyles: any = { // TODO: fix type
-        subComponentStyles: {
+      menuStyles: Fluent.IContextualMenuStyles = {
+        subComponentStyles: { // TODO: Fix missing 'callout' from Fluent.IContextualMenuSubComponentStyles; Partial<> not working
           menuItem: {
             icon: { lineHeight: 'initial' },
             subMenuIcon: { lineHeight: 'initial', height: 'auto' }
           },
         }
       },
-      getItemProps = (commands: Command[]) => {
-        return commands.map(({ name, label, caption, icon, value, data, items }) =>
-        ({
+      getItemProps: (commands: Command[]) => Fluent.IContextualMenuItem[] = commands => {
+        return commands.map(({ name, label, caption, icon, value, data, items }) => ({
           key: name,
           text: label,
           title: caption,
@@ -160,14 +159,10 @@ const
           data: value ?? data, disabled,
           onClick: handleOnClick(name, value),
           subMenuProps: items
-            ? { items: getItemProps(items) as Fluent.IContextualMenuItem[], styles: menuStyles } as Fluent.IContextualMenuProps
+            ? { items: getItemProps(items), styles: menuStyles }
             : undefined
-        })
-        ) as Fluent.IContextualMenuItem[]
-      },
-      menuItems = commands
-        ? getItemProps(commands)
-        : undefined
+        }))
+      }
 
     React.useEffect(() => {
       wave.args[name] = false
@@ -184,11 +179,11 @@ const
       onClick,
       styles,
       iconProps: { iconName: icon },
-      menuProps: menuItems ? {
-        items: menuItems,
+      menuProps: commands ? {
+        items: getItemProps(commands),
         styles: menuStyles
       } : undefined,
-      split: !!menuItems
+      split: !!commands
     }
     if (!label && icon) return <Fluent.IconButton {...btnProps} data-test={name} title={caption} />
 

--- a/website/widgets/form/button.md
+++ b/website/widgets/form/button.md
@@ -127,20 +127,20 @@ q.page['form'] = ui.form_card(box='1 1 1 1', items=[
 ])
 ```
 
-## With choices
+## With commands
 
-Using the `choices` attribute, you can provide other relevant actions for the button that are displayed in the context menu.
+Using the `commands` attribute, you can provide other relevant actions for the button that are displayed in the context menu.
 
 ```py
 q.page['form'] = ui.form_card(box='1 1 1 2', items=[
-    ui.button(name='choice_button', label='Button with choices', choices=[
-            ui.button_choice(name='first_choice', label='First choice'), 
-            ui.button_choice(name='second_choice', label='Second choice'),
+    ui.button(name='command_button', label='Button with commands', commands=[
+            ui.command(name='first_command', label='First command'), 
+            ui.command(name='second_command', label='Second command'),
     ])
 ])
 ```
 
-In addition, each choice supports `caption`, `icon`, `value`, `disabled` and `path` attributes which work exactly like with the button.
+In addition, each command supports `caption`, `icon` and `value` attributes which work exactly like with the button.
 
 ```py
 q.page['form'] = ui.form_card(box='1 1 1 2', items=[
@@ -148,9 +148,9 @@ q.page['form'] = ui.form_card(box='1 1 1 2', items=[
         name='like', 
         value='reaction_like', 
         icon='Like', 
-        choices=[
-            ui.button_choice(name='love', icon='Heart', value='reaction_love'), 
-            ui.button_choice(name='dislike', icon='Dislike', value='reaction_dislike', disabled=True)
+        commands=[
+            ui.command(name='love', icon='Heart', value='reaction_love'), 
+            ui.command(name='dislike', icon='Dislike', value='reaction_dislike')
     ])
 ])
 ```

--- a/website/widgets/form/button.md
+++ b/website/widgets/form/button.md
@@ -126,3 +126,16 @@ q.page['form'] = ui.form_card(box='1 1 1 1', items=[
     ui.button(name='external_path_button', label='External', path='https://h2o.ai/')
 ])
 ```
+
+## With choices
+
+Using the `choices` attribute, you can provide other relevant actions for the button that are displayed in the context menu.
+
+```py
+q.page['form'] = ui.form_card(box='1 1 1 2', items=[
+    ui.button(name='choice_button', label='Button with choices', choices=[
+            ui.button_choice(name='first_choice', label='First choice'), 
+            ui.button_choice(name='second_choice', label='Second choice'),
+    ])
+])
+```

--- a/website/widgets/form/button.md
+++ b/website/widgets/form/button.md
@@ -132,7 +132,7 @@ q.page['form'] = ui.form_card(box='1 1 1 1', items=[
 Using the `commands` attribute, you can provide other relevant actions for the button that are displayed in the context menu.
 
 ```py
-q.page['form'] = ui.form_card(box='1 1 1 2', items=[
+q.page['form'] = ui.form_card(box='1 1 2 1', items=[
     ui.button(name='command_button', label='Button with commands', commands=[
             ui.command(name='first_command', label='First command'), 
             ui.command(name='other_commands', label='Other commands', items=[
@@ -146,14 +146,25 @@ q.page['form'] = ui.form_card(box='1 1 1 2', items=[
 In addition, each [command](/docs/api/ui#command) supports `caption`, `icon` and `value` attributes which work exactly like with the button.
 
 ```py
-q.page['form'] = ui.form_card(box='1 1 1 2', items=[
+q.page['form'] = ui.form_card(box='1 1 1 1', items=[
     ui.button(
-        name='like', 
+        name='like',
+        caption='React with like emoji', 
         value='reaction_like', 
         icon='Like', 
         commands=[
-            ui.command(name='love', icon='Heart', value='reaction_love'), 
-            ui.command(name='dislike', icon='Dislike', value='reaction_dislike')
+            ui.command(
+                name='love', 
+                icon='Heart', 
+                caption='React with heart emoji', 
+                value='reaction_love'
+            ), 
+            ui.command(
+                name='dislike', 
+                icon='Dislike', 
+                caption='React with dislike emoji', 
+                value='reaction_dislike'
+            )
     ])
 ])
 ```

--- a/website/widgets/form/button.md
+++ b/website/widgets/form/button.md
@@ -129,7 +129,7 @@ q.page['form'] = ui.form_card(box='1 1 1 1', items=[
 
 ## With actions
 
-Using the `commands` attribute, you can provide other relevant actions for the button that are displayed in the context menu.
+The `commands` attribute can provide other relevant actions for the button that are displayed in the context menu.
 
 ```py
 q.page['form'] = ui.form_card(box='1 1 2 1', items=[

--- a/website/widgets/form/button.md
+++ b/website/widgets/form/button.md
@@ -127,7 +127,7 @@ q.page['form'] = ui.form_card(box='1 1 1 1', items=[
 ])
 ```
 
-## With commands
+## With actions
 
 Using the `commands` attribute, you can provide other relevant actions for the button that are displayed in the context menu.
 
@@ -135,12 +135,15 @@ Using the `commands` attribute, you can provide other relevant actions for the b
 q.page['form'] = ui.form_card(box='1 1 1 2', items=[
     ui.button(name='command_button', label='Button with commands', commands=[
             ui.command(name='first_command', label='First command'), 
-            ui.command(name='second_command', label='Second command'),
+            ui.command(name='other_commands', label='Other commands', items=[
+                        ui.command(name='second_command', label='Second command'),
+                        ui.command(name='third_command', label='Third command'),  
+                    ]),
     ])
 ])
 ```
 
-In addition, each command supports `caption`, `icon` and `value` attributes which work exactly like with the button.
+In addition, each [command](/docs/api/ui#command) supports `caption`, `icon` and `value` attributes which work exactly like with the button.
 
 ```py
 q.page['form'] = ui.form_card(box='1 1 1 2', items=[

--- a/website/widgets/form/button.md
+++ b/website/widgets/form/button.md
@@ -139,3 +139,18 @@ q.page['form'] = ui.form_card(box='1 1 1 2', items=[
     ])
 ])
 ```
+
+In addition, each choice supports `caption`, `icon`, `value`, `disabled` and `path` attributes which work exactly like with the button.
+
+```py
+q.page['form'] = ui.form_card(box='1 1 1 2', items=[
+    ui.button(
+        name='like', 
+        value='reaction_like', 
+        icon='Like', 
+        choices=[
+            ui.button_choice(name='love', icon='Heart', value='reaction_love'), 
+            ui.button_choice(name='dislike', icon='Dislike', value='reaction_dislike', disabled=True)
+    ])
+])
+```

--- a/website/widgets/form/button.md
+++ b/website/widgets/form/button.md
@@ -129,7 +129,7 @@ q.page['form'] = ui.form_card(box='1 1 1 1', items=[
 
 ## With actions
 
-The `commands` attribute can provide other relevant actions for the button that are displayed in the context menu.
+The `commands` attribute can provide other relevant actions for the button that are displayed inside of a context menu. See [ui.command API](/docs/api/ui#command) for available options.
 
 ```py
 q.page['form'] = ui.form_card(box='1 1 2 1', items=[
@@ -139,32 +139,6 @@ q.page['form'] = ui.form_card(box='1 1 2 1', items=[
                         ui.command(name='second_command', label='Second command'),
                         ui.command(name='third_command', label='Third command'),  
                     ]),
-    ])
-])
-```
-
-In addition, each [command](/docs/api/ui#command) supports `caption`, `icon` and `value` attributes which work exactly like with the button.
-
-```py
-q.page['form'] = ui.form_card(box='1 1 1 1', items=[
-    ui.button(
-        name='like',
-        caption='React with like emoji', 
-        value='reaction_like', 
-        icon='Like', 
-        commands=[
-            ui.command(
-                name='love', 
-                icon='Heart', 
-                caption='React with heart emoji', 
-                value='reaction_love'
-            ), 
-            ui.command(
-                name='dislike', 
-                icon='Dislike', 
-                caption='React with dislike emoji', 
-                value='reaction_dislike'
-            )
     ])
 ])
 ```


### PR DESCRIPTION
This change brings the `commands` attribute for _ui.button_ where you can provide other relevant actions for the button that are displayed in the context menu.

```ts
export interface Button {
  /** An identifying name for this component. If the name is prefixed with a '#', the button sets the location hash to the name when clicked. */
  name: Id
  /** The text displayed on the button. */
  label?: S
  /** The caption displayed below the label. */
  caption?: S
  /** A value for this button. If a value is set, it is used for the button's submitted instead of a boolean True. */
  value?: S
  /** True if the button should be rendered as the primary button in the set. */
  primary?: B
  /** True if the button should be disabled. */
  disabled?: B
  /** True if the button should be rendered as link text and not a standard button. */
  link?: B
  /** An optional icon to display next to the button label (not applicable for links). */
  icon?: S
  /** The width of the button, e.g. '100px'. */
  width?: S
  /** True if the component should be visible. Defaults to True. */
  visible?: B
  /** An optional tooltip message displayed when a user clicks the help icon to the right of the component. */
  tooltip?: S
  /** The path or URL to link to. If specified, the `name` is ignored. The URL is opened in a new browser window or tab. */
  path?: S
  /** When specified, a split button is rendered with extra actions tied to it within a context menu. Mutually exclusive with `link` attribute. */
  commands?: Command[]
}
```

Example:

https://user-images.githubusercontent.com/23740173/232728214-44ae100f-9b04-472b-8ca8-b2c3251725c3.mov


Closes #1887 

