### PR TITLE
fix: Show curly braces in pydocs correctly #1880

### DIFF
--- a/py/h2o_lightwave/h2o_lightwave/routing.py
+++ b/py/h2o_lightwave/h2o_lightwave/routing.py
@@ -62,7 +62,7 @@ def on(arg: str = None, predicate: Optional[Callable] = None):
     A function annotated with `@on('foo.bar', lambda x: 42 <= x <= 420)` is invoked whenever `q.events.foo.bar` between 42 and 420.
     A function annotated with `@on('#foo')` is invoked whenever `q.args['#']` equals 'foo'.
     A function annotated with `@on('#foo/bar')` is invoked whenever `q.args['#']` equals 'foo/bar'.
-    A function annotated with `@on('#foo/&lcub;fruit&rcub;')` is invoked whenever `q.args['#']` matches 'foo/apple', 'foo/orange', etc. The parameter 'fruit' is passed to the function (in this case, 'apple', 'orange', etc.)
+    A function annotated with `@on('#foo/{"{fruit}"}')` is invoked whenever `q.args['#']` matches 'foo/apple', 'foo/orange', etc. The parameter 'fruit' is passed to the function (in this case, 'apple', 'orange', etc.)
 
     Parameters in patterns (indicated within curly braces) can be converted to `str`, `int`, `float` or `uuid.UUID` instances by suffixing the parameters with `str`, `int`, `float` or `uuid`, respectively.
 

--- a/py/h2o_wave/h2o_wave/routing.py
+++ b/py/h2o_wave/h2o_wave/routing.py
@@ -62,7 +62,7 @@ def on(arg: str = None, predicate: Optional[Callable] = None):
     A function annotated with `@on('foo.bar', lambda x: 42 <= x <= 420)` is invoked whenever `q.events.foo.bar` between 42 and 420.
     A function annotated with `@on('#foo')` is invoked whenever `q.args['#']` equals 'foo'.
     A function annotated with `@on('#foo/bar')` is invoked whenever `q.args['#']` equals 'foo/bar'.
-    A function annotated with `@on('#foo/&lcub;fruit&rcub;')` is invoked whenever `q.args['#']` matches 'foo/apple', 'foo/orange', etc. The parameter 'fruit' is passed to the function (in this case, 'apple', 'orange', etc.)
+    A function annotated with `@on('#foo/{"{fruit}"}')` is invoked whenever `q.args['#']` matches 'foo/apple', 'foo/orange', etc. The parameter 'fruit' is passed to the function (in this case, 'apple', 'orange', etc.)
 
     Parameters in patterns (indicated within curly braces) can be converted to `str`, `int`, `float` or `uuid.UUID` instances by suffixing the parameters with `str`, `int`, `float` or `uuid`, respectively.
 


### PR DESCRIPTION
Pdoc builds the docs correctly when curly braces `{}` are used.
The problem is with [docusaurus using the MDX compiler](https://github.com/facebook/docusaurus/issues/3018) for `.md` files generated by pdoc while building the website.
In MDX, curly braces are reserved for expressions so in our case the MDX compiler is looking for a `fruit` variable which is, obviously, not defined - `@on('#foo/{fruit}')`. We can fix this by writing an expression inside the curly braces which returns what we want, in our case `{"{fruit}"}`.


Closes #1880 