### PR TITLE
fix: Filter out empty strings for tags and filter options #1905

### DIFF
--- a/ui/src/table.test.tsx
+++ b/ui/src/table.test.tsx
@@ -77,6 +77,91 @@ describe('Table.tsx', () => {
     expect(getAllByRole('gridcell')[0].textContent).toBe('6/23/2022, 12:50:28 AM')
   })
 
+  it('Renders tags correctly', () => {
+    tableProps = {
+      ...tableProps,
+      columns: [
+        { name: 'colname1', label: 'col1' },
+        {
+          name: 'colname2',
+          label: 'col2',
+          filterable: true,
+          cell_type: {
+            tag: {
+              name: 'tags',
+              tags: [
+                { label: 'TAG1', color: 'red' },
+                { label: 'TAG2', color: 'green' },
+                { label: 'TAG3', color: 'blue' },
+              ]
+            }
+          }
+        },
+      ],
+      rows: [
+        { name: 'rowname1', cells: [cell11, 'TAG1'] },
+        { name: 'rowname2', cells: [cell21, 'TAG2,TAG3'] },
+        { name: 'rowname3', cells: [cell31, 'TAG2'] }
+      ]
+    }
+
+    const { container, getAllByRole, getAllByTestId } = render(<XTable model={tableProps} />)
+
+    fireEvent.click(container.querySelector('.ms-DetailsHeader-filterChevron')!)
+
+    const checkboxes = getAllByRole('checkbox')
+    expect(checkboxes).toHaveLength(3)
+
+    const [tag1, tag2, tag3] = checkboxes
+    expect(tag1).not.toBeChecked()
+    expect(tag2).not.toBeChecked()
+    expect(tag3).not.toBeChecked()
+
+    expect(getAllByTestId('tags')[0].childElementCount).toBe(1)
+    expect(getAllByTestId('tags')[1].childElementCount).toBe(2)
+    expect(getAllByTestId('tags')[2].childElementCount).toBe(1)
+  })
+
+  it('Do not render tags with empty string values', () => {
+    tableProps = {
+      ...tableProps,
+      columns: [
+        { name: 'colname1', label: 'col1' },
+        {
+          name: 'colname2',
+          label: 'col2',
+          filterable: true,
+          cell_type: {
+            tag: {
+              name: 'tags',
+              tags: [
+                { label: 'TAG1', color: 'red' },
+                { label: 'TAG2', color: 'green' },
+                { label: 'TAG3', color: 'blue' },
+              ]
+            }
+          }
+        },
+      ],
+      rows: [
+        { name: 'rowname1', cells: [cell11, 'TAG1'] },
+        { name: 'rowname2', cells: [cell21, 'TAG2,TAG1'] },
+        { name: 'rowname3', cells: [cell31, ''] }
+      ]
+    }
+
+    const { container, getAllByRole, getAllByTestId } = render(<XTable model={tableProps} />)
+
+    fireEvent.click(container.querySelector('.ms-DetailsHeader-filterChevron')!)
+
+    const checkboxes = getAllByRole('checkbox')
+    expect(checkboxes).toHaveLength(2)
+
+    expect(getAllByTestId('tags')[0].childElementCount).toBe(1)
+    expect(getAllByTestId('tags')[1].childElementCount).toBe(2)
+    expect(getAllByTestId('tags')[2].childElementCount).toBe(0)
+  })
+
   // TODO: Add a test to check that no event is emitted on rows update. Would result in infinite loop.
 
   describe('Height compute', () => {

--- a/ui/src/table.test.tsx
+++ b/ui/src/table.test.tsx
@@ -110,10 +110,7 @@ describe('Table.tsx', () => {
     const checkboxes = getAllByRole('checkbox')
     expect(checkboxes).toHaveLength(3)
 
-    const [tag1, tag2, tag3] = checkboxes
-    expect(tag1).not.toBeChecked()
-    expect(tag2).not.toBeChecked()
-    expect(tag3).not.toBeChecked()
+    checkboxes.forEach(c => expect(c).not.toBeChecked())
 
     expect(getAllByTestId('tags')[0].childElementCount).toBe(1)
     expect(getAllByTestId('tags')[1].childElementCount).toBe(2)
@@ -135,8 +132,7 @@ describe('Table.tsx', () => {
 
     fireEvent.click(container.querySelector('.ms-DetailsHeader-filterChevron')!)
 
-    const checkboxes = getAllByRole('checkbox')
-    expect(checkboxes).toHaveLength(2)
+    expect(getAllByRole('checkbox')).toHaveLength(2)
 
     const [tags1, tags2, tags3] = getAllByTestId('tags')
     expect(tags1.childElementCount).toBe(1)

--- a/ui/src/table.test.tsx
+++ b/ui/src/table.test.tsx
@@ -26,7 +26,22 @@ const
   groupHeaderRow = 1,
   groupHeaderRowsCount = 2,
   filteredItem = 1,
-  emitMock = jest.fn()
+  emitMock = jest.fn(),
+  tagsColumn = {
+    name: 'tagsColumn',
+    label: 'tagsColumn',
+    filterable: true,
+    cell_type: {
+      tag: {
+        name: 'tags',
+        tags: [
+          { label: 'TAG1', color: 'red' },
+          { label: 'TAG2', color: 'green' },
+          { label: 'TAG3', color: 'blue' },
+        ]
+      }
+    }
+  }
 
 let tableProps: Table
 
@@ -80,28 +95,11 @@ describe('Table.tsx', () => {
   it('Renders tags correctly', () => {
     tableProps = {
       ...tableProps,
-      columns: [
-        { name: 'colname1', label: 'col1' },
-        {
-          name: 'colname2',
-          label: 'col2',
-          filterable: true,
-          cell_type: {
-            tag: {
-              name: 'tags',
-              tags: [
-                { label: 'TAG1', color: 'red' },
-                { label: 'TAG2', color: 'green' },
-                { label: 'TAG3', color: 'blue' },
-              ]
-            }
-          }
-        },
-      ],
+      columns: [tagsColumn],
       rows: [
-        { name: 'rowname1', cells: [cell11, 'TAG1'] },
-        { name: 'rowname2', cells: [cell21, 'TAG2,TAG3'] },
-        { name: 'rowname3', cells: [cell31, 'TAG2'] }
+        { name: 'rowname1', cells: ['TAG1'] },
+        { name: 'rowname2', cells: ['TAG2,TAG3'] },
+        { name: 'rowname3', cells: ['TAG2'] }
       ]
     }
 
@@ -122,31 +120,14 @@ describe('Table.tsx', () => {
     expect(getAllByTestId('tags')[2].childElementCount).toBe(1)
   })
 
-  it('Do not render tags with empty string values', () => {
+  it('Does not render empty tags', () => {
     tableProps = {
       ...tableProps,
-      columns: [
-        { name: 'colname1', label: 'col1' },
-        {
-          name: 'colname2',
-          label: 'col2',
-          filterable: true,
-          cell_type: {
-            tag: {
-              name: 'tags',
-              tags: [
-                { label: 'TAG1', color: 'red' },
-                { label: 'TAG2', color: 'green' },
-                { label: 'TAG3', color: 'blue' },
-              ]
-            }
-          }
-        },
-      ],
+      columns: [tagsColumn],
       rows: [
-        { name: 'rowname1', cells: [cell11, 'TAG1'] },
-        { name: 'rowname2', cells: [cell21, 'TAG2,TAG1'] },
-        { name: 'rowname3', cells: [cell31, ''] }
+        { name: 'rowname1', cells: ['TAG1'] },
+        { name: 'rowname2', cells: ['TAG2,TAG1'] },
+        { name: 'rowname3', cells: [''] }
       ]
     }
 
@@ -713,21 +694,7 @@ describe('Table.tsx', () => {
         ...tableProps,
         columns: [
           { name: 'colname1', label: 'col1' },
-          {
-            name: 'colname2',
-            label: 'col2',
-            filterable: true,
-            cell_type: {
-              tag: {
-                name: 'tags',
-                tags: [
-                  { label: 'TAG1', color: 'red' },
-                  { label: 'TAG2', color: 'green' },
-                  { label: 'TAG3', color: 'blue' },
-                ]
-              }
-            }
-          },
+          tagsColumn
         ],
         rows: [
           { name: 'rowname1', cells: [cell11, 'TAG1'] },
@@ -775,7 +742,7 @@ describe('Table.tsx', () => {
 
       fireEvent.click(container.querySelector('.ms-DetailsHeader-filterChevron')!)
       fireEvent.click(getAllByText('TAG1')[1].parentElement!)
-      expect(emitMock).toHaveBeenCalledWith(tableProps.name, 'filter', { 'colname2': ['TAG1'] })
+      expect(emitMock).toHaveBeenCalledWith(tableProps.name, 'filter', { 'tagsColumn': ['TAG1'] })
       expect(emitMock).toHaveBeenCalledTimes(1)
     })
   })

--- a/ui/src/table.test.tsx
+++ b/ui/src/table.test.tsx
@@ -157,9 +157,10 @@ describe('Table.tsx', () => {
     const checkboxes = getAllByRole('checkbox')
     expect(checkboxes).toHaveLength(2)
 
-    expect(getAllByTestId('tags')[0].childElementCount).toBe(1)
-    expect(getAllByTestId('tags')[1].childElementCount).toBe(2)
-    expect(getAllByTestId('tags')[2].childElementCount).toBe(0)
+    const [tags1, tags2, tags3] = getAllByTestId('tags')
+    expect(tags1.childElementCount).toBe(1)
+    expect(tags2.childElementCount).toBe(2)
+    expect(tags3.childElementCount).toBe(0)
   })
 
   // TODO: Add a test to check that no event is emitted on rows update. Would result in infinite loop.

--- a/ui/src/table.tsx
+++ b/ui/src/table.tsx
@@ -393,9 +393,9 @@ const
           /> : null
       }, [onFilterChange, setFiltersInBulk]),
       onColumnContextMenu = React.useCallback((col: WaveColumn, e: React.MouseEvent<HTMLElement>) => {
-        const menuFilters = (col.filters || items.map(i => i[col.fieldName || col.key])).filter(item => item !== '')
+        const menuFilters = col.filters || items.map(i => i[col.fieldName || col.key])
         setColContextMenuList({
-          items: Array.from(new Set(menuFilters)).map(option => ({ key: option, text: option, data: col.fieldName || col.key })),
+          items: Array.from(new Set(menuFilters)).filter(item => item !== '').map(option => ({ key: option, text: option, data: col.fieldName || col.key })),
           target: e.target as HTMLElement,
           directionalHint: Fluent.DirectionalHint.bottomLeftEdge,
           gapSpace: 10,

--- a/ui/src/table.tsx
+++ b/ui/src/table.tsx
@@ -393,7 +393,7 @@ const
           /> : null
       }, [onFilterChange, setFiltersInBulk]),
       onColumnContextMenu = React.useCallback((col: WaveColumn, e: React.MouseEvent<HTMLElement>) => {
-        const menuFilters = col.filters || items.map(i => i[col.fieldName || col.key])
+        const menuFilters = (col.filters || items.map(i => i[col.fieldName || col.key])).filter(item => item !== '')
         setColContextMenuList({
           items: Array.from(new Set(menuFilters)).map(option => ({ key: option, text: option, data: col.fieldName || col.key })),
           target: e.target as HTMLElement,

--- a/ui/src/tag_table_cell_type.tsx
+++ b/ui/src/tag_table_cell_type.tsx
@@ -73,5 +73,5 @@ export const XTagTableCellType = ({ model, serializedTags, isMultiline }: { mode
 
       return <span key={i} style={{ background, color }} className={clas(css.tag, 'wave-s12 wave-w6', isMultiline ? css.multiline : '')}>{tagLabel}</span>
     })
-  return <div data-test={model.name}>{serializedTags.split(',').map(mapTags)}</div>
+  return <div data-test={model.name}>{serializedTags.split(',').filter(tag => tag !== '').map(mapTags)}</div>
 }


### PR DESCRIPTION
After fix:
![image](https://user-images.githubusercontent.com/23740173/233605484-de6959b6-911f-4abc-abec-7273cd2ab3b5.png)

Before fix:
![image](https://user-images.githubusercontent.com/23740173/233605586-a7513591-8a26-4a28-b974-4e67ba8fe729.png)


Closes #1905 