### PR TITLE
fix: Prevent components from being overlapped by the sticky header of ui.table

### DIFF
--- a/ui/src/dialog.tsx
+++ b/ui/src/dialog.tsx
@@ -44,7 +44,8 @@ export interface Dialog {
   events?: S[]
 }
 
-export const layerProps: Fluent.ILayerProps = { styles: { root: { zIndex: 1 } } }
+// z-index needs to be higher than sticky header in ui.table
+export const layerProps: Fluent.ILayerProps = { styles: { root: { zIndex: 3 } } }
 
 export default bond(() => {
   const

--- a/ui/src/notification_bar.tsx
+++ b/ui/src/notification_bar.tsx
@@ -120,7 +120,7 @@ export const
                   animationFillMode: 'forwards',
                   maxWidth: 500,
                   width: pc(100),
-                  zIndex: 3, // Needs to be higher than Fluent UI Panel's z-index
+                  zIndex: 5, // Needs to be higher than z-index of ui.time_picker
                   ...getPosition(currentModel?.position, shouldBeOpen)
                 },
                 content: { alignItems: isMultiline ? 'start' : 'center' },

--- a/ui/src/time_picker.tsx
+++ b/ui/src/time_picker.tsx
@@ -81,7 +81,7 @@ const
   popoverProps: Partial<PopperProps> | undefined = {
     placement: 'bottom-start',
     sx: {
-      zIndex: 2, // Needs to be higher than Fluent UI Panel, but lower than ui.notification_bar.
+      zIndex: 4, // Needs to be higher than ui.dialog/ui.side_panel, but lower than ui.notification_bar.
       '& .MuiPaper-root': {
         borderRadius: '2px',
         boxShadow: `${cssVar('$text1')} 0px 6.4px 14.4px 0px, ${cssVar('$text2')} 0px 1.2px 3.6px 0px`


### PR DESCRIPTION
Closes #1980