### PR TITLE
feat: Make tour examples to support path-based routing #1875

### DIFF
--- a/py/apps/tour/app.toml
+++ b/py/apps/tour/app.toml
@@ -8,4 +8,5 @@ LongDescription = "about.md"
 
 [Runtime]
 Module = "examples.tour"
+RoutingMode = "BASE_URL"
 RuntimeVersion = "deb11_py310_wlatest"

--- a/py/examples/link.py
+++ b/py/examples/link.py
@@ -9,10 +9,10 @@ page = site['/demo']
 page['example'] = ui.form_card(
     box='1 1 4 7',
     items=[
-        ui.link(label='Internal link', path='/starred'),
-        ui.link(label='Internal link, new tab', path='/starred', target=''),
-        ui.link(label='Internal link, new tab', path='/starred', target='_blank'),  # same as target=''
-        ui.link(label='Internal link, disabled', path='/starred', disabled=True),
+        ui.link(label='Internal link', path='./starred'),
+        ui.link(label='Internal link, new tab', path='./starred', target=''),
+        ui.link(label='Internal link, new tab', path='./starred', target='_blank'),  # same as target=''
+        ui.link(label='Internal link, disabled', path='./starred', disabled=True),
         ui.link(label='External link', path='https://h2o.ai'),
         ui.link(label='External link, new tab', path='https://h2o.ai', target=''),
         ui.link(label='External link, new tab', path='https://h2o.ai', target='_blank'),  # same as target=''

--- a/py/examples/link.py
+++ b/py/examples/link.py
@@ -9,10 +9,10 @@ page = site['/demo']
 page['example'] = ui.form_card(
     box='1 1 4 7',
     items=[
-        ui.link(label='Internal link', path='./starred'),
-        ui.link(label='Internal link, new tab', path='./starred', target=''),
-        ui.link(label='Internal link, new tab', path='./starred', target='_blank'),  # same as target=''
-        ui.link(label='Internal link, disabled', path='./starred', disabled=True),
+        ui.link(label='Internal link', path='starred'),
+        ui.link(label='Internal link, new tab', path='starred', target=''),
+        ui.link(label='Internal link, new tab', path='starred', target='_blank'),  # same as target=''
+        ui.link(label='Internal link, disabled', path='starred', disabled=True),
         ui.link(label='External link', path='https://h2o.ai'),
         ui.link(label='External link, new tab', path='https://h2o.ai', target=''),
         ui.link(label='External link, new tab', path='https://h2o.ai', target='_blank'),  # same as target=''

--- a/py/examples/meta_icon.py
+++ b/py/examples/meta_icon.py
@@ -14,7 +14,7 @@ page['meta'] = ui.meta_card(box='', icon='https://en.wikipedia.org/static/apple-
 page['example'] = ui.markdown_card(
     box='1 1 2 2',
     title='',
-    content='<a href="./demo" target="_blank">Open this page in a new window</a> to view its icon.',
+    content='<a href="demo" target="_blank">Open this page in a new window</a> to view its icon.',
 )
 
 page.save()

--- a/py/examples/meta_icon.py
+++ b/py/examples/meta_icon.py
@@ -14,7 +14,7 @@ page['meta'] = ui.meta_card(box='', icon='https://en.wikipedia.org/static/apple-
 page['example'] = ui.markdown_card(
     box='1 1 2 2',
     title='',
-    content='<a href="/demo" target="_blank">Open this page in a new window</a> to view its icon.',
+    content='<a href="./demo" target="_blank">Open this page in a new window</a> to view its icon.',
 )
 
 page.save()

--- a/py/examples/meta_title.py
+++ b/py/examples/meta_title.py
@@ -10,7 +10,7 @@ page['meta'] = ui.meta_card(box='', title='And now for something completely diff
 page['example'] = ui.markdown_card(
     box='1 1 2 2',
     title='',
-    content='<a href="/demo" target="_blank">Open this page in a new window</a> to view its title.',
+    content='<a href="./demo" target="_blank">Open this page in a new window</a> to view its title.',
 )
 
 page.save()

--- a/py/examples/meta_title.py
+++ b/py/examples/meta_title.py
@@ -10,7 +10,7 @@ page['meta'] = ui.meta_card(box='', title='And now for something completely diff
 page['example'] = ui.markdown_card(
     box='1 1 2 2',
     title='',
-    content='<a href="./demo" target="_blank">Open this page in a new window</a> to view its title.',
+    content='<a href="demo" target="_blank">Open this page in a new window</a> to view its title.',
 )
 
 page.save()

--- a/py/examples/site_async.py
+++ b/py/examples/site_async.py
@@ -44,7 +44,7 @@ async def serve(q: Q):
 
         # Set up this app's UI
         q.page['form'] = ui.form_card(box='1 1 6 5', items=[
-            ui.frame(path='./stats', height='110px'),
+            ui.frame(path='stats', height='110px'),
             ui.button(name='toggle', label='Start updates', primary=True),
         ])
         await q.page.save()

--- a/py/examples/site_async.py
+++ b/py/examples/site_async.py
@@ -44,7 +44,7 @@ async def serve(q: Q):
 
         # Set up this app's UI
         q.page['form'] = ui.form_card(box='1 1 6 5', items=[
-            ui.frame(path='/stats', height='110px'),
+            ui.frame(path='./stats', height='110px'),
             ui.button(name='toggle', label='Start updates', primary=True),
         ])
         await q.page.save()


### PR DESCRIPTION
A relative URL with `/` in the beginning replaces the entire path name of the base URL.
What we want here is to appended a relative URL to the full base URL and this can be achieved by removing the leading slash.


https://user-images.githubusercontent.com/23740173/234636257-ad5ee447-fff2-46b2-a066-3e60bfe1f4b1.mov



Closes #1875 