### PR TITLE
fix: Set active tool other than 'select' to emit the click event

### DIFF
--- a/ui/src/image_annotator.test.tsx
+++ b/ui/src/image_annotator.test.tsx
@@ -448,6 +448,7 @@ describe('ImageAnnotator.tsx', () => {
       const emitMock = jest.fn()
       wave.emit = emitMock
 
+      fireEvent.keyDown(canvasEl, { key: 'r' })
       userEvent.click(canvasEl, { clientX: 100, clientY: 120 })
       expect(emitMock).toHaveBeenCalled()
       expect(emitMock).toHaveBeenCalledWith(model.name, 'click', { x: 100, y: 120 })


### PR DESCRIPTION
This PR fixes the failing ui.image_annotator test.