### PR TITLE
feat: Render dashboard demo app links in header and add h2o logo 

### DIFF
--- a/py/demo/common.py
+++ b/py/demo/common.py
@@ -1,13 +1,11 @@
 from h2o_wave import ui
 
 global_nav = [
-    ui.nav_group('Dashboards', items=[
-        ui.nav_item(name='#dashboards/red', label='Red'),
-        ui.nav_item(name='#dashboards/blue', label='Blue'),
-        ui.nav_item(name='#dashboards/orange', label='Orange'),
-        ui.nav_item(name='#dashboards/cyan', label='Cyan'),
-        ui.nav_item(name='#dashboards/grey', label='Grey'),
-        ui.nav_item(name='#dashboards/mint', label='Mint'),
-        ui.nav_item(name='#dashboards/purple', label='Purple'),
-    ]),
+    ui.tab(name='#dashboards/red', label='Red'),
+    ui.tab(name='#dashboards/blue', label='Blue'),
+    ui.tab(name='#dashboards/orange', label='Orange'),
+    ui.tab(name='#dashboards/cyan', label='Cyan'),
+    ui.tab(name='#dashboards/grey', label='Grey'),
+    ui.tab(name='#dashboards/mint', label='Mint'),
+    ui.tab(name='#dashboards/purple', label='Purple'),
 ]

--- a/py/demo/dashboard_blue.py
+++ b/py/demo/dashboard_blue.py
@@ -20,7 +20,9 @@ async def show_blue_dashboard(q: Q):
     ])
 
     q.page['header'] = ui.header_card(box='header', title='H2O Wave Demo', subtitle='Blue Dashboard',
-                                      nav=global_nav)
+                                      image='https://wave.h2o.ai/img/h2o-logo.svg',
+                                      items=[ui.tabs(name='Dashboards', value='#dashboards/blue', 
+                                                     items=global_nav),])
 
     q.page['title'] = ui.section_card(
         box='title',

--- a/py/demo/dashboard_cyan.py
+++ b/py/demo/dashboard_cyan.py
@@ -27,7 +27,9 @@ async def show_cyan_dashboard(q: Q):
     ])
 
     q.page['header'] = ui.header_card(box='header', title='H2O Wave Demo', subtitle='Cyan Dashboard',
-                                      nav=global_nav)
+                                      image='https://wave.h2o.ai/img/h2o-logo.svg',
+                                      items=[ui.tabs(name='Dashboards', value='#dashboards/cyan', 
+                                                     items=global_nav),])
     q.page['section'] = ui.section_card(
         box=ui.box('top', order=1, size=0),
         title=next(sample_title),

--- a/py/demo/dashboard_grey.py
+++ b/py/demo/dashboard_grey.py
@@ -23,7 +23,9 @@ async def show_grey_dashboard(q: Q):
     ])
 
     q.page['header'] = ui.header_card(box='header', title='H2O Wave Demo', subtitle='Grey Dashboard',
-                                      nav=global_nav)
+                                      image='https://wave.h2o.ai/img/h2o-logo.svg',
+                                      items=[ui.tabs(name='Dashboards', value='#dashboards/grey', 
+                                                     items=global_nav),])
     q.page['section'] = ui.section_card(
         box='title',
         title=next(sample_title),

--- a/py/demo/dashboard_mint.py
+++ b/py/demo/dashboard_mint.py
@@ -20,7 +20,9 @@ async def show_mint_dashboard(q: Q):
         )
     ])
     q.page['header'] = ui.header_card(box='header', title='H2O Wave Demo', subtitle='Mint Dashboard',
-                                      nav=global_nav)
+                                      image='https://wave.h2o.ai/img/h2o-logo.svg',
+                                      items=[ui.tabs(name='Dashboards', value='#dashboards/mint', 
+                                                     items=global_nav),])
     q.page['main_section'] = ui.section_card(
         box='main_section',
         title=next(sample_title),

--- a/py/demo/dashboard_orange.py
+++ b/py/demo/dashboard_orange.py
@@ -23,7 +23,9 @@ async def show_orange_dashboard(q: Q):
     ])
 
     q.page['header'] = ui.header_card(box='header', title='H2O Wave Demo', subtitle='Orange Dashboard',
-                                      nav=global_nav)
+                                      image='https://wave.h2o.ai/img/h2o-logo.svg',
+                                      items=[ui.tabs(name='Dashboards', value='#dashboards/orange', 
+                                                     items=global_nav),])
 
     q.page['section'] = ui.section_card(
         box='control',

--- a/py/demo/dashboard_purple.py
+++ b/py/demo/dashboard_purple.py
@@ -51,7 +51,9 @@ async def show_purple_dashboard(q: Q):
         )
     ])
     q.page['header'] = ui.header_card(box='header', title='H2O Wave Demo', subtitle='Purple Dashboard',
-                                      nav=global_nav)
+                                      image='https://wave.h2o.ai/img/h2o-logo.svg',
+                                      items=[ui.tabs(name='Dashboards', value='#dashboards/purple', 
+                                                     items=global_nav),])
 
     q.page['title'] = ui.section_card(
         box='title',

--- a/py/demo/dashboard_red.py
+++ b/py/demo/dashboard_red.py
@@ -29,7 +29,9 @@ async def show_red_dashboard(q: Q):
     ])
 
     q.page['header'] = ui.header_card(box='header', title='H2O Wave Demo', subtitle='Red Dashboard',
-                                      nav=global_nav)
+                                      image='https://wave.h2o.ai/img/h2o-logo.svg',
+                                      items=[ui.tabs(name='Dashboards', value='#dashboards/red', 
+                                                     items=global_nav),])
     q.page['title'] = ui.section_card(
         box='title',
         title=next(sample_title),


### PR DESCRIPTION
## **Github Issue**
Closes #1867

## **Description**
Updated dashboard demo app to: 
- include h2o logo 
- directly render links in the header using tabs

Links are now accessible without needing to click the hamburger menu.

## **Successful Local Testing**
![Screen Shot 2023-04-16 at 7 44 55 AM](https://user-images.githubusercontent.com/84405827/232308881-1f549d90-f95f-4321-b9d6-d1c80f5f3b0e.png)

![Screen Shot 2023-04-16 at 7 45 05 AM](https://user-images.githubusercontent.com/84405827/232308882-d203e6ae-482b-49e1-9404-454a4a5227c9.png)

![Screen Shot 2023-04-16 at 7 45 11 AM](https://user-images.githubusercontent.com/84405827/232308883-38b14737-0304-4f12-839d-5681449f2303.png)


