### PR TITLE
fix: Allow dynamic value change for picker #1154

### DIFF
--- a/ui/src/picker.test.tsx
+++ b/ui/src/picker.test.tsx
@@ -50,6 +50,13 @@ describe('Picker.tsx', () => {
     expect(wave.args[name]).toMatchObject([name])
   })
 
+  it('Set args when value is updated', () => {
+    const { rerender } = render(<XPicker model={pickerProps} />)
+    expect(wave.args[name]).toBe(null)
+    rerender(<XPicker model={{ ...pickerProps, values: [name] }} />)
+    expect(wave.args[name]).toMatchObject([name])
+  })
+
   it('Renders label if specified', () => {
     const { getByText } = render(<XPicker model={{ ...pickerProps, label: name }} />)
     expect(getByText(name)).toBeInTheDocument()
@@ -90,6 +97,13 @@ describe('Picker.tsx', () => {
     expect(queryAllByRole('listitem')).toHaveLength(1)
     fireEvent.click(getByRole('listitem').querySelector('.ms-TagItem-close')!)
     expect(queryAllByRole('listitem')).toHaveLength(0)
+  })
+
+  it('Shows correct values - value updated', () => {
+    const { rerender, queryAllByRole } = render(<XPicker model={pickerProps} />)
+    expect(queryAllByRole('listitem')).toHaveLength(0)
+    rerender(<XPicker model={{ ...pickerProps, values: [name] }} />)
+    expect(queryAllByRole('listitem')).toHaveLength(1)
   })
 
   it('Does not render label if not specified', () => {

--- a/ui/src/picker.test.tsx
+++ b/ui/src/picker.test.tsx
@@ -18,6 +18,7 @@ import { Picker, XPicker } from './picker'
 import { wave } from './ui'
 
 const name = 'picker'
+const altName = 'something else'
 let pickerProps: Picker
 
 const typeToInput = (input: HTMLInputElement, value: string) => {
@@ -30,7 +31,7 @@ describe('Picker.tsx', () => {
   beforeEach(() => {
     pickerProps = {
       name,
-      choices: [{ name }, { name: 'something else' }]
+      choices: [{ name }, { name: altName }]
     }
     wave.args[name] = null
   })
@@ -50,9 +51,24 @@ describe('Picker.tsx', () => {
     expect(wave.args[name]).toMatchObject([name])
   })
 
-  it('Set args when value is updated', () => {
+  it('Set args when value is updated to different value', () => {
     const { rerender } = render(<XPicker model={pickerProps} />)
     expect(wave.args[name]).toBe(null)
+    rerender(<XPicker model={{ ...pickerProps, values: [name] }} />)
+    expect(wave.args[name]).toMatchObject([name])
+  })
+
+  it('Set args when value is updated to initial value', () => {
+    const { queryAllByRole, getByRole, rerender } = render(<XPicker model={{ ...pickerProps, values: [name] }} />)
+    expect(wave.args[name]).toMatchObject([name])
+
+    expect(queryAllByRole('listitem')).toHaveLength(1)
+    const input = (getByRole('combobox') as HTMLInputElement)
+
+    typeToInput(input, altName)
+    fireEvent.click(getByRole('option'))
+    expect(queryAllByRole('listitem')).toHaveLength(2)
+
     rerender(<XPicker model={{ ...pickerProps, values: [name] }} />)
     expect(wave.args[name]).toMatchObject([name])
   })

--- a/ui/src/picker.tsx
+++ b/ui/src/picker.tsx
@@ -69,8 +69,11 @@ export const XPicker = ({ model: m }: { model: Picker }) => {
     },
     onEmptyResolveSuggestions = () => tags
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  React.useEffect(() => { wave.args[m.name] = m.values || null }, [])
+  React.useEffect(() => {
+    wave.args[m.name] = m.values || null
+    setSelectedTags(tags.filter(({ key }) => m.values?.includes(key as S)))
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [m.values])
 
   return (
     <>

--- a/ui/src/picker.tsx
+++ b/ui/src/picker.tsx
@@ -72,8 +72,7 @@ export const XPicker = ({ model: m }: { model: Picker }) => {
   React.useEffect(() => {
     wave.args[m.name] = m.values || null
     setSelectedTags(tags.filter(({ key }) => m.values?.includes(key as S)))
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [m.values])
+  }, [m.name, m.values, tags])
 
   return (
     <>


### PR DESCRIPTION
**The PR fulfills these requirements:** (check all the apply)

- [x] It's submitted to the `main` branch.
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `feat: Add a button #xxx`, where "xxx" is the issue number).
- [x] When resolving a specific issue, the PR description includes `Closes #xxx`, where "xxx" is the issue number.
- [x] If changes were made to `ui` folder, unit tests (`make test`) still pass.
- [x] New/updated tests are included

___

This PR partially resolves issue #1154.

NOTE: Do not forget to update status in [this comment](https://github.com/h2oai/wave/issues/1154#issuecomment-1252010473) once merged.
