### PR TITLE
fix: Dynamic choices change for single/multi-valued dialog dropdown #1154

### DIFF
--- a/ui/src/dropdown.test.tsx
+++ b/ui/src/dropdown.test.tsx
@@ -708,6 +708,27 @@ describe('Dropdown.tsx', () => {
           rerender(<XDropdown model={{ ...dialogProps, value: '1' }} />)
           expect(wave.args[name]).toEqual('1')
         })
+
+        it('Updates choices of single-valued dialog dropdown', () => {
+          const
+            choices = [{ name: 'A', label: 'Choice A' }],
+            updatedChoices = [
+              { name: 'D', label: 'Choice D' },
+              { name: 'E', label: 'Choice E' },
+              { name: 'F', label: 'Choice F' },
+            ],
+            { getByTestId, getByText, rerender } = render(<XDropdown model={{ ...dialogProps, choices }} />)
+
+          fireEvent.click(getByTestId(name))
+          expect(getByText('Choice A')).toBeInTheDocument()
+
+          rerender(<XDropdown model={{ ...dialogProps, choices: updatedChoices }} />)
+          fireEvent.click(getByTestId(name))
+
+          expect(getByText('Choice D')).toBeInTheDocument()
+          expect(getByText('Choice E')).toBeInTheDocument()
+          expect(getByText('Choice F')).toBeInTheDocument()
+        })
       })
 
       describe('Multi-valued', () => {
@@ -803,6 +824,27 @@ describe('Dropdown.tsx', () => {
           expect(checkboxes).toHaveLength(2)
           expect(checkboxes[0]).toBeChecked()
           expect(checkboxes[1]).toBeChecked()
+        })
+
+        it('Updates choices of multi-valued dialog dropdown', () => {
+          const
+            choices = [{ name: 'A', label: 'Choice A' }],
+            updatedChoices = [
+              { name: 'D', label: 'Choice D' },
+              { name: 'E', label: 'Choice E' },
+              { name: 'F', label: 'Choice F' },
+            ],
+            { getByTestId, getByText, rerender } = render(<XDropdown model={{ ...dialogProps, choices, values: ['A'] }} />)
+
+          fireEvent.click(getByTestId(name))
+          expect(getByText('Choice A')).toBeInTheDocument()
+
+          rerender(<XDropdown model={{ ...dialogProps, choices: updatedChoices, values: ['D'] }} />)
+          fireEvent.click(getByTestId(name))
+
+          expect(getByText('Choice D')).toBeInTheDocument()
+          expect(getByText('Choice E')).toBeInTheDocument()
+          expect(getByText('Choice F')).toBeInTheDocument()
         })
       })
     })

