### PR TITLE
fix: Allow dynamic value change for choice group #1154

### DIFF
--- a/ui/src/choice_group.test.tsx
+++ b/ui/src/choice_group.test.tsx
@@ -43,6 +43,13 @@ describe('ChoiceGroup.tsx', () => {
     expect(wave.args[name]).toBe('Choice3')
   })
 
+  it('Set args when value is updated', () => {
+    const { rerender } = render(<XChoiceGroup model={choiceGroupProps} />)
+    expect(wave.args[name]).toBe(null)
+    rerender(<XChoiceGroup model={{ ...choiceGroupProps, value: 'Choice3' }} />)
+    expect(wave.args[name]).toBe('Choice3')
+  })
+
   it('Does not call sync - trigger not specified', () => {
     const { getByText } = render(<XChoiceGroup model={choiceGroupProps} />)
     const pushMock = jest.fn()

--- a/ui/src/choice_group.test.tsx
+++ b/ui/src/choice_group.test.tsx
@@ -27,6 +27,24 @@ describe('ChoiceGroup.tsx', () => {
     expect(queryByTestId(name)).toBeInTheDocument()
   })
 
+  it('Set args when value is updated to different value', () => {
+    const { rerender } = render(<XChoiceGroup model={choiceGroupProps} />)
+    expect(wave.args[name]).toBe(null)
+    rerender(<XChoiceGroup model={{ ...choiceGroupProps, value: 'Choice3' }} />)
+    expect(wave.args[name]).toBe('Choice3')
+  })
+
+  it('Set args when value is updated to initial value', () => {
+    const { getByText, rerender } = render(<XChoiceGroup model={{ ...choiceGroupProps, value: 'Choice3' }} />)
+    expect(wave.args[name]).toBe('Choice3')
+
+    fireEvent.click(getByText('Choice2').parentElement!)
+    expect(wave.args[name]).toBe('Choice2')
+
+    rerender(<XChoiceGroup model={{ ...choiceGroupProps, value: 'Choice3' }} />)
+    expect(wave.args[name]).toBe('Choice3')
+  })
+
   it('Sets args - single selection', () => {
     const { getByText } = render(<XChoiceGroup model={choiceGroupProps} />)
     fireEvent.click(getByText('Choice1').parentElement!)
@@ -43,11 +61,14 @@ describe('ChoiceGroup.tsx', () => {
     expect(wave.args[name]).toBe('Choice3')
   })
 
-  it('Set args when value is updated', () => {
-    const { rerender } = render(<XChoiceGroup model={choiceGroupProps} />)
-    expect(wave.args[name]).toBe(null)
-    rerender(<XChoiceGroup model={{ ...choiceGroupProps, value: 'Choice3' }} />)
-    expect(wave.args[name]).toBe('Choice3')
+  it('Calls sync - trigger specified', () => {
+    const { getByText } = render(<XChoiceGroup model={{ ...choiceGroupProps, trigger: true }} />)
+    const pushMock = jest.fn()
+
+    wave.push = pushMock
+    fireEvent.click(getByText('Choice1').parentElement!)
+
+    expect(pushMock).toHaveBeenCalled()
   })
 
   it('Does not call sync - trigger not specified', () => {
@@ -58,15 +79,5 @@ describe('ChoiceGroup.tsx', () => {
     fireEvent.click(getByText('Choice1').parentElement!)
 
     expect(pushMock).toBeCalledTimes(0)
-  })
-
-  it('Calls sync - trigger specified', () => {
-    const { getByText } = render(<XChoiceGroup model={{ ...choiceGroupProps, trigger: true }} />)
-    const pushMock = jest.fn()
-
-    wave.push = pushMock
-    fireEvent.click(getByText('Choice1').parentElement!)
-
-    expect(pushMock).toHaveBeenCalled()
   })
 })

--- a/ui/src/choice_group.tsx
+++ b/ui/src/choice_group.tsx
@@ -82,8 +82,7 @@ export const
     React.useEffect(() => {
       wave.args[m.name] = m.value || null
       setValue(m.value)
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [m.value])
+    }, [m.name, m.value])
 
     return (
       <Fluent.ChoiceGroup

--- a/ui/src/choice_group.tsx
+++ b/ui/src/choice_group.tsx
@@ -67,15 +67,22 @@ export interface ChoiceGroup {
 export const
   XChoiceGroup = ({ model: m }: { model: ChoiceGroup }) => {
     const
+      [value, setValue] = React.useState(m.value),
       optionStyles = { choiceFieldWrapper: { marginRight: 15 } },
       options = (m.choices || []).map(({ name, label, disabled }): Fluent.IChoiceGroupOption => ({ key: name, text: label || name, disabled, styles: optionStyles })),
       onChange = (_e?: React.FormEvent<HTMLElement>, option?: Fluent.IChoiceGroupOption) => {
-        if (option) wave.args[m.name] = option.key
+        if (option) {
+          wave.args[m.name] = option.key
+          setValue(option.key)
+        }
         if (m.trigger) wave.push()
       }
 
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    React.useEffect(() => { wave.args[m.name] = m.value || null }, [])
+    React.useEffect(() => {
+      wave.args[m.name] = m.value || null
+      setValue(m.value)
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [m.value])
 
     return (
       <Fluent.ChoiceGroup
@@ -83,7 +90,7 @@ export const
         data-test={m.name}
         label={m.label}
         required={m.required}
-        defaultSelectedKey={m.value}
+        selectedKey={value}
         options={options}
         onChange={onChange}
       />

--- a/ui/src/choice_group.tsx
+++ b/ui/src/choice_group.tsx
@@ -73,6 +73,7 @@ export const
       onChange = (_e?: React.FormEvent<HTMLElement>, option?: Fluent.IChoiceGroupOption) => {
         if (option) {
           wave.args[m.name] = option.key
+          m.value = option.key
           setValue(option.key)
         }
         if (m.trigger) wave.push()


### PR DESCRIPTION
**The PR fulfills these requirements:** (check all the apply)

- [x] It's submitted to the `main` branch.
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `feat: Add a button #xxx`, where "xxx" is the issue number).
- [x] When resolving a specific issue, the PR description includes `Closes #xxx`, where "xxx" is the issue number.
- [x] If changes were made to `ui` folder, unit tests (`make test`) still pass.
- [x] New/updated tests are included

___

This PR partially resolves issue #1154.

NOTE: Do not forget to update status in [this comment](https://github.com/h2oai/wave/issues/1154#issuecomment-1252010473) once merged.
