### PR TITLE
feat: Render dashboard demo app links in header and add h2o logo

### DIFF
--- a/py/demo/common.py
+++ b/py/demo/common.py
@@ -1,13 +1,11 @@
 from h2o_wave import ui
 
 global_nav = [
-    ui.nav_group('Dashboards', items=[
-        ui.nav_item(name='#dashboards/red', label='Red'),
-        ui.nav_item(name='#dashboards/blue', label='Blue'),
-        ui.nav_item(name='#dashboards/orange', label='Orange'),
-        ui.nav_item(name='#dashboards/cyan', label='Cyan'),
-        ui.nav_item(name='#dashboards/grey', label='Grey'),
-        ui.nav_item(name='#dashboards/mint', label='Mint'),
-        ui.nav_item(name='#dashboards/purple', label='Purple'),
-    ]),
+    ui.tab(name='#dashboards/red', label='Red'),
+    ui.tab(name='#dashboards/blue', label='Blue'),
+    ui.tab(name='#dashboards/orange', label='Orange'),
+    ui.tab(name='#dashboards/cyan', label='Cyan'),
+    ui.tab(name='#dashboards/grey', label='Grey'),
+    ui.tab(name='#dashboards/mint', label='Mint'),
+    ui.tab(name='#dashboards/purple', label='Purple'),
 ]