--- a/ui/src/dropdown.test.tsx
+++ b/ui/src/dropdown.test.tsx
@@ -717,7 +717,7 @@ describe('Dropdown.tsx', () => {
               { name: 'E', label: 'Choice E' },
               { name: 'F', label: 'Choice F' },
             ],
-            { getByTestId, getByText, rerender } = render(<XDropdown model={{ ...dialogProps, choices }} />)
+            { getByTestId, getByText, queryByText, rerender } = render(<XDropdown model={{ ...dialogProps, choices }} />)
 
           fireEvent.click(getByTestId(name))
           expect(getByText('Choice A')).toBeInTheDocument()
@@ -725,6 +725,7 @@ describe('Dropdown.tsx', () => {
           rerender(<XDropdown model={{ ...dialogProps, choices: updatedChoices }} />)
           fireEvent.click(getByTestId(name))
 
+          expect(queryByText('Choice A')).not.toBeInTheDocument()
           expect(getByText('Choice D')).toBeInTheDocument()
           expect(getByText('Choice E')).toBeInTheDocument()
           expect(getByText('Choice F')).toBeInTheDocument()
@@ -834,7 +835,7 @@ describe('Dropdown.tsx', () => {
               { name: 'E', label: 'Choice E' },
               { name: 'F', label: 'Choice F' },
             ],
-            { getByTestId, getByText, rerender } = render(<XDropdown model={{ ...dialogProps, choices, values: ['A'] }} />)
+            { getByTestId, getByText, queryByText, rerender } = render(<XDropdown model={{ ...dialogProps, choices, values: ['A'] }} />)
 
           fireEvent.click(getByTestId(name))
           expect(getByText('Choice A')).toBeInTheDocument()
@@ -842,6 +843,7 @@ describe('Dropdown.tsx', () => {
           rerender(<XDropdown model={{ ...dialogProps, choices: updatedChoices, values: ['D'] }} />)
           fireEvent.click(getByTestId(name))
 
+          expect(queryByText('Choice A')).not.toBeInTheDocument()
           expect(getByText('Choice D')).toBeInTheDocument()
           expect(getByText('Choice E')).toBeInTheDocument()
           expect(getByText('Choice F')).toBeInTheDocument()

--- a/ui/src/dropdown.tsx
+++ b/ui/src/dropdown.tsx
@@ -206,14 +206,9 @@ const
       }
 
     React.useEffect(() => {
-      if (model.value !== undefined) {
-        wave.args[name] = model.value ?? null
-        setItems(items => items.map(i => ({ ...i, checked: model.value === i.name })))
-      }
-    }, [name, model.value, setItems])
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    React.useEffect(() => setItems(choicesToItems(choices, model.value)), [choices])
+      wave.args[name] = model.value ?? null
+      setItems(choicesToItems(choices, model.value))
+    }, [name, model.value, choices, setItems])
 
     return (
       <>
@@ -277,14 +272,9 @@ const
       }
 
     React.useEffect(() => {
-      if (values) {
-        wave.args[name] = values
-        setItems(items => items.map(i => ({ ...i, checked: values.includes(i.name) })))
-      }
-    }, [name, values, setItems])
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    React.useEffect(() => setItems(choicesToItems(choices, values)), [choices])
+      wave.args[name] = values
+      setItems(choicesToItems(choices, values))
+    }, [name, values, choices, setItems])
 
     return (
       <>

--- a/ui/src/dropdown.tsx
+++ b/ui/src/dropdown.tsx
@@ -168,11 +168,11 @@ const
   ROW_HEIGHT = 44,
   PAGE_SIZE = 40,
   getPageSpecification = () => ({ itemCount: PAGE_SIZE, height: ROW_HEIGHT * PAGE_SIZE } as Fluent.IPageSpecification),
+  choicesToItems = (choices: Choice[], v?: S | S[]) => choices.map(({ name, label, disabled = false }, idx) =>
+    ({ name, text: label || name, idx, checked: Array.isArray(v) ? v.includes(name) : v === name, show: true, disabled })),
   useItems = (choices: Choice[], v?: S | S[]) => {
-    const
-      [items, setItems] = React.useState<DropdownItem[]>(choices.map(({ name, label, disabled = false }, idx) =>
-        ({ name, text: label || name, idx, checked: Array.isArray(v) ? v.includes(name) : v === name, show: true, disabled }))),
-      onSearchChange = (_e?: React.ChangeEvent<HTMLInputElement>, newVal = '') => setItems(items => items.map(i => ({ ...i, show: fuzzysearch(i.text, newVal) })))
+    const [items, setItems] = React.useState<DropdownItem[]>(choicesToItems(choices, v))
+    const onSearchChange = (_e?: React.ChangeEvent<HTMLInputElement>, newVal = '') => setItems(items => items.map(i => ({ ...i, show: fuzzysearch(i.text, newVal) })))
 
     return [items, setItems, onSearchChange] as const
   },
@@ -211,6 +211,9 @@ const
         setItems(items => items.map(i => ({ ...i, checked: model.value === i.name })))
       }
     }, [name, model.value, setItems])
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    React.useEffect(() => setItems(choicesToItems(choices, model.value)), [choices])
 
     return (
       <>
@@ -279,6 +282,9 @@ const
         setItems(items => items.map(i => ({ ...i, checked: values.includes(i.name) })))
       }
     }, [name, values, setItems])
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    React.useEffect(() => setItems(choicesToItems(choices, values)), [choices])
 
     return (
       <>


### PR DESCRIPTION
**The PR fulfills these requirements:** (check all the apply)

- [x] It's submitted to the `main` branch.
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `feat: Add a button #xxx`, where "xxx" is the issue number).
- [ ] When resolving a specific issue, the PR description includes `Closes #xxx`, where "xxx" is the issue number.
- [x] If changes were made to `ui` folder, unit tests (`make test`) still pass.
- [x] New/updated tests are included

___

Currently the value/values prop can be updated dynamically through Wave app for base dropdown and for both single and multi-valued dialog dropdown. However the dynamic update of choices can be done only for the base dropdown. This PR unifies the behavior and brings support for dynamic update of choices also for multi-valued and single-valued dialog dropdown.

NOTE: Do not forget to update status in [this comment](https://github.com/h2oai/wave/issues/1154#issuecomment-1252010473) once merged.
