### PR TITLE
feat: Implement `compact` attribute for markup card

### DIFF
--- a/py/h2o_lightwave/h2o_lightwave/types.py
+++ b/py/h2o_lightwave/h2o_lightwave/types.py
@@ -9491,11 +9491,13 @@ class MarkupCard:
             box: str,
             title: str,
             content: str,
+            compact: Optional[bool] = None,
             commands: Optional[List[Command]] = None,
     ):
         _guard_scalar('MarkupCard.box', box, (str,), False, False, False)
         _guard_scalar('MarkupCard.title', title, (str,), False, False, False)
         _guard_scalar('MarkupCard.content', content, (str,), False, False, False)
+        _guard_scalar('MarkupCard.compact', compact, (bool,), False, True, False)
         _guard_vector('MarkupCard.commands', commands, (Command,), False, True, False)
         self.box = box
         """A string indicating how to place this component on the page."""
@@ -9503,6 +9505,8 @@ class MarkupCard:
         """The title for this card."""
         self.content = content
         """The HTML content."""
+        self.compact = compact
+        """True if title and padding should be removed. Defaults to False."""
         self.commands = commands
         """Contextual menu commands for this component."""
 
@@ -9511,12 +9515,14 @@ class MarkupCard:
         _guard_scalar('MarkupCard.box', self.box, (str,), False, False, False)
         _guard_scalar('MarkupCard.title', self.title, (str,), False, False, False)
         _guard_scalar('MarkupCard.content', self.content, (str,), False, False, False)
+        _guard_scalar('MarkupCard.compact', self.compact, (bool,), False, True, False)
         _guard_vector('MarkupCard.commands', self.commands, (Command,), False, True, False)
         return _dump(
             view='markup',
             box=self.box,
             title=self.title,
             content=self.content,
+            compact=self.compact,
             commands=None if self.commands is None else [__e.dump() for __e in self.commands],
         )
 
@@ -9529,16 +9535,20 @@ class MarkupCard:
         _guard_scalar('MarkupCard.title', __d_title, (str,), False, False, False)
         __d_content: Any = __d.get('content')
         _guard_scalar('MarkupCard.content', __d_content, (str,), False, False, False)
+        __d_compact: Any = __d.get('compact')
+        _guard_scalar('MarkupCard.compact', __d_compact, (bool,), False, True, False)
         __d_commands: Any = __d.get('commands')
         _guard_vector('MarkupCard.commands', __d_commands, (dict,), False, True, False)
         box: str = __d_box
         title: str = __d_title
         content: str = __d_content
+        compact: Optional[bool] = __d_compact
         commands: Optional[List[Command]] = None if __d_commands is None else [Command.load(__e) for __e in __d_commands]
         return MarkupCard(
             box,
             title,
             content,
+            compact,
             commands,
         )
 

--- a/py/h2o_lightwave/h2o_lightwave/types.py
+++ b/py/h2o_lightwave/h2o_lightwave/types.py
@@ -9506,7 +9506,7 @@ class MarkupCard:
         self.content = content
         """The HTML content."""
         self.compact = compact
-        """True if title and padding should be removed. Defaults to False."""
+        """True if outer spacing should be removed. Defaults to False."""
         self.commands = commands
         """Contextual menu commands for this component."""
 

