### PR TITLE
feat: Use absolute URLs in API docs #2078

### DIFF
--- a/py/docs/templates/config.mako
+++ b/py/docs/templates/config.mako
@@ -28,7 +28,7 @@
 
     # A prefix to use for every HTML hyperlink in the generated documentation.
     # No prefix results in all links being relative.
-    link_prefix = ''
+    link_prefix = 'docs/api/'
 
     # Enable syntax highlighting for code/source blocks by including Highlight.js
     syntax_highlighting = False

--- a/py/docs/templates/text.mako
+++ b/py/docs/templates/text.mako
@@ -9,10 +9,9 @@
     name = name or dobj.qualname + ('()' if isinstance(dobj, pdoc.Function) else '')
     if isinstance(dobj, pdoc.External) and not external_links:
         return name
-    url = dobj.url(relative_to=module, link_prefix=link_prefix,
-                   top_ancestor=not show_inherited_members).replace('.html','')
+    url = dobj.url(link_prefix=link_prefix, top_ancestor=not show_inherited_members).replace('.html','')
     ## Replace "." with "_" because Docusarus doesn't seem to like "." in custom heading ids.
-    return f'<a title="{dobj.refname}" href={{useBaseUrl("docs/api/{url.replace(".", "_")}")}}>{name}</a>'
+    return f'<a title="{dobj.refname}" href={{useBaseUrl("{url.replace("h2o_wave/", "").replace(".", "_")}")}}>{name}</a>'
 
 
   def to_html(text):

--- a/py/docs/templates/text.mako
+++ b/py/docs/templates/text.mako
@@ -12,7 +12,7 @@
     url = dobj.url(relative_to=module, link_prefix=link_prefix,
                    top_ancestor=not show_inherited_members).replace('.html','')
     ## Replace "." with "_" because Docusarus doesn't seem to like "." in custom heading ids.
-    return '<a title="{}" href="{}">{}</a>'.format(dobj.refname, url.replace('.', '_'), name)
+    return f'<a title="{dobj.refname}" href={{useBaseUrl("docs/api/{url.replace(".", "_")}")}}>{name}</a>'
 
 
   def to_html(text):
@@ -84,6 +84,7 @@ title: ${'Namespace' if module.is_namespace else  \
                       'Package' if module.is_package and not module.supermodule else \
                       'Module'} ${module.name}
 ---
+import useBaseUrl from '@docusaurus/useBaseUrl';
 
 ${module.docstring | to_html}
 


### PR DESCRIPTION
**The PR fulfills these requirements:** (check all the apply)

- [x] It's submitted to the `main` branch.
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `feat: Add a button #xxx`, where "xxx" is the issue number).
- [x] When resolving a specific issue, the PR description includes `Closes #xxx`, where "xxx" is the issue number.
- [x] If changes were made to `ui` folder, unit tests (`make test`) still pass.
- [ ] New/updated tests are included

___


https://github.com/h2oai/wave/assets/23740173/ac9d3bc3-fbf9-4278-a72f-a63830e1ec0f


Closes #2078
Closes #1667 
