### PR TITLE
Fix: Support multi spaces in stat values #1666

### DIFF
--- a/py/examples/stat_label_space.py
+++ b/py/examples/stat_label_space.py
@@ -1,0 +1,18 @@
+# Stat / Label / Space
+# Simple example of a stat card with a label that has spaces in it
+# ----
+
+from h2o_wave import site, ui
+
+page = site['/demo']
+
+page.add('example', ui.tall_stats_card(
+    box='1 1 3 5',
+    items=[
+        ui.stat(label='PARAMETER       NAME      Some data', value='125%'),
+        ui.stat(label='Category 1    x', value='578 Users'),
+
+    ]
+))
+
+page.save()

--- a/ui/src/index.scss
+++ b/ui/src/index.scss
@@ -177,6 +177,7 @@ $fontTrackings: (
 @each $size,
 $tracking in $fontTrackings {
   .wave-s#{$size} {
+    white-space: pre-wrap;
     font-size: $size + px;
     letter-spacing: $tracking + em;
     line-height: round(1.4 * $size) + px;


### PR DESCRIPTION
**The PR fulfills these requirements:** (check all the apply)

- [x] It's submitted to the `main` branch.
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `feat: Add a button #xxx`, where "xxx" is the issue number).
- [x] When resolving a specific issue, the PR description includes `Closes #xxx`, where "xxx" is the issue number.
- [x] If changes were made to `ui` folder, unit tests (`make test`) still pass.
- [x] New/updated tests are included
------
Closes #1666 
### Specific change : Added white-space: pre-wrap; so that Whitespace is preserved and  text will wrap when necessary, and on line breaks 

-----
![image](https://github.com/h2oai/wave/assets/36219488/6c701cbd-e794-4041-854e-0c12067da679)
----
# Test case output 
![image](https://github.com/h2oai/wave/assets/36219488/0abdb793-f5dd-4a5a-b443-4ada0633a2be)
![image](https://github.com/h2oai/wave/assets/36219488/86fe723e-5616-4ff0-b14f-1bd661474f9f)

