### PR TITLE
fix: Do not append text input into messages when stopping the generation

### DIFF
--- a/py/examples/chatbot_events_stop.py
+++ b/py/examples/chatbot_events_stop.py
@@ -28,8 +28,15 @@ async def serve(q: Q):
         q.page['meta'] = ui.meta_card(box='', theme='h2o-dark')
         q.client.initialized = True
 
+    # Check if we get a stop event
+    if q.events.chatbot:
+        if q.events.chatbot.stop:
+            # Cancel the streaming task
+            q.client.task.cancel()
+            # Hide the "Stop generating" button
+            q.page['example'].generating = False
     # A new message arrived.
-    if q.args.chatbot:
+    elif q.args.chatbot:
         # Append user message.
         q.client.msg_num += 1
         q.page['example'].data[q.client.msg_num] = [q.args.chatbot, True]
@@ -39,13 +46,5 @@ async def serve(q: Q):
         chatbot_response = 'I am a fake chatbot. Sorry, I cannot help you.'
         # Create and run a task to stream the message
         q.client.task = asyncio.create_task(stream_message(q, chatbot_response))
-
-    # Check if we get a stop event
-    if q.events.chatbot:
-        if q.events.chatbot.stop:
-            # Cancel the streaming task
-            q.client.task.cancel()
-            # Hide the "Stop generating" button
-            q.page['example'].generating = False
 
     await q.page.save()

--- a/website/widgets/ai/chatbot.md
+++ b/website/widgets/ai/chatbot.md
@@ -50,7 +50,7 @@ This event can be triggered by clicking the [*Stop generating* button](#with-a-s
 
 ![chatbot events gif](/img/widgets/chatbot_events_stop.gif)
 
-```py ignore {23,40,41}
+```py ignore {23,28,29}
 from h2o_wave import main, app, Q, ui, data
 import asyncio
 
@@ -77,8 +77,15 @@ async def serve(q: Q):
         q.page['meta'] = ui.meta_card(box='', theme='h2o-dark')
         q.client.initialized = True
 
+    # Check if we get a stop event
+    if q.events.chatbot:
+        if q.events.chatbot.stop:
+            # Cancel the streaming task
+            q.client.task.cancel()
+            # Hide the "Stop generating" button
+            q.page['example'].generating = False
     # A new message arrived.
-    if q.args.chatbot:
+    elif q.args.chatbot:
         # Append user message.
         q.client.msg_num += 1
         q.page['example'].data[q.client.msg_num] = [q.args.chatbot, True]
@@ -89,13 +96,5 @@ async def serve(q: Q):
         # Create and run a task to stream the message
         q.client.task = asyncio.create_task(stream_message(q, chatbot_response))
 
-    # Check if we get a stop event
-    if q.events.chatbot:
-        if q.events.chatbot.stop:
-            # Cancel the streaming task
-            q.client.task.cancel()
-            # Hide the "Stop generating" button
-            q.page['example'].generating = False
-
-    await q.page.save()   
+    await q.page.save()
 ```


### PR DESCRIPTION
This PR fixes the issue where text input content was appended into messages after clicking on the _Stop generating_ button in the `chatbot_events_stop.py` tour example.

https://github.com/h2oai/wave/assets/23740173/c163f25a-bae4-4bf0-9f0d-48d762b7b7a5

