### PR TITLE
fix: Perform numerical sort in map buffer if possible.

### DIFF
--- a/ts/index.ts
+++ b/ts/index.ts
@@ -626,7 +626,11 @@ const
       },
       list = (): Rec[] => {
         const keys = keysOf(tups)
-        keys.sort()
+
+        isNaN(+keys[0])
+          ? keys.sort()
+          : keys.sort((a, b) => +a - +b)
+
         const xs: Rec[] = []
         for (const k of keys) xs.push(t.make(tups[k]))
         return xs


### PR DESCRIPTION
This PR makes sure that map buffer entries are sorted in numerical order (if keys are valid numbers), defaulting to regular string sort.

## Needs discussion

@lo5 this is a possible breaking change although I don't think there are many people relying on string sort order. There are ways around making this non-breaking, but not sure if worth the hassle + IMO this should be the right behavior. Wdyt?