--- a/py/h2o_lightwave/h2o_lightwave/ui.py
+++ b/py/h2o_lightwave/h2o_lightwave/ui.py
@@ -3353,6 +3353,7 @@ def markup_card(
         box: str,
         title: str,
         content: str,
+        compact: Optional[bool] = None,
         commands: Optional[List[Command]] = None,
 ) -> MarkupCard:
     """Render HTML content.
@@ -3361,6 +3362,7 @@ def markup_card(
         box: A string indicating how to place this component on the page.
         title: The title for this card.
         content: The HTML content.
+        compact: True if title and padding should be removed. Defaults to False.
         commands: Contextual menu commands for this component.
     Returns:
         A `h2o_wave.types.MarkupCard` instance.
@@ -3369,6 +3371,7 @@ def markup_card(
         box,
         title,
         content,
+        compact,
         commands,
     )
 

--- a/py/h2o_lightwave/h2o_lightwave/ui.py
+++ b/py/h2o_lightwave/h2o_lightwave/ui.py
@@ -3362,7 +3362,7 @@ def markup_card(
         box: A string indicating how to place this component on the page.
         title: The title for this card.
         content: The HTML content.
-        compact: True if title and padding should be removed. Defaults to False.
+        compact: True if outer spacing should be removed. Defaults to False.
         commands: Contextual menu commands for this component.
     Returns:
         A `h2o_wave.types.MarkupCard` instance.

--- a/py/h2o_wave/h2o_wave/types.py
+++ b/py/h2o_wave/h2o_wave/types.py
@@ -9491,11 +9491,13 @@ class MarkupCard:
             box: str,
             title: str,
             content: str,
+            compact: Optional[bool] = None,
             commands: Optional[List[Command]] = None,
     ):
         _guard_scalar('MarkupCard.box', box, (str,), False, False, False)
         _guard_scalar('MarkupCard.title', title, (str,), False, False, False)
         _guard_scalar('MarkupCard.content', content, (str,), False, False, False)
+        _guard_scalar('MarkupCard.compact', compact, (bool,), False, True, False)
         _guard_vector('MarkupCard.commands', commands, (Command,), False, True, False)
         self.box = box
         """A string indicating how to place this component on the page."""
@@ -9503,6 +9505,8 @@ class MarkupCard:
         """The title for this card."""
         self.content = content
         """The HTML content."""
+        self.compact = compact
+        """True if title and padding should be removed. Defaults to False."""
         self.commands = commands
         """Contextual menu commands for this component."""
 
@@ -9511,12 +9515,14 @@ class MarkupCard:
         _guard_scalar('MarkupCard.box', self.box, (str,), False, False, False)
         _guard_scalar('MarkupCard.title', self.title, (str,), False, False, False)
         _guard_scalar('MarkupCard.content', self.content, (str,), False, False, False)
+        _guard_scalar('MarkupCard.compact', self.compact, (bool,), False, True, False)
         _guard_vector('MarkupCard.commands', self.commands, (Command,), False, True, False)
         return _dump(
             view='markup',
             box=self.box,
             title=self.title,
             content=self.content,
+            compact=self.compact,
             commands=None if self.commands is None else [__e.dump() for __e in self.commands],
         )
 
@@ -9529,16 +9535,20 @@ class MarkupCard:
         _guard_scalar('MarkupCard.title', __d_title, (str,), False, False, False)
         __d_content: Any = __d.get('content')
         _guard_scalar('MarkupCard.content', __d_content, (str,), False, False, False)
+        __d_compact: Any = __d.get('compact')
+        _guard_scalar('MarkupCard.compact', __d_compact, (bool,), False, True, False)
         __d_commands: Any = __d.get('commands')
         _guard_vector('MarkupCard.commands', __d_commands, (dict,), False, True, False)
         box: str = __d_box
         title: str = __d_title
         content: str = __d_content
+        compact: Optional[bool] = __d_compact
         commands: Optional[List[Command]] = None if __d_commands is None else [Command.load(__e) for __e in __d_commands]
         return MarkupCard(
             box,
             title,
             content,
+            compact,
             commands,
         )
 

--- a/py/h2o_wave/h2o_wave/types.py
+++ b/py/h2o_wave/h2o_wave/types.py
@@ -9506,7 +9506,7 @@ class MarkupCard:
         self.content = content
         """The HTML content."""
         self.compact = compact
-        """True if title and padding should be removed. Defaults to False."""
+        """True if outer spacing should be removed. Defaults to False."""
         self.commands = commands
         """Contextual menu commands for this component."""
 

--- a/py/h2o_wave/h2o_wave/ui.py
+++ b/py/h2o_wave/h2o_wave/ui.py
@@ -3353,6 +3353,7 @@ def markup_card(
         box: str,
         title: str,
         content: str,
+        compact: Optional[bool] = None,
         commands: Optional[List[Command]] = None,
 ) -> MarkupCard:
     """Render HTML content.
@@ -3361,6 +3362,7 @@ def markup_card(
         box: A string indicating how to place this component on the page.
         title: The title for this card.
         content: The HTML content.
+        compact: True if title and padding should be removed. Defaults to False.
         commands: Contextual menu commands for this component.
     Returns:
         A `h2o_wave.types.MarkupCard` instance.
@@ -3369,6 +3371,7 @@ def markup_card(
         box,
         title,
         content,
+        compact,
         commands,
     )
 

--- a/py/h2o_wave/h2o_wave/ui.py
+++ b/py/h2o_wave/h2o_wave/ui.py
@@ -3362,7 +3362,7 @@ def markup_card(
         box: A string indicating how to place this component on the page.
         title: The title for this card.
         content: The HTML content.
-        compact: True if title and padding should be removed. Defaults to False.
+        compact: True if outer spacing should be removed. Defaults to False.
         commands: Contextual menu commands for this component.
     Returns:
         A `h2o_wave.types.MarkupCard` instance.

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -3900,7 +3900,7 @@ ui_markdown_card <- function(
 #' @param box A string indicating how to place this component on the page.
 #' @param title The title for this card.
 #' @param content The HTML content.
-#' @param compact True if title and padding should be removed. Defaults to False.
+#' @param compact True if outer spacing should be removed. Defaults to False.
 #' @param commands Contextual menu commands for this component.
 #' @return A MarkupCard instance.
 #' @export

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -3900,6 +3900,7 @@ ui_markdown_card <- function(
 #' @param box A string indicating how to place this component on the page.
 #' @param title The title for this card.
 #' @param content The HTML content.
+#' @param compact True if title and padding should be removed. Defaults to False.
 #' @param commands Contextual menu commands for this component.
 #' @return A MarkupCard instance.
 #' @export
@@ -3907,15 +3908,18 @@ ui_markup_card <- function(
   box,
   title,
   content,
+  compact = NULL,
   commands = NULL) {
   .guard_scalar("box", "character", box)
   .guard_scalar("title", "character", title)
   .guard_scalar("content", "character", content)
+  .guard_scalar("compact", "logical", compact)
   .guard_vector("commands", "WaveCommand", commands)
   .o <- list(
     box=box,
     title=title,
     content=content,
+    compact=compact,
     commands=commands,
     view='markup')
   class(.o) <- append(class(.o), c(.wave_obj, "WaveMarkupCard"))

--- a/tools/intellij-plugin/src/main/resources/templates/wave-components.xml
+++ b/tools/intellij-plugin/src/main/resources/templates/wave-components.xml
@@ -1620,10 +1620,11 @@
       <option name="Python" value="true"/>
     </context>
   </template>
-  <template name="w_full_markup_card" value="ui.markup_card(box='$box$',title='$title$',content='$content$',commands=[&#10;	$commands$	&#10;])$END$" description="Create Wave MarkupCard with full attributes." toReformat="true" toShortenFQNames="true">
+  <template name="w_full_markup_card" value="ui.markup_card(box='$box$',title='$title$',content='$content$',compact=$compact$,commands=[&#10;	$commands$	&#10;])$END$" description="Create Wave MarkupCard with full attributes." toReformat="true" toShortenFQNames="true">
     <variable name="box" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="title" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="content" expression="" defaultValue="" alwaysStopAt="true"/>
+    <variable name="compact" expression="" defaultValue="&quot;False&quot;" alwaysStopAt="true"/>
     <variable name="commands" expression="" defaultValue="" alwaysStopAt="true"/>
     <context>
       <option name="Python" value="true"/>

--- a/tools/vscode-extension/component-snippets.json
+++ b/tools/vscode-extension/component-snippets.json
@@ -1325,7 +1325,7 @@
   "Wave Full MarkupCard": {
     "prefix": "w_full_markup_card",
     "body": [
-      "ui.markup_card(box='$1', title='$2', content='$3', commands=[\n\t\t$4\t\t\n])$0"
+      "ui.markup_card(box='$1', title='$2', content='$3', compact=${4:False}, commands=[\n\t\t$5\t\t\n])$0"
     ],
     "description": "Create a full Wave MarkupCard."
   },

--- a/ui/src/markup.tsx
+++ b/ui/src/markup.tsx
@@ -63,7 +63,7 @@ interface State {
    **/
   content: S
   /** 
-   * True if title and padding should be removed. Defaults to False.
+   * True if outer spacing should be removed. Defaults to False.
    **/
   compact?: B
 }
@@ -74,7 +74,7 @@ export const
   ),
   MarkupCard = ({ name, title, content, compact }: { name: S, title: S, content: S, compact?: B }) => (
     <div data-test={name} className={clas(css.card, compact ? '' : css.cardPadding)}>
-      {!compact && title && <div className='wave-s12 wave-w6'>{title}</div>}
+      {title && <div className='wave-s12 wave-w6'>{title}</div>}
       <div className={css.body}>
         <XMarkup model={{ content }} />
       </div>

--- a/ui/src/markup.tsx
+++ b/ui/src/markup.tsx
@@ -16,6 +16,7 @@ import { B, Model, S } from 'h2o-wave'
 import React from 'react'
 import { stylesheet } from 'typestyle'
 import { cards, grid } from './layout'
+import { clas } from './theme'
 import { bond } from './ui'
 
 const
@@ -23,6 +24,8 @@ const
     card: {
       display: 'flex',
       flexDirection: 'column',
+    },
+    cardPadding: {
       padding: grid.gap,
     },
     body: {
@@ -59,22 +62,26 @@ interface State {
    * :value "<div/>"
    **/
   content: S
+  /** 
+   * True if title and padding should be removed. Defaults to False.
+   **/
+  compact?: B
 }
 
 export const
   XMarkup = ({ model: { content, name } }: { model: Markup }) => (
     <div data-test={name} dangerouslySetInnerHTML={{ __html: content }} />
   ),
-  MarkupCard = ({ name, title, content }: { name: S, title: S, content: S }) => (
-    <div data-test={name} className={css.card}>
-      {title && <div className='wave-s12 wave-w6'>{title}</div>}
+  MarkupCard = ({ name, title, content, compact }: { name: S, title: S, content: S, compact?: B }) => (
+    <div data-test={name} className={clas(css.card, compact ? '' : css.cardPadding)}>
+      {!compact && title && <div className='wave-s12 wave-w6'>{title}</div>}
       <div className={css.body}>
         <XMarkup model={{ content }} />
       </div>
     </div>
   ),
   View = bond(({ name, state, changed }: Model<State>) => {
-    const render = () => <MarkupCard name={name} title={state.title} content={state.content} />
+    const render = () => <MarkupCard name={name} title={state.title} content={state.content} compact={state.compact} />
     return { render, changed }
   })
 

--- a/website/widgets/content/markup.md
+++ b/website/widgets/content/markup.md
@@ -25,17 +25,17 @@ menu = '''
 q.page['example'] = ui.markup_card(box='1 1 2 2', title='Menu', content=menu)
 ```
 
-## Without padding
+## Without outer card spacing
 
-You can set the `compact` attribute to `True` to remove the title and padding of a markup card.
+Set the `compact` attribute to `True` to remove the outer spacing.
 
 ```py
 menu = '''
-<ol>
-    <li>Spam</li>
-    <li>Ham</li>
-    <li>Eggs</li>
-</ol>
+<p>
+    <span>Spam</span>
+    <span>Ham</span>
+    <span>Eggs</span>
+</p>
 '''
 
 q.page['example'] = ui.markup_card(box='1 1 2 2', title='Menu', content=menu, compact=True)

--- a/website/widgets/content/markup.md
+++ b/website/widgets/content/markup.md
@@ -24,3 +24,19 @@ menu = '''
 
 q.page['example'] = ui.markup_card(box='1 1 2 2', title='Menu', content=menu)
 ```
+
+## Without padding
+
+You can set the `compact` attribute to `True` to remove the title and padding of a markup card.
+
+```py
+menu = '''
+<ol>
+    <li>Spam</li>
+    <li>Ham</li>
+    <li>Eggs</li>
+</ol>
+'''
+
+q.page['example'] = ui.markup_card(box='1 1 2 2', title='Menu', content=menu, compact=True)
+```


### PR DESCRIPTION
## **Github Issue**
Closes #1922

## **Description**
Added a `compact` attribute to the `State` interface of `markup.tsx`. Users can now specify whether they want the markup card to include the paddings or not. `compact` attribute defaults to `False`.

## **Succssful Local Testing**
<img width="449" alt="Screen Shot 2023-04-17 at 9 28 29 AM" src="https://user-images.githubusercontent.com/84405827/232499587-d1bbc125-e58e-49a3-b70e-9f379e6d9d3e.png">

Differences between `compact` invocations are depicted above.

The code used to produce the markup cards above is included below.
```py
menu = '''
<p>
    <span>Spam</span>
    <span>Ham</span>
    <span>Eggs</span>
</p>
'''

# Markup card with default padding (compact attribute not invoked)
page['example1'] = ui.markup_card(
    box='4 1 3 2',
    title='Markup card with default padding (compact attribute not invoked)',
    content=menu,
)

# Markup card with padding (compact=False)
page['example2'] = ui.markup_card(
    box='4 3 3 2',
    title='Markup card with padding (compact=False)',
    content=menu,
    compact=False
)

# Markup card with no padding (compact=True)
page['example3'] = ui.markup_card(
    box='4 5 3 2',
    title='Markup card with no padding (compact=True)',
    content=menu,
    compact=True
)
```
