### PR TITLE
feat: Add data buffer support to components (form card). #441

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -79,6 +79,14 @@
       ]
     },
     {
+      "name": "Debug Wave Script",
+      "type": "python",
+      "request": "launch",
+      "program": "${file}",
+      "python": "${workspaceFolder}/py/venv/bin/python",
+      "console": "integratedTerminal",
+    },
+    {
       "name": "Debug Wave App",
       "type": "python",
       "request": "launch",

--- a/card.go
+++ b/card.go
@@ -285,4 +285,6 @@ func fillFormCardBufs(data map[string]any, outData map[string]any, bufs *[]BufD,
 			*bufs = append(*bufs, b.dump())
 		}
 	}
+	//lint:ignore SA4006 this function is recursive so mutation is necessary.
+	keys = keys[:len(keys)-1]
 }

--- a/card.go
+++ b/card.go
@@ -97,7 +97,6 @@ func (c *Card) set(ks []string, v any) {
 		}
 
 		keys := strings.Split(p, ".")
-		lastKey := keys[len(keys)-1]
 		var x any = c.data
 		// Get the object even if nested.
 		for i := 0; i < len(keys)-1; i++ {
@@ -105,6 +104,7 @@ func (c *Card) set(ks []string, v any) {
 		}
 
 		if x, ok := x.(map[string]any); ok {
+			lastKey := keys[len(keys)-1]
 			if v == nil {
 				delete(x, lastKey)
 			} else {
@@ -120,8 +120,8 @@ func (c *Card) set(ks []string, v any) {
 			x = c.nameComponentMap[ks[0]]
 			startIdx = 1
 		}
-		for i := startIdx; i < len(ks)-1; i++ {
-			x = get(x, ks[i])
+		for _, k := range ks[startIdx : len(ks)-1] {
+			x = get(x, k)
 		}
 
 		p := ks[len(ks)-1]

--- a/card.go
+++ b/card.go
@@ -99,8 +99,8 @@ func (c *Card) set(ks []string, v any) {
 		keys := strings.Split(p, ".")
 		var x any = c.data
 		// Get the object even if nested.
-		for i := 0; i < len(keys)-1; i++ {
-			x = get(x, keys[i])
+		for _, key := range keys[:len(keys)-1] {
+			x = get(x, key)
 		}
 
 		if x, ok := x.(map[string]any); ok {

--- a/card.go
+++ b/card.go
@@ -177,8 +177,10 @@ func (c *Card) dump() CardD {
 	var bufs []BufD
 
 	// Look for nested buffers within form_card.
-	if v, ok := c.data["view"]; ok && v.(string) == "form" {
-		fillFormCardBufs(c.data, data, &bufs, make([]string, 0))
+	if v, ok := c.data["view"]; ok {
+		if v, ok := v.(string); ok && v == "form" {
+			fillFormCardBufs(c.data, data, &bufs, make([]string, 0))
+		}
 	}
 
 	for k, iv := range c.data {

--- a/py/h2o_lightwave/h2o_lightwave/core.py
+++ b/py/h2o_lightwave/h2o_lightwave/core.py
@@ -52,6 +52,39 @@ def _guard_key(key: str):
             raise KeyError('invalid key type: want str or int')
 
 
+def _fill_data_buffers(props: Dict, data: list, bufs: list, keys=[], is_form_card=False):
+    for k, v in props.items():
+        if isinstance(v, Data):
+            keys.append(k)
+            data.append(('.'.join(keys), len(bufs)))
+            bufs.append(v.dump())
+            keys.pop()
+        elif not is_form_card:
+            continue
+        elif isinstance(v, list):
+            keys.append(k)
+            for idx, e in enumerate(v):
+                if isinstance(e, dict):
+                    keys.append(str(idx))
+                    _fill_data_buffers(e, data, bufs, keys, is_form_card)
+                    keys.pop()
+            keys.pop()
+        elif isinstance(v, dict):
+            keys.append(k)
+            _fill_data_buffers(v, data, bufs, keys, is_form_card)
+            keys.pop()
+
+
+def _del_dict_key(d: dict, keys: List[str]):
+    if len(keys) == 1:
+        del d[keys[0]]
+    else:
+        next_key = keys[0]
+        key = int(next_key) if next_key.isdigit() else next_key
+        _del_dict_key(d[key], keys[1:])
+
+
+
 DICT = '__kv'
 
 
@@ -375,13 +408,11 @@ class PageBase:
 
         data = []
         bufs = []
-        for k, v in props.items():
-            if isinstance(v, Data):
-                data.append((k, len(bufs)))
-                bufs.append(v.dump())
+
+        _fill_data_buffers(props, data, bufs, [], props['view'] == 'form')
 
         for k, v in data:
-            del props[k]
+            _del_dict_key(props, k.split('.'))
             props[f'~{k}'] = v
 
         if len(bufs) > 0:

--- a/py/h2o_lightwave/h2o_lightwave/core.py
+++ b/py/h2o_lightwave/h2o_lightwave/core.py
@@ -409,7 +409,7 @@ class PageBase:
         data = []
         bufs = []
 
-        _fill_data_buffers(props, data, bufs, [], props['view'] == 'form')
+        _fill_data_buffers(props, data, bufs, [], props.get('view') == 'form')
 
         for k, v in data:
             _del_dict_key(props, k.split('.'))

--- a/py/h2o_wave/h2o_wave/core.py
+++ b/py/h2o_wave/h2o_wave/core.py
@@ -527,7 +527,7 @@ class PageBase:
 
         data = []
         bufs = []
-        _fill_data_buffers(props, data, bufs, [], props['view'] == 'form')
+        _fill_data_buffers(props, data, bufs, [], props.get('view') == 'form')
 
         for k, v in data:
             _del_dict_key(props, k.split('.'))

--- a/py/h2o_wave/h2o_wave/core.py
+++ b/py/h2o_wave/h2o_wave/core.py
@@ -18,7 +18,6 @@ import ipaddress
 import json
 import platform
 import secrets
-import shutil
 import subprocess
 from urllib.parse import urlparse
 from uuid import uuid4
@@ -97,17 +96,6 @@ def _are_primitives(xs: Any) -> bool:
         if not _is_primitive(x):
             return False
     return True
-
-
-def _guard_primitive_list(xs: Any):
-    if not _are_primitives(xs):
-        raise ValueError('value must be a primitive list or tuple')
-
-
-def _guard_primitive_dict_values(d: Dict[str, Any]):
-    if d:
-        for x in d.values():
-            _guard_primitive(x)
 
 
 def _guard_str_key(key: str):
@@ -269,6 +257,38 @@ def _dump(xs: Any):
         return xs.dump()
     else:
         return xs
+
+
+def _fill_data_buffers(props: Dict, data: list, bufs: list, keys=[], is_form_card=False):
+    for k, v in props.items():
+        if isinstance(v, Data):
+            keys.append(k)
+            data.append(('.'.join(keys), len(bufs)))
+            bufs.append(v.dump())
+            keys.pop()
+        elif not is_form_card:
+            continue
+        elif isinstance(v, list):
+            keys.append(k)
+            for idx, e in enumerate(v):
+                if isinstance(e, dict):
+                    keys.append(str(idx))
+                    _fill_data_buffers(e, data, bufs, keys, is_form_card)
+                    keys.pop()
+            keys.pop()
+        elif isinstance(v, dict):
+            keys.append(k)
+            _fill_data_buffers(v, data, bufs, keys, is_form_card)
+            keys.pop()
+
+
+def _del_dict_key(d: dict, keys: List[str]):
+    if len(keys) == 1:
+        del d[keys[0]]
+    else:
+        next_key = keys[0]
+        key = int(next_key) if next_key.isdigit() else next_key
+        _del_dict_key(d[key], keys[1:])
 
 
 class Ref:
@@ -507,13 +527,10 @@ class PageBase:
 
         data = []
         bufs = []
-        for k, v in props.items():
-            if isinstance(v, Data):
-                data.append((k, len(bufs)))
-                bufs.append(v.dump())
+        _fill_data_buffers(props, data, bufs, [], props['view'] == 'form')
 
         for k, v in data:
-            del props[k]
+            _del_dict_key(props, k.split('.'))
             props[f'~{k}'] = v
 
         if len(bufs) > 0:

--- a/py/tests/utils.py
+++ b/py/tests/utils.py
@@ -18,6 +18,40 @@ def make_card(**props):
             d[k] = v
     return dict(d=d, b=b) if len(b) else dict(d=d)
 
+def make_form_card(buf):
+    return {
+    "p": {
+      "c": {
+        "card1": {
+          "b": [ buf ],
+          "d": {
+            "box": "1 1 1 1",
+            "items": [
+              {
+                "visualization": {
+                  "data": {},
+                  "name": "my_plot",
+                  "plot": {
+                    "marks": [
+                      {
+                        "type": "interval",
+                        "x": "=profession",
+                        "y": "=salary",
+                        "y_min": 0
+                      }
+                    ]
+                  }
+                }
+              }
+            ],
+            "view": "form",
+            "~items.0.visualization.data": 0
+            }
+          }
+        }
+      },
+    }
+
 
 def make_map_buf(fields, data): return {'__m__': dict(f=fields, d=data)}
 

--- a/tools/showcase/showcase.py
+++ b/tools/showcase/showcase.py
@@ -100,7 +100,7 @@ def make_snippet_screenshot(code: List[str], img_name: str, page, groups: List[s
         os.makedirs(os.path.dirname(path), exist_ok=True)
         card_name = match[0][2] if match[0][2] != 'meta' else match[1][2]
         selector = f'[data-test="{card_name}"]'
-        if('ui.form_card' in code_str):
+        if 'ui.form_card' in code_str:
             widget_count = len(page.query_selector_all(f'{selector} > :first-child > *'))
             selector = f'{selector} > *' if widget_count > 1 else f'{selector} > :first-child > *'
         page.wait_for_selector(selector)

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -785,17 +785,23 @@ const
                 b.put(v)
                 return
               }
-              if (v == null) delete data[p]; else data[p] = v
+              const keys = p.split('.')
+              const lastKey = keys[keys.length - 1]
+              let x = data
+              for (let i = 0; i < keys.length - 1; i++) x = gget(x, keys[i])
+              v === null ? delete x[lastKey] : x[lastKey] = v
               return
             }
           default:
             {
               let x: any = data
-              if (ks.length === 2 && componentCache[ks[0]]) x = componentCache[ks[0]]
-              // DEPRECATED: Access via page.items[idx].wrapper.prop.
-              else for (const k of ks.slice(0, ks.length - 1)) x = gget(x, k)
-              const prop = ks[ks.length - 1]
-              gset(x, prop, v)
+              let i = 0
+              if (!data.hasOwnProperty(ks[0]) && componentCache[ks[0]]) {
+                x = componentCache[ks[0]]
+                i = 1
+              }
+              for (; i < ks.length - 1; i++) x = gget(x, ks[i])
+              gset(x, ks[ks.length - 1], v)
               return
             }
         }

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -786,22 +786,21 @@ const
                 return
               }
               const keys = p.split('.')
-              const lastKey = keys[keys.length - 1]
+              const lastKey = keys.pop() as S
               let x = data
-              for (let i = 0; i < keys.length - 1; i++) x = gget(x, keys[i])
+              for (const k of keys) x = gget(x, k)
               v === null ? delete x[lastKey] : x[lastKey] = v
               return
             }
           default:
             {
               let x: any = data
-              let i = 0
               if (!data.hasOwnProperty(ks[0]) && componentCache[ks[0]]) {
-                x = componentCache[ks[0]]
-                i = 1
+                x = componentCache[ks.shift() as S]
               }
-              for (; i < ks.length - 1; i++) x = gget(x, ks[i])
-              gset(x, ks[ks.length - 1], v)
+              const lastKey = ks.pop() as S
+              for (const k of ks) x = gget(x, k)
+              gset(x, lastKey, v)
               return
             }
         }

--- a/ui/src/plot.tsx
+++ b/ui/src/plot.tsx
@@ -14,7 +14,7 @@
 
 import { Chart } from '@antv/g2'
 import { AdjustOption, AnnotationPosition, ArcOption, AxisOption, ChartCfg, CoordinateActions, CoordinateOption, DataMarkerOption, DataRegionOption, GeometryOption, LineOption, RegionOption, ScaleOption, TextOption, TooltipItem } from '@antv/g2/lib/interface'
-import { B, Dict, Disposable, F, Model, on, parseI, parseU, Rec, S, unpack, V } from 'h2o-wave'
+import { B, Dict, Disposable, F, isBuf, Model, on, parseI, parseU, Rec, S, unpack, V } from 'h2o-wave'
 import React from 'react'
 import ReactDOM from 'react-dom'
 import { stylesheet } from 'typestyle'
@@ -1131,22 +1131,27 @@ export const
             chart.render(true)
           })
         }
-      }
+      },
+      updateData = React.useCallback(() => {
+        const el = container.current
+        if (!el || !currentChart.current || !currentPlot.current) return
+        const
+          raw_data = unpack<any[]>(model.data),
+          data = refactorData(raw_data, currentPlot.current.marks)
+        originalDataRef.current = unpack<any[]>(model.data)
+        currentChart.current.changeData(data)
+      }, [model.data])
+
+    React.useEffect(() => {
+      if (isBuf(model.data)) model.data.registerOnChange(updateData)
+    }, [model.data, updateData])
 
     React.useEffect(() => {
       init()
       return () => themeWatchRef.current?.dispose()
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
-    React.useEffect(() => {
-      const el = container.current
-      if (!el || !currentChart.current || !currentPlot.current) return
-      const
-        raw_data = unpack<any[]>(model.data),
-        data = refactorData(raw_data, currentPlot.current.marks)
-      originalDataRef.current = unpack<any[]>(model.data)
-      currentChart.current.changeData(data)
-    }, [currentChart, currentPlot, model])
+    React.useEffect(() => updateData(), [updateData])
 
     const
       { width = 'auto', height = 'auto', name } = model,

--- a/website/widgets/form/visualization.md
+++ b/website/widgets/form/visualization.md
@@ -21,7 +21,7 @@ from h2o_wave import data
 q.page['example'] = ui.form_card(box='1 1 4 4', items=[
     ui.visualization(
         plot=ui.plot([ui.mark(type='interval', x='=product', y='=price', y_min=0)]),
-        data=data(fields='product price', pack=True, rows=[
+        data=data(fields='product price', rows=[
             ('category1', 7),
             ('category2', 8),
             ('category3', 9),
@@ -45,7 +45,7 @@ q.page['example'] = ui.form_card(box='1 1 4 4', items=[
     ui.visualization(
         height='300px',
         plot=ui.plot([ui.mark(type='interval', x='=product', y='=price', y_min=0)]),
-        data=data(fields='product price', pack=True, rows=[
+        data=data(fields='product price', rows=[
             ('category1', 7),
             ('category2', 8),
             ('category3', 9),
@@ -68,7 +68,7 @@ q.page['example'] = ui.form_card(box='1 1 4 4', items=[
         name='viz',
         height='300px',
         plot=ui.plot([ui.mark(type='interval', x='=product', y='=price', y_min=0)]),
-        data=data(fields='product price', pack=True, rows=[
+        data=data(fields='product price', rows=[
             ('category1', 7),
             ('category2', 8),
             ('category3', 9),


### PR DESCRIPTION
This PR introduces support for non-packed data buffers within `ui.visualization` components - form cards.

By-name access is supported as well, buffers behave in the same way for form components as they do in cards.

```py
import time

from h2o_wave import site, ui, data

page = site['/demo']

page.add('example', ui.form_card(
    box='1 1 -1 8',
    items=[
        ui.visualization(
            name='my_plot',
            plot=ui.plot([ui.mark(type='interval', x='=profession', y='=salary', y_min=0)]),
            data=data(fields='profession salary', rows=[
                ('medicine', 23000),
                ('fire fighting', 18000),
                ('pedagogy', 24000),
                ('psychology', 22500),
                ('computer science', 36000),
            ]),
        ),
        ui.visualization(
            plot=ui.plot([ui.mark(type='interval', x='=profession', y='=salary', y_min=0)]),
            data=data(fields='profession salary', rows=[
                ('medicine', 21000),
                ('fire fighting', 17000),
                ('pedagogy', 23500),
                ('psychology', 22300),
                ('computer science', 33000),
            ])
        ),
    ],
))

page.save()

time.sleep(5)

page['example'].my_plot.data[0] = ('medicine', 1000)
page.save()

```

Closes #441