--- a/py/demo/dashboard_blue.py
+++ b/py/demo/dashboard_blue.py
@@ -20,7 +20,9 @@ async def show_blue_dashboard(q: Q):
     ])
 
     q.page['header'] = ui.header_card(box='header', title='H2O Wave Demo', subtitle='Blue Dashboard',
-                                      nav=global_nav)
+                                      image='https://wave.h2o.ai/img/h2o-logo.svg',
+                                      items=[ui.tabs(name='Dashboards', value='#dashboards/blue', 
+                                                     items=global_nav),])
 
     q.page['title'] = ui.section_card(
         box='title',

--- a/py/demo/dashboard_blue.py
+++ b/py/demo/dashboard_blue.py
@@ -9,7 +9,7 @@ async def show_blue_dashboard(q: Q):
             breakpoint='xs',
             width='1200px',
             zones=[
-                ui.zone('header', size='65px'),
+                ui.zone('header', size='76px'),
                 ui.zone('title'),
                 ui.zone('top', direction=ui.ZoneDirection.ROW, size='200px'),
                 ui.zone('middle', direction=ui.ZoneDirection.ROW, size='385px'),

--- a/py/demo/dashboard_cyan.py
+++ b/py/demo/dashboard_cyan.py
@@ -27,7 +27,9 @@ async def show_cyan_dashboard(q: Q):
     ])
 
     q.page['header'] = ui.header_card(box='header', title='H2O Wave Demo', subtitle='Cyan Dashboard',
-                                      nav=global_nav)
+                                      image='https://wave.h2o.ai/img/h2o-logo.svg',
+                                      items=[ui.tabs(name='Dashboards', value='#dashboards/cyan', 
+                                                     items=global_nav),])
     q.page['section'] = ui.section_card(
         box=ui.box('top', order=1, size=0),
         title=next(sample_title),

--- a/py/demo/dashboard_cyan.py
+++ b/py/demo/dashboard_cyan.py
@@ -9,7 +9,7 @@ async def show_cyan_dashboard(q: Q):
             breakpoint='xs',
             width='1200px',
             zones=[
-                ui.zone('header', size='65px'),
+                ui.zone('header', size='76px'),
                 ui.zone('body', size='1400px', direction=ui.ZoneDirection.ROW, zones=[
                     ui.zone('content', size='75%', zones=[
                         ui.zone('top', size='600px'),

--- a/py/demo/dashboard_grey.py
+++ b/py/demo/dashboard_grey.py
@@ -23,7 +23,9 @@ async def show_grey_dashboard(q: Q):
     ])
 
     q.page['header'] = ui.header_card(box='header', title='H2O Wave Demo', subtitle='Grey Dashboard',
-                                      nav=global_nav)
+                                      image='https://wave.h2o.ai/img/h2o-logo.svg',
+                                      items=[ui.tabs(name='Dashboards', value='#dashboards/grey', 
+                                                     items=global_nav),])
     q.page['section'] = ui.section_card(
         box='title',
         title=next(sample_title),

--- a/py/demo/dashboard_grey.py
+++ b/py/demo/dashboard_grey.py
@@ -9,7 +9,7 @@ async def show_grey_dashboard(q: Q):
             breakpoint='xs',
             min_width='800px',
             zones=[
-                ui.zone('header', size='65px'),
+                ui.zone('header', size='76px'),
                 ui.zone('title'),
                 ui.zone('body', size='1000px', zones=[
                     ui.zone('top', direction=ui.ZoneDirection.ROW, size='25%'),

--- a/py/demo/dashboard_mint.py
+++ b/py/demo/dashboard_mint.py
@@ -20,7 +20,9 @@ async def show_mint_dashboard(q: Q):
         )
     ])
     q.page['header'] = ui.header_card(box='header', title='H2O Wave Demo', subtitle='Mint Dashboard',
-                                      nav=global_nav)
+                                      image='https://wave.h2o.ai/img/h2o-logo.svg',
+                                      items=[ui.tabs(name='Dashboards', value='#dashboards/mint', 
+                                                     items=global_nav),])
     q.page['main_section'] = ui.section_card(
         box='main_section',
         title=next(sample_title),

--- a/py/demo/dashboard_mint.py
+++ b/py/demo/dashboard_mint.py
@@ -9,7 +9,7 @@ async def show_mint_dashboard(q: Q):
             breakpoint='xs',
             width='1200px',
             zones=[
-                ui.zone('header', size='65px'),
+                ui.zone('header', size='76px'),
                 ui.zone('main_section'),
                 ui.zone('overview', direction=ui.ZoneDirection.ROW, size='425px'),
                 ui.zone('tickers', direction=ui.ZoneDirection.ROW, size='175px'),

--- a/py/demo/dashboard_orange.py
+++ b/py/demo/dashboard_orange.py
@@ -23,7 +23,9 @@ async def show_orange_dashboard(q: Q):
     ])
 
     q.page['header'] = ui.header_card(box='header', title='H2O Wave Demo', subtitle='Orange Dashboard',
-                                      nav=global_nav)
+                                      image='https://wave.h2o.ai/img/h2o-logo.svg',
+                                      items=[ui.tabs(name='Dashboards', value='#dashboards/orange', 
+                                                     items=global_nav),])
 
     q.page['section'] = ui.section_card(
         box='control',

--- a/py/demo/dashboard_orange.py
+++ b/py/demo/dashboard_orange.py
@@ -9,7 +9,7 @@ async def show_orange_dashboard(q: Q):
             breakpoint='xs',
             width='1200px',
             zones=[
-                ui.zone('header', size='65px'),
+                ui.zone('header', size='76px'),
                 ui.zone('control'),
                 ui.zone('top', direction=ui.ZoneDirection.ROW, size='385px', zones=[
                     ui.zone('top_left', direction=ui.ZoneDirection.ROW, size='66%'),

--- a/py/demo/dashboard_purple.py
+++ b/py/demo/dashboard_purple.py
@@ -51,7 +51,9 @@ async def show_purple_dashboard(q: Q):
         )
     ])
     q.page['header'] = ui.header_card(box='header', title='H2O Wave Demo', subtitle='Purple Dashboard',
-                                      nav=global_nav)
+                                      image='https://wave.h2o.ai/img/h2o-logo.svg',
+                                      items=[ui.tabs(name='Dashboards', value='#dashboards/purple', 
+                                                     items=global_nav),])
 
     q.page['title'] = ui.section_card(
         box='title',

--- a/py/demo/dashboard_purple.py
+++ b/py/demo/dashboard_purple.py
@@ -8,7 +8,7 @@ async def show_purple_dashboard(q: Q):
         ui.layout(
             breakpoint='xs',
             zones=[
-                ui.zone('header', size='65px'),
+                ui.zone('header', size='76px'),
                 ui.zone('title', size='60px'),
                 ui.zone('body'),
                 ui.zone('footer', size='80px'),
@@ -17,7 +17,7 @@ async def show_purple_dashboard(q: Q):
         ui.layout(
             breakpoint='m',
             zones=[
-                ui.zone('header', size='65px'),
+                ui.zone('header', size='76px'),
                 ui.zone('title', size='60px'),
                 ui.zone('body', direction=ui.ZoneDirection.ROW, zones=[
                     ui.zone('main', zones=[
@@ -35,7 +35,7 @@ async def show_purple_dashboard(q: Q):
             breakpoint='xl',
             width='1200px',
             zones=[
-                ui.zone('header', size='65px'),
+                ui.zone('header', size='76px'),
                 ui.zone('title', size='60px'),
                 ui.zone('body', size='1150px', direction=ui.ZoneDirection.ROW, zones=[
                     ui.zone('main', size='3', zones=[

--- a/py/demo/dashboard_red.py
+++ b/py/demo/dashboard_red.py
@@ -29,7 +29,9 @@ async def show_red_dashboard(q: Q):
     ])
 
     q.page['header'] = ui.header_card(box='header', title='H2O Wave Demo', subtitle='Red Dashboard',
-                                      nav=global_nav)
+                                      image='https://wave.h2o.ai/img/h2o-logo.svg',
+                                      items=[ui.tabs(name='Dashboards', value='#dashboards/red', 
+                                                     items=global_nav),])
     q.page['title'] = ui.section_card(
         box='title',
         title=next(sample_title),

--- a/py/demo/dashboard_red.py
+++ b/py/demo/dashboard_red.py
@@ -9,7 +9,7 @@ async def show_red_dashboard(q: Q):
             breakpoint='xs',
             width='1200px',
             zones=[
-                ui.zone('header', size='65px'),
+                ui.zone('header', size='76px'),
                 ui.zone('title'),
                 ui.zone('top', direction=ui.ZoneDirection.ROW, size='385px', zones=[
                     ui.zone('top_left'),


### PR DESCRIPTION
## **Github Issue**
Closes #1867 

## **Description**
Updated dashboard demo app to:
- include h2o logo
- directly render links in the header using tabs

Links are now accessible without needing to click the hamburger menu.

## **Successful Local Testing**
![Screen Shot 2023-04-17 at 3 29 53 AM](https://user-images.githubusercontent.com/84405827/232416930-e89085c0-2d54-41c7-91b7-3ece6b0c56d3.png)

![Screen Shot 2023-04-17 at 3 30 08 AM](https://user-images.githubusercontent.com/84405827/232416934-1409e77d-4dc8-4a3b-a5b3-8e4c9f2ffa59.png)

![Screen Shot 2023-04-17 at 3 30 16 AM](https://user-images.githubusercontent.com/84405827/232416940-3ceb0003-3c9c-41ae-b502-afebc82b11f3.png)

