### PR TITLE
fix: Make dynamic value change consistent

### DIFF
--- a/ui/src/checklist.test.tsx
+++ b/ui/src/checklist.test.tsx
@@ -70,13 +70,13 @@ describe('Checklist.tsx', () => {
     const { getByText, rerender } = render(<XChecklist model={{ ...checklistProps, values: ['Choice1'] }} />)
     expect(wave.args[name]).toMatchObject(['Choice1'])
 
-    rerender(<XChecklist model={{ ...checklistProps, choices: [...choices] }} />)
+    rerender(<XChecklist model={{ ...checklistProps }} />)
     expect(wave.args[name]).toMatchObject([])
 
     fireEvent.click(getByText('Choice2').parentElement!)
     expect(wave.args[name]).toMatchObject(['Choice2'])
 
-    rerender(<XChecklist model={{ ...checklistProps, choices: [...choices] }} />)
+    rerender(<XChecklist model={{ ...checklistProps }} />)
     expect(wave.args[name]).toMatchObject([])
   })
 

--- a/ui/src/checklist.test.tsx
+++ b/ui/src/checklist.test.tsx
@@ -65,6 +65,20 @@ describe('Checklist.tsx', () => {
     expect(wave.args[name]).toMatchObject(['Choice1'])
   })
 
+  it('Set correct args when value is cleared twice', () => {
+    const { getByText, rerender } = render(<XChecklist model={{ ...checklistProps, values: ['Choice1'] }} />)
+    expect(wave.args[name]).toMatchObject(['Choice1'])
+
+    rerender(<XChecklist model={{ ...checklistProps }} />)
+    expect(wave.args[name]).toMatchObject([])
+
+    fireEvent.click(getByText('Choice2').parentElement!)
+    expect(wave.args[name]).toMatchObject(['Choice2'])
+
+    rerender(<XChecklist model={{ ...checklistProps }} />)
+    expect(wave.args[name]).toMatchObject([])
+  })
+
   it('Updates choices', () => {
     const { rerender, getByText } = render(<XChecklist model={checklistProps} />)
     expect(getByText('Choice1')).toBeInTheDocument()

--- a/ui/src/checklist.test.tsx
+++ b/ui/src/checklist.test.tsx
@@ -18,7 +18,8 @@ import { Checklist, XChecklist } from './checklist'
 import { wave } from './ui'
 
 const name = 'checklist'
-const checklistProps: Checklist = { name, choices: [{ name: 'Choice1' }, { name: 'Choice2' }, { name: 'Choice3' },] }
+const choices = [{ name: 'Choice1' }, { name: 'Choice2' }, { name: 'Choice3' },]
+const checklistProps: Checklist = { name, choices }
 describe('Checklist.tsx', () => {
   beforeEach(() => {
     jest.clearAllMocks()
@@ -69,13 +70,13 @@ describe('Checklist.tsx', () => {
     const { getByText, rerender } = render(<XChecklist model={{ ...checklistProps, values: ['Choice1'] }} />)
     expect(wave.args[name]).toMatchObject(['Choice1'])
 
-    rerender(<XChecklist model={{ ...checklistProps }} />)
+    rerender(<XChecklist model={{ ...checklistProps, choices: [...choices] }} />)
     expect(wave.args[name]).toMatchObject([])
 
     fireEvent.click(getByText('Choice2').parentElement!)
     expect(wave.args[name]).toMatchObject(['Choice2'])
 
-    rerender(<XChecklist model={{ ...checklistProps }} />)
+    rerender(<XChecklist model={{ ...checklistProps, choices: [...choices] }} />)
     expect(wave.args[name]).toMatchObject([])
   })
 

--- a/ui/src/checklist.test.tsx
+++ b/ui/src/checklist.test.tsx
@@ -23,6 +23,7 @@ describe('Checklist.tsx', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     wave.args[name] = null
+    checklistProps.values = undefined
   })
 
   it('Renders data-test attr', () => {

--- a/ui/src/checklist.tsx
+++ b/ui/src/checklist.tsx
@@ -83,6 +83,7 @@ export const
         const _choices = choices.map(({ c, selected }) => ({ c, selected: c.disabled ? selected : value }))
         setChoices(_choices)
         capture(_choices)
+        m.values = value ? _choices.map(({ c }) => { return c.name }) : []
       },
       selectAll = () => select(true),
       deselectAll = () => select(false),
@@ -90,6 +91,7 @@ export const
         const _choices = [...choices]
         _choices[idx].selected = checked
         setChoices(_choices)
+        m.values = _choices.filter(({ selected }) => selected).map(({ c }) => c.name)
         capture(_choices)
       },
       items = choices.map(({ c, selected }, i) => (

--- a/ui/src/checklist.tsx
+++ b/ui/src/checklist.tsx
@@ -83,7 +83,6 @@ export const
         const _choices = choices.map(({ c, selected }) => ({ c, selected: c.disabled ? selected : value }))
         setChoices(_choices)
         capture(_choices)
-        m.values = value ? _choices.map(({ c }) => { return c.name }) : []
       },
       selectAll = () => select(true),
       deselectAll = () => select(false),
@@ -91,7 +90,6 @@ export const
         const _choices = [...choices]
         _choices[idx].selected = checked
         setChoices(_choices)
-        m.values = _choices.filter(({ selected }) => selected).map(({ c }) => c.name)
         capture(_choices)
       },
       items = choices.map(({ c, selected }, i) => (
@@ -106,8 +104,13 @@ export const
           styles={{ root: { marginBottom: 4 }, checkmark: { display: 'flex' } }} // Fix: Center the checkmark in the checkbox.
         />
       ))
-    React.useEffect(() => { wave.args[m.name] = m.values || [] }, [m.name, m.values])
-    React.useEffect(() => { setChoices(getMappedChoices()) }, [getMappedChoices, m.choices])
+
+    React.useEffect(() => {
+      const newChoices = getMappedChoices()
+      setChoices(newChoices)
+      wave.args[m.name] = newChoices.filter(({ selected }) => selected).map(({ c }) => c.name)
+    }, [getMappedChoices, m.choices, m.name, m.values])
+
     return (
       <div data-test={m.name}>
         <Fluent.Label>{m.label}</Fluent.Label>

--- a/ui/src/checklist.tsx
+++ b/ui/src/checklist.tsx
@@ -83,13 +83,17 @@ export const
         const _choices = choices.map(({ c, selected }) => ({ c, selected: c.disabled ? selected : value }))
         setChoices(_choices)
         capture(_choices)
+        m.values = value ? _choices.map(({ c }) => c.name) : []
       },
       selectAll = () => select(true),
       deselectAll = () => select(false),
       onChange = (idx: U) => (_e?: React.FormEvent<HTMLElement>, checked = false) => {
         const _choices = [...choices]
-        _choices[idx].selected = checked
+        const choice = _choices[idx]
+        choice.selected = checked
         setChoices(_choices)
+        checked ? defaultSelection.add(choice.c.name) : defaultSelection.delete(choice.c.name)
+        m.values = [...defaultSelection]
         capture(_choices)
       },
       items = choices.map(({ c, selected }, i) => (

--- a/ui/src/combobox.test.tsx
+++ b/ui/src/combobox.test.tsx
@@ -22,7 +22,7 @@ const
   name = 'combobox',
   comboboxProps: Combobox = { name, choices: ['A', 'B', 'C'] },
   pushMock = jest.fn()
-  wave.push = pushMock
+wave.push = pushMock
 
 describe('Combobox.tsx', () => {
   it('Renders data-test attr', () => {
@@ -34,7 +34,7 @@ describe('Combobox.tsx', () => {
     it('Displays new typed option', () => {
       const { getByRole } = render(<XCombobox model={{ ...comboboxProps, value: 'A' }} />)
       expect(wave.args[name]).toEqual('A')
-      
+
       userEvent.type(getByRole('combobox'), '{backspace}D{enter}')
       expect(wave.args[name]).toEqual('D')
     })
@@ -65,7 +65,7 @@ describe('Combobox.tsx', () => {
         render(<XCombobox model={{ ...comboboxProps, value: 'D' }} />)
         expect(wave.args[name]).toBe('D')
       })
-  
+
       it('Sets args to manually selected option', () => {
         const { getByRole, getByTitle } = render(<XCombobox model={{ ...comboboxProps }} />)
         fireEvent.click(getByRole('presentation', { hidden: true }))
@@ -79,10 +79,10 @@ describe('Combobox.tsx', () => {
 
       it('Calls sync when trigger is on', () => {
         const { getByRole, getByText } = render(<XCombobox model={{ ...comboboxProps, trigger: true }} />)
-    
+
         fireEvent.click(getByRole('presentation', { hidden: true }))
         fireEvent.click(getByText('A'))
-    
+
         expect(pushMock).toHaveBeenCalled()
       })
 
@@ -95,7 +95,7 @@ describe('Combobox.tsx', () => {
 
       it('Sets wave args as string when a new valued is typed and user clicks away - after init', () => {
         const { getByRole } = render(<XCombobox model={{ ...comboboxProps, value: 'A' }} />)
-    
+
         expect(wave.args[name]).toBe('A')
 
         userEvent.type(getByRole('combobox'), '{backspace}D')
@@ -109,7 +109,7 @@ describe('Combobox.tsx', () => {
 
       it('Sets wave args as string when a new valued is typed and tab is pressed - after init', () => {
         const { getByRole } = render(<XCombobox model={{ ...comboboxProps, value: 'A' }} />)
-    
+
         expect(wave.args[name]).toBe('A')
 
         userEvent.type(getByRole('combobox'), '{backspace}D')
@@ -125,7 +125,7 @@ describe('Combobox.tsx', () => {
         const { getByRole, getAllByRole, rerender } = render(<XCombobox model={{ ...comboboxProps, value: 'A' }} />)
         fireEvent.click(getByRole('presentation', { hidden: true }))
         expect(getAllByRole('option')).toHaveLength(3)
-  
+
         rerender(<XCombobox model={{ ...comboboxProps, choices: ['A', 'B'] }} />)
         expect(getAllByRole('option')).toHaveLength(2)
       })
@@ -134,47 +134,65 @@ describe('Combobox.tsx', () => {
         const { getByRole, getByText, rerender } = render(<XCombobox model={{ ...comboboxProps, value: 'A' }} />)
         expect(getByRole('combobox')).toHaveValue('A')
         expect(wave.args[name]).toEqual('A')
-  
+
         rerender(<XCombobox model={{ ...comboboxProps, value: 'B' }} />)
         expect(getByRole('combobox')).toHaveValue('B')
         expect(wave.args[name]).toEqual('B')
-        
+
         fireEvent.click(getByRole('presentation', { hidden: true }))
         fireEvent.click(getByText('C'))
         expect(getByRole('combobox')).toHaveValue('C')
         expect(wave.args[name]).toEqual('C')
-  
+
         rerender(<XCombobox model={{ ...comboboxProps, value: 'B' }} />)
         expect(getByRole('combobox')).toHaveValue('B')
         expect(wave.args[name]).toEqual('B')
       })
-  
+
       it('Updates "choices" prop and "value" prop to value different than the initial one', () => {
         const { getByRole, rerender } = render(<XCombobox model={{ ...comboboxProps, value: 'A' }} />)
         expect(wave.args[name]).toEqual('A')
         expect(getByRole('combobox')).toHaveValue('A')
-  
+
         rerender(<XCombobox model={{ ...comboboxProps, choices: ['A', 'B'], value: 'B' }} />)
         expect(getByRole('combobox')).toHaveValue('B')
       })
-  
+
+      it('Clears all "choices"', () => {
+        const { getByRole, queryByText, rerender } = render(<XCombobox model={comboboxProps} />)
+        expect(getByRole('combobox')).not.toHaveValue()
+
+        fireEvent.click(getByRole('presentation', { hidden: true }))
+        expect(queryByText('A')).toBeInTheDocument()
+        expect(queryByText('B')).toBeInTheDocument()
+        expect(queryByText('C')).toBeInTheDocument()
+
+        rerender(<XCombobox model={{ ...comboboxProps, choices: undefined }} />)
+        expect(getByRole('combobox')).not.toHaveValue()
+
+        fireEvent.click(getByRole('presentation', { hidden: true }))
+        expect(queryByText('A')).not.toBeInTheDocument()
+        expect(queryByText('B')).not.toBeInTheDocument()
+        expect(queryByText('C')).not.toBeInTheDocument()
+      })
+
       it('Types new option and then updates combobox value when "value" prop changes', () => {
         const { getByRole, getByText, rerender } = render(<XCombobox model={{ ...comboboxProps, value: 'A' }} />)
         expect(getByRole('combobox')).toHaveValue('A')
         expect(wave.args[name]).toEqual('A')
-  
+
         fireEvent.click(getByRole('presentation', { hidden: true }))
         fireEvent.click(getByText('B'))
         fireEvent.blur(getByRole('presentation', { hidden: true }))
         userEvent.type(getByRole('combobox'), 'B{Enter}')
         expect(getByRole('combobox')).toHaveValue('BB')
         expect(wave.args[name]).toEqual('BB')
-  
+
         rerender(<XCombobox model={{ ...comboboxProps, value: 'C' }} />)
         expect(getByRole('combobox')).toHaveValue('C')
         expect(wave.args[name]).toEqual('C')
       })
-  
+
       it('Adds initial value to options if it\'s not included in "choices" prop', () => {
         const { getByTitle, getAllByRole, getByRole } = render(<XCombobox model={{ ...comboboxProps, value: 'Z' }} />)
         expect(wave.args[name]).toEqual('Z')
@@ -187,7 +205,7 @@ describe('Combobox.tsx', () => {
       it('Adds value to choices when both are updated and value was included in previous choices but not in the new choices', () => {
         const { getByRole, getAllByRole, getByTitle, rerender } = render(<XCombobox model={{ ...comboboxProps, value: 'A' }} />)
         expect(getByRole('combobox')).toHaveValue('A')
-        
+
         rerender(<XCombobox model={{ ...comboboxProps, value: 'C', choices: ['A', 'B'] }} />)
         expect(getByRole('combobox')).toHaveValue('C')
         fireEvent.click(getByRole('presentation', { hidden: true }))
@@ -196,7 +214,7 @@ describe('Combobox.tsx', () => {
       })
 
       it('Display same value if choices change and value is included in choices', () => {
-        const { getByRole, rerender,  } = render(<XCombobox model={{ ...comboboxProps, value: 'A' }} />, { })
+        const { getByRole, rerender, } = render(<XCombobox model={{ ...comboboxProps, value: 'A' }} />, {})
         expect(getByRole('combobox')).toHaveValue('A')
         rerender(<XCombobox model={{ ...comboboxProps, choices: ['A', 'B'], value: 'A' }} />)
         expect(getByRole('combobox')).toHaveValue('A')
@@ -217,7 +235,7 @@ describe('Combobox.tsx', () => {
     it('Displays new typed option', () => {
       const { getByRole } = render(<XCombobox model={{ ...comboboxProps, values: ['A'] }} />)
       expect(wave.args[name]).toEqual(['A'])
-      
+
       userEvent.type(getByRole('combobox'), 'D{enter}')
       expect(wave.args[name]).toEqual(['A', 'D'])
     })
@@ -225,19 +243,19 @@ describe('Combobox.tsx', () => {
     it('Unselects every option and types a new one', () => {
       const { getByText, getByRole } = render(<XCombobox model={{ ...comboboxProps, values: ['A', 'B'] }} />)
       expect(wave.args[name]).toEqual(['A', 'B'])
-  
+
       fireEvent.click(getByRole('presentation', { hidden: true }))
       fireEvent.click(getByText('A'))
       fireEvent.click(getByText('B'))
       expect(wave.args[name]).toEqual([])
-  
+
       userEvent.type(getByRole('combobox'), 'D{Enter}')
       expect(wave.args[name]).toEqual(['D'])
     })
 
     describe('Wave args', () => {
       it('Sets args to null when "values" is empty', () => {
-        render(<XCombobox model={{...comboboxProps, values: []}} />)
+        render(<XCombobox model={{ ...comboboxProps, values: [] }} />)
         expect(wave.args[name]).toBeNull()
       })
 
@@ -251,17 +269,17 @@ describe('Combobox.tsx', () => {
         fireEvent.click(getByRole('presentation', { hidden: true }))
         fireEvent.click(getByText('A'))
         fireEvent.click(getByText('B'))
-    
+
         expect(wave.args[name]).toEqual(['A', 'B'])
       })
 
       it('Calls sync when trigger is on', () => {
         const { getByRole, getByText } = render(<XCombobox model={{ ...comboboxProps, values: [], trigger: true }} />)
-    
+
         fireEvent.click(getByRole('presentation', { hidden: true }))
         fireEvent.click(getByText('A'))
         fireEvent.click(getByText('B'))
-    
+
         expect(pushMock).toHaveBeenCalled()
       })
     })
@@ -270,24 +288,24 @@ describe('Combobox.tsx', () => {
       it('Types new option and then updates combobox value when "values" prop changes', () => {
         const { getByRole, getByText, rerender } = render(<XCombobox model={{ ...comboboxProps, values: ['A', 'B'] }} />)
         expect(getByRole('combobox')).toHaveValue('A, B')
-  
+
         rerender(<XCombobox model={{ ...comboboxProps, values: ['C'] }} />)
         expect(getByRole('combobox')).toHaveValue('C')
-  
+
         fireEvent.click(getByRole('presentation', { hidden: true }))
         fireEvent.click(getByText('B'))
         fireEvent.blur(getByRole('presentation', { hidden: true }))
         expect(getByRole('combobox')).toHaveValue('B, C')
-  
+
         rerender(<XCombobox model={{ ...comboboxProps, values: ['A', 'B'] }} />)
         expect(getByRole('combobox')).toHaveValue('A, B')
       })
-  
+
       it('Displays new options in options list when "choices" prop is updated', () => {
         const { getByRole, getAllByRole, rerender } = render(<XCombobox model={{ ...comboboxProps, values: ['A'] }} />)
         fireEvent.click(getByRole('presentation', { hidden: true }))
         expect(getAllByRole('option')).toHaveLength(3)
-  
+
         rerender(<XCombobox model={{ ...comboboxProps, choices: ['A', 'B'] }} />)
         fireEvent.click(getByRole('presentation', { hidden: true }))
         expect(getAllByRole('option')).toHaveLength(2)

--- a/ui/src/combobox.tsx
+++ b/ui/src/combobox.tsx
@@ -160,11 +160,11 @@ const ComboboxMultiSelect = ({ model: m }: { model: Omit<Combobox, 'value'> }) =
   )
 }
 
-const useOptions = (choices: S[] = []): [Fluent.IComboBoxOption[], React.Dispatch<React.SetStateAction<Fluent.IComboBoxOption[]>>] => {
+const useOptions = (choices?: S[]): [Fluent.IComboBoxOption[], React.Dispatch<React.SetStateAction<Fluent.IComboBoxOption[]>>] => {
   const mappedChoices = React.useMemo(() => (choices || []).map((text): Fluent.IComboBoxOption => ({ key: text, text })), [choices])
   const [options, setOptions] = React.useState(mappedChoices)
 
-  React.useEffect(() => { setOptions(mappedChoices) }, [choices, mappedChoices])
+  React.useEffect(() => setOptions(mappedChoices), [choices, mappedChoices])
 
   return [options, setOptions]
 }

--- a/ui/src/dropdown.test.tsx
+++ b/ui/src/dropdown.test.tsx
@@ -730,6 +730,21 @@ describe('Dropdown.tsx', () => {
           expect(getByText('Choice E')).toBeInTheDocument()
           expect(getByText('Choice F')).toBeInTheDocument()
         })
+
+
+        it('Removes all choices of single-valued dialog dropdown', () => {
+          const
+            choices = [{ name: 'A', label: 'Choice A' }],
+            { getByTestId, getByText, queryByText, rerender } = render(<XDropdown model={{ ...dialogProps, choices }} />)
+
+          fireEvent.click(getByTestId(name))
+          expect(getByText('Choice A')).toBeInTheDocument()
+
+          rerender(<XDropdown model={{ ...dialogProps, choices: undefined }} />)
+          fireEvent.click(getByTestId(name))
+
+          expect(queryByText('Choice A')).not.toBeInTheDocument()
+        })
       })
 
       describe('Multi-valued', () => {
@@ -847,6 +862,20 @@ describe('Dropdown.tsx', () => {
           expect(getByText('Choice D')).toBeInTheDocument()
           expect(getByText('Choice E')).toBeInTheDocument()
           expect(getByText('Choice F')).toBeInTheDocument()
+        })
+
+        it('Removes all choices of multi-valued dialog dropdown', () => {
+          const
+            choices = [{ name: 'A', label: 'Choice A' }],
+            { getByTestId, getByText, queryByText, rerender } = render(<XDropdown model={{ ...dialogProps, choices, values: ['A'] }} />)
+
+          fireEvent.click(getByTestId(name))
+          expect(getByText('Choice A')).toBeInTheDocument()
+
+          rerender(<XDropdown model={{ ...dialogProps, choices: undefined, values: ['A'] }} />)
+          fireEvent.click(getByTestId(name))
+
+          expect(queryByText('Choice A')).not.toBeInTheDocument()
         })
       })
     })

--- a/ui/src/dropdown.tsx
+++ b/ui/src/dropdown.tsx
@@ -168,9 +168,9 @@ const
   ROW_HEIGHT = 44,
   PAGE_SIZE = 40,
   getPageSpecification = () => ({ itemCount: PAGE_SIZE, height: ROW_HEIGHT * PAGE_SIZE } as Fluent.IPageSpecification),
-  choicesToItems = (choices: Choice[], v?: S | S[]) => choices.map(({ name, label, disabled = false }, idx) =>
+  choicesToItems = (choices: Choice[] = [], v?: S | S[]) => choices.map(({ name, label, disabled = false }, idx) =>
     ({ name, text: label || name, idx, checked: Array.isArray(v) ? v.includes(name) : v === name, show: true, disabled })),
-  useItems = (choices: Choice[], v?: S | S[]) => {
+  useItems = (choices?: Choice[], v?: S | S[]) => {
     const [items, setItems] = React.useState<DropdownItem[]>(choicesToItems(choices, v))
     const onSearchChange = (_e?: React.ChangeEvent<HTMLInputElement>, newVal = '') => setItems(items => items.map(i => ({ ...i, show: fuzzysearch(i.text, newVal) })))
 
@@ -192,7 +192,7 @@ const
 
   DialogDropdownSingle = ({ model }: { model: Dropdown }) => {
     const
-      { name, choices = [], disabled, required, trigger, placeholder, label } = model,
+      { name, choices, disabled, required, trigger, placeholder, label } = model,
       [isDialogHidden, setIsDialogHidden] = React.useState(true),
       [items, setItems, onSearchChange] = useItems(choices, model.value),
       toggleDialog = () => setIsDialogHidden(v => !v),
@@ -242,7 +242,7 @@ const
   },
   DialogDropdownMulti = ({ model }: { model: Dropdown }) => {
     const
-      { name, choices = [], values = [], disabled, required, trigger, placeholder, label } = model,
+      { name, choices, values, disabled, required, trigger, placeholder, label } = model,
       [isDialogHidden, setIsDialogHidden] = React.useState(true),
       [items, setItems, onSearchChange] = useItems(choices, values),
       itemsOnDialogOpen = React.useRef(items),
@@ -272,7 +272,7 @@ const
       }
 
     React.useEffect(() => {
-      wave.args[name] = values
+      wave.args[name] = values || []
       setItems(choicesToItems(choices, values))
     }, [name, values, choices, setItems])
 

--- a/ui/src/header.tsx
+++ b/ui/src/header.tsx
@@ -107,6 +107,7 @@ const
   Navigation = bond(({ items, isOpenB }: { items: NavGroup[], isOpenB: Box<B> }) => {
     const
       hideNav = () => isOpenB(false),
+      valueB = box<S | undefined>(),
       render = () => (
         <Fluent.Panel
           isLightDismiss
@@ -115,10 +116,10 @@ const
           onDismiss={hideNav}
           hasCloseButton={false}
         >
-          <XNav items={items} hideNav={hideNav} />
+          <XNav items={items} hideNav={hideNav} valueB={valueB} />
         </Fluent.Panel>
       )
-    return { render, isOpenB }
+    return { render, isOpenB, valueB }
   })
 
 

--- a/ui/src/nav.test.tsx
+++ b/ui/src/nav.test.tsx
@@ -62,9 +62,8 @@ describe('Nav.tsx', () => {
   })
 
   it('No item is selected by default', () => {
-    const { getByTitle } = render(<View {...navProps} />)
-    expect(getByTitle('Nav 1').parentElement).not.toHaveClass('is-selected')
-    expect(getByTitle('Nav 2').parentElement).not.toHaveClass('is-selected')
+    const { container } = render(<View {...navProps} />)
+    expect(container.querySelector('.is-selected')).not.toBeInTheDocument()
   })
 
   it('Makes link active when value specified', () => {
@@ -160,9 +159,8 @@ describe('Nav.tsx', () => {
 
     it('Selects nav item on value update', () => {
       const props: T.Model<State> = { ...navProps, state: { items } }
-      const { rerender, getByTitle } = render(<View {...props} />)
-      expect(getByTitle('Nav 1').parentElement).not.toHaveClass('is-selected')
-      expect(getByTitle('Nav 2').parentElement).not.toHaveClass('is-selected')
+      const { container, rerender, getByTitle } = render(<View {...props} />)
+      expect(container.querySelector('.is-selected')).not.toBeInTheDocument()
 
       props.state.value = 'nav2'
       rerender(<View {...props} />)
@@ -174,10 +172,6 @@ describe('Nav.tsx', () => {
     it('Selects nav item when value is updated to the same value twice', () => {
       const
         props: T.Model<State> = { ...navProps, state: { items } },
-        expectNoneSelected = () => {
-          expect(getByTitle('Nav 1').parentElement).not.toHaveClass('is-selected')
-          expect(getByTitle('Nav 2').parentElement).not.toHaveClass('is-selected')
-        },
         expectFirstSelected = () => {
           expect(getByTitle('Nav 1').parentElement).toHaveClass('is-selected')
           expect(getByTitle('Nav 2').parentElement).not.toHaveClass('is-selected')
@@ -186,9 +180,10 @@ describe('Nav.tsx', () => {
           expect(getByTitle('Nav 1').parentElement).not.toHaveClass('is-selected')
           expect(getByTitle('Nav 2').parentElement).toHaveClass('is-selected')
         },
-        { rerender, getByTitle } = render(<View {...props} />)
+        { container, rerender, getByTitle } = render(<View {...props} />)
 
-      expectNoneSelected()
+
+      expect(container.querySelector('.is-selected')).not.toBeInTheDocument()
 
       props.state.value = 'nav2'
       rerender(<View {...props} />)
@@ -207,7 +202,7 @@ describe('Nav.tsx', () => {
 
     it('Unselect all nav items', () => {
       const props: T.Model<State> = { ...navProps, state: { items, value: 'nav1' } }
-      const { rerender, getByTitle } = render(<View {...props} />)
+      const { container, rerender, getByTitle } = render(<View {...props} />)
 
       expect(getByTitle('Nav 1').parentElement).toHaveClass('is-selected')
       expect(getByTitle('Nav 2').parentElement).not.toHaveClass('is-selected')
@@ -215,8 +210,7 @@ describe('Nav.tsx', () => {
       props.state.value = undefined
       rerender(<View {...props} />)
 
-      expect(getByTitle('Nav 1').parentElement).not.toHaveClass('is-selected')
-      expect(getByTitle('Nav 2').parentElement).not.toHaveClass('is-selected')
+      expect(container.querySelector('.is-selected')).not.toBeInTheDocument()
     })
 
     it('Does not set args on value update when name starts with hash', () => {

--- a/ui/src/nav.test.tsx
+++ b/ui/src/nav.test.tsx
@@ -61,6 +61,12 @@ describe('Nav.tsx', () => {
     expect(wave.args[name]).toBeUndefined()
   })
 
+  it('No item is selected by default', () => {
+    const { getByTitle } = render(<View {...navProps} />)
+    expect(getByTitle('Nav 1').parentElement).not.toHaveClass('is-selected')
+    expect(getByTitle('Nav 2').parentElement).not.toHaveClass('is-selected')
+  })
+
   it('Makes link active when value specified', () => {
     const props: T.Model<State> = { ...navProps, state: { ...navProps.state, value: 'nav1' } }
     const { getByTitle } = render(<View {...props} />)
@@ -155,7 +161,7 @@ describe('Nav.tsx', () => {
     it('Selects nav item on value update', () => {
       const props: T.Model<State> = { ...navProps, state: { items } }
       const { rerender, getByTitle } = render(<View {...props} />)
-      expect(getByTitle('Nav 1').parentElement).toHaveClass('is-selected')
+      expect(getByTitle('Nav 1').parentElement).not.toHaveClass('is-selected')
       expect(getByTitle('Nav 2').parentElement).not.toHaveClass('is-selected')
 
       props.state.value = 'nav2'
@@ -168,6 +174,10 @@ describe('Nav.tsx', () => {
     it('Selects nav item when value is updated to the same value twice', () => {
       const
         props: T.Model<State> = { ...navProps, state: { items } },
+        expectNoneSelected = () => {
+          expect(getByTitle('Nav 1').parentElement).not.toHaveClass('is-selected')
+          expect(getByTitle('Nav 2').parentElement).not.toHaveClass('is-selected')
+        },
         expectFirstSelected = () => {
           expect(getByTitle('Nav 1').parentElement).toHaveClass('is-selected')
           expect(getByTitle('Nav 2').parentElement).not.toHaveClass('is-selected')
@@ -178,7 +188,7 @@ describe('Nav.tsx', () => {
         },
         { rerender, getByTitle } = render(<View {...props} />)
 
-      expectFirstSelected()
+      expectNoneSelected()
 
       props.state.value = 'nav2'
       rerender(<View {...props} />)

--- a/ui/src/nav.test.tsx
+++ b/ui/src/nav.test.tsx
@@ -205,6 +205,20 @@ describe('Nav.tsx', () => {
       expectSecondSelected()
     })
 
+    it('Unselect all nav items', () => {
+      const props: T.Model<State> = { ...navProps, state: { items, value: 'nav1' } }
+      const { rerender, getByTitle } = render(<View {...props} />)
+
+      expect(getByTitle('Nav 1').parentElement).toHaveClass('is-selected')
+      expect(getByTitle('Nav 2').parentElement).not.toHaveClass('is-selected')
+
+      props.state.value = undefined
+      rerender(<View {...props} />)
+
+      expect(getByTitle('Nav 1').parentElement).not.toHaveClass('is-selected')
+      expect(getByTitle('Nav 2').parentElement).not.toHaveClass('is-selected')
+    })
+
     it('Does not set args on value update when name starts with hash', () => {
       const props: T.Model<State> = { ...navProps, state: { items: hashItems } }
       const { rerender } = render(<View {...props} />)

--- a/ui/src/nav.tsx
+++ b/ui/src/nav.tsx
@@ -144,7 +144,7 @@ export const
         }
       }))
     }))
-    return <Fluent.Nav groups={groups} selectedKey={valueB() || groups[0].links[0].key} styles={{ groupContent: { marginBottom: 0 } }} />
+    return <Fluent.Nav groups={groups} selectedKey={valueB()} styles={{ groupContent: { marginBottom: 0 } }} />
   },
   View = bond(({ name, state, changed }: Model<State>) => {
     const

--- a/ui/src/nav.tsx
+++ b/ui/src/nav.tsx
@@ -117,7 +117,7 @@ const css = stylesheet({
 })
 
 export const
-  XNav = ({ items, hideNav, linksOnly = false, valueB }: State & { hideNav?: () => void, linksOnly?: B, valueB?: Box<S | undefined> }) => {
+  XNav = ({ items, hideNav, linksOnly = false, valueB }: State & { hideNav?: () => void, linksOnly?: B, valueB: Box<S | undefined> }) => {
     const groups = items.map((g): Fluent.INavLinkGroup => ({
       name: g.label,
       collapseByDefault: g.collapsed,
@@ -133,7 +133,7 @@ export const
         },
         url: '',
         onClick: () => {
-          if (valueB) valueB(name)
+          valueB(name)
           if (hideNav) hideNav()
           if (path) window.open(path, "_blank")
           else if (name.startsWith('#')) window.location.hash = name.substring(1)
@@ -144,13 +144,7 @@ export const
         }
       }))
     }))
-    return <Fluent.Nav
-      groups={groups}
-      // HACK: Unselect all items by using not existing key when user changes value to None within the Wave app.
-      initialSelectedKey={'non-existent-key'}
-      selectedKey={valueB?.()}
-      styles={{ groupContent: { marginBottom: 0 } }}
-    />
+    return <Fluent.Nav groups={groups} selectedKey={valueB() || ''} styles={{ groupContent: { marginBottom: 0 } }} />
   },
   View = bond(({ name, state, changed }: Model<State>) => {
     const

--- a/ui/src/nav.tsx
+++ b/ui/src/nav.tsx
@@ -144,7 +144,13 @@ export const
         }
       }))
     }))
-    return <Fluent.Nav groups={groups} selectedKey={valueB?.()} styles={{ groupContent: { marginBottom: 0 } }} />
+    return <Fluent.Nav
+      groups={groups}
+      // HACK: Unselect all items by using not existing key when user changes value to None within the Wave app.
+      initialSelectedKey={'non-existent-key'}
+      selectedKey={valueB?.()}
+      styles={{ groupContent: { marginBottom: 0 } }}
+    />
   },
   View = bond(({ name, state, changed }: Model<State>) => {
     const
@@ -172,8 +178,9 @@ export const
       update = (prevProps: Model<State>) => {
         if (prevProps.state.value === valueB()) return
         valueB(prevProps.state.value)
-        const name = prevProps.state.value || prevProps.state.items[0].items[0].name
+        const name = prevProps.state.value
 
+        if (!name) return
         if (name.startsWith('#')) window.location.hash = name.substring(1)
         else wave.args[name] = true
       },

--- a/ui/src/nav.tsx
+++ b/ui/src/nav.tsx
@@ -117,7 +117,7 @@ const css = stylesheet({
 })
 
 export const
-  XNav = ({ items, hideNav, linksOnly = false, valueB }: State & { hideNav?: () => void, linksOnly?: B, valueB: Box<S | undefined> }) => {
+  XNav = ({ items, hideNav, linksOnly = false, valueB }: State & { hideNav?: () => void, linksOnly?: B, valueB?: Box<S | undefined> }) => {
     const groups = items.map((g): Fluent.INavLinkGroup => ({
       name: g.label,
       collapseByDefault: g.collapsed,
@@ -133,7 +133,7 @@ export const
         },
         url: '',
         onClick: () => {
-          valueB(name)
+          if (valueB) valueB(name)
           if (hideNav) hideNav()
           if (path) window.open(path, "_blank")
           else if (name.startsWith('#')) window.location.hash = name.substring(1)
@@ -144,7 +144,7 @@ export const
         }
       }))
     }))
-    return <Fluent.Nav groups={groups} selectedKey={valueB()} styles={{ groupContent: { marginBottom: 0 } }} />
+    return <Fluent.Nav groups={groups} selectedKey={valueB?.()} styles={{ groupContent: { marginBottom: 0 } }} />
   },
   View = bond(({ name, state, changed }: Model<State>) => {
     const

--- a/ui/src/tab.test.tsx
+++ b/ui/src/tab.test.tsx
@@ -76,6 +76,17 @@ describe('Tab.tsx', () => {
     expect(pushMock).toHaveBeenCalledTimes(0)
   })
 
+  it('Does not call sync on click - args not changed', () => {
+    const pushMock = jest.fn()
+    wave.push = pushMock
+
+    const { getByRole } = render(<View {...tabProps} />)
+    wave.args[name] = name
+    fireEvent.click(getByRole('tab'))
+
+    expect(pushMock).toHaveBeenCalledTimes(0)
+  })
+
   it('Set args when value is updated - state name not defined', () => {
     const items = [{ name: 'tab1' }, { name: 'tab2' }]
     const props = { ...tabProps, state: { items, value: 'tab1' } }

--- a/ui/src/tab.test.tsx
+++ b/ui/src/tab.test.tsx
@@ -42,7 +42,7 @@ describe('Tab.tsx', () => {
     expect(queryByTestId(name)).toBeInTheDocument()
   })
 
-  it('Sets args and calls sync on click - state name is not defined', () => {
+  it('Sets args and calls sync on click - name is not defined', () => {
     const pushMock = jest.fn()
     wave.push = pushMock
 
@@ -53,7 +53,7 @@ describe('Tab.tsx', () => {
     expect(pushMock).toHaveBeenCalled()
   })
 
-  it('Sets args and calls sync on click - state name is defined', () => {
+  it('Sets args and calls sync on click - name is defined', () => {
     const pushMock = jest.fn()
     wave.push = pushMock
 
@@ -76,7 +76,7 @@ describe('Tab.tsx', () => {
     expect(pushMock).toHaveBeenCalledTimes(0)
   })
 
-  it('Does not call sync on click - args not changed - state name not defined', () => {
+  it('Does not call sync on click - args not changed - name not defined', () => {
     const pushMock = jest.fn()
     wave.push = pushMock
 
@@ -87,7 +87,7 @@ describe('Tab.tsx', () => {
     expect(pushMock).toHaveBeenCalledTimes(0)
   })
 
-  it('Does not call sync on click - args not changed - state name defined', () => {
+  it('Does not call sync on click - args not changed - name defined', () => {
     const pushMock = jest.fn()
     wave.push = pushMock
 
@@ -99,7 +99,7 @@ describe('Tab.tsx', () => {
     expect(pushMock).toHaveBeenCalledTimes(0)
   })
 
-  it('Set args when value is updated - state name not defined', () => {
+  it('Set args when value is updated - name not defined', () => {
     const items = [{ name: 'tab1' }, { name: 'tab2' }]
     const props = { ...tabProps, state: { items, value: 'tab1' } }
     const { rerender, getAllByRole } = render(<View {...props} />)
@@ -112,7 +112,7 @@ describe('Tab.tsx', () => {
     expect(wave.args[name]).toBeNull()
   })
 
-  it('Set args when value is updated - state name defined', () => {
+  it('Set args when value is updated - name defined', () => {
     const items = [{ name: 'tab1' }, { name: 'tab2' }]
     const props = { ...tabProps, state: { items, value: 'tab1', name } }
     const { rerender, getAllByRole } = render(<View {...props} />)

--- a/ui/src/tab.test.tsx
+++ b/ui/src/tab.test.tsx
@@ -42,7 +42,7 @@ describe('Tab.tsx', () => {
     expect(queryByTestId(name)).toBeInTheDocument()
   })
 
-  it('Sets args and calls sync on click', () => {
+  it('Sets args and calls sync on click - state name is not defined', () => {
     const pushMock = jest.fn()
     wave.push = pushMock
 
@@ -50,6 +50,18 @@ describe('Tab.tsx', () => {
     fireEvent.click(getByRole('tab'))
 
     expect(wave.args[name]).toBe(true)
+    expect(pushMock).toHaveBeenCalled()
+  })
+
+  it('Sets args and calls sync on click - state name is defined', () => {
+    const pushMock = jest.fn()
+    wave.push = pushMock
+
+    const { getByRole } = render(<View {...{ ...tabProps, state: { items: [{ name: 'tab1' }], name } }} />)
+    fireEvent.click(getByRole('tab'))
+
+    expect(wave.args[name]).toBe('tab1')
+    expect(wave.args['tab1']).toBeUndefined()
     expect(pushMock).toHaveBeenCalled()
   })
 

--- a/ui/src/tab.test.tsx
+++ b/ui/src/tab.test.tsx
@@ -76,11 +76,23 @@ describe('Tab.tsx', () => {
     expect(pushMock).toHaveBeenCalledTimes(0)
   })
 
-  it('Does not call sync on click - args not changed', () => {
+  it('Does not call sync on click - args not changed - state name not defined', () => {
     const pushMock = jest.fn()
     wave.push = pushMock
 
     const { getByRole } = render(<View {...tabProps} />)
+    wave.args[name] = true
+    fireEvent.click(getByRole('tab'))
+
+    expect(pushMock).toHaveBeenCalledTimes(0)
+  })
+
+  it('Does not call sync on click - args not changed - state name defined', () => {
+    const pushMock = jest.fn()
+    wave.push = pushMock
+
+    const props = { ...tabProps, state: { items: [{ name }], name } }
+    const { getByRole } = render(<View {...props} />)
     wave.args[name] = name
     fireEvent.click(getByRole('tab'))
 

--- a/ui/src/tab.test.tsx
+++ b/ui/src/tab.test.tsx
@@ -32,6 +32,7 @@ const
 describe('Tab.tsx', () => {
   beforeEach(() => {
     window.location.hash = ''
+    wave.args = [] as any
     wave.args[name] = null
     jest.clearAllMocks()
   })
@@ -63,7 +64,7 @@ describe('Tab.tsx', () => {
     expect(pushMock).toHaveBeenCalledTimes(0)
   })
 
-  it('Set args when value is updated', () => {
+  it('Set args when value is updated - state name not defined', () => {
     const items = [{ name: 'tab1' }, { name: 'tab2' }]
     const props = { ...tabProps, state: { items, value: 'tab1' } }
     const { rerender, getAllByRole } = render(<View {...props} />)
@@ -73,6 +74,20 @@ describe('Tab.tsx', () => {
     props.state.value = 'tab2'
     rerender(<View {...props} />)
     expect(wave.args['tab2']).toBe(true)
+    expect(wave.args[name]).toBeNull()
+  })
+
+  it('Set args when value is updated - state name defined', () => {
+    const items = [{ name: 'tab1' }, { name: 'tab2' }]
+    const props = { ...tabProps, state: { items, value: 'tab1', name } }
+    const { rerender, getAllByRole } = render(<View {...props} />)
+    expect(getAllByRole('tab')[0]).toHaveClass('is-selected')
+    expect(wave.args['tab2']).toBeUndefined()
+
+    props.state.value = 'tab2'
+    rerender(<View {...props} />)
+    expect(wave.args['tab2']).toBeUndefined()
+    expect(wave.args[name]).toBe('tab2')
   })
 
   it('Does not set args when value is updated - hash name', () => {

--- a/ui/src/tab.test.tsx
+++ b/ui/src/tab.test.tsx
@@ -74,6 +74,7 @@ describe('Tab.tsx', () => {
     fireEvent.click(getByRole('tab'))
 
     expect(wave.args[name]).toBeNull()
+    expect(pushMock).toHaveBeenCalledTimes(0)
   })
 
   it('Does not set args when value is updated - hash name', () => {

--- a/ui/src/tab.tsx
+++ b/ui/src/tab.tsx
@@ -46,9 +46,13 @@ export const
   View = bond(({ name, state, changed }: Model<State>) => {
     const
       valueB = box<S | undefined>(state.value),
-      handleArgs = (name: S, trigger: B = false) => {
+      handleArgs = (name?: S, trigger: B = false) => {
         // TODO: name: undefined, m.name: 'name'
         // TODO: name: undefined, m.name: ''
+        if (!name) {
+          state.name ? wave.args[state.name] = null : wave.args = {}
+          return
+        }
         if (name.startsWith('#')) {
           window.location.hash = name.substring(1)
           return
@@ -58,6 +62,7 @@ export const
           wave.args[state.name] = name
           if (trigger) wave.push()
         } else {
+          if (wave.args[name] === true) return
           wave.args[name] = true
           if (trigger) wave.push()
         }
@@ -77,14 +82,14 @@ export const
           ))
         return (
           <div data-test={name} className={css.card}>
-            <Pivot linkFormat={linkFormat} onLinkClick={onLinkClick} selectedKey={valueB() || state.items[0].name}>{items}</Pivot>
+            <Pivot linkFormat={linkFormat} onLinkClick={onLinkClick} selectedKey={valueB()}>{items}</Pivot>
           </div>
         )
       },
       update = (prevProps: Model<State>) => {
         if (prevProps.state.value === valueB()) return
         valueB(prevProps.state.value)
-        handleArgs(prevProps.state.value || prevProps.state.items[0].name)
+        handleArgs(prevProps.state.value)
       }
 
     return { render, changed, update, valueB }

--- a/ui/src/tab.tsx
+++ b/ui/src/tab.tsx
@@ -47,17 +47,9 @@ export const
     const
       valueB = box<S | undefined>(state.value),
       handleArgs = (name?: S, trigger: B = false) => {
-        // TODO: name: undefined, m.name: 'name'
-        // TODO: name: undefined, m.name: ''
-        if (!name) {
-          state.name ? wave.args[state.name] = null : wave.args = {}
-          return
-        }
-        if (name.startsWith('#')) {
-          window.location.hash = name.substring(1)
-          return
-        }
-        if (state.name) {
+        if (!name) state.name ? wave.args[state.name] = null : wave.args = {}
+        else if (name.startsWith('#')) window.location.hash = name.substring(1)
+        else if (state.name) {
           if (name === wave.args[state.name]) return
           wave.args[state.name] = name
           if (trigger) wave.push()

--- a/ui/src/tab.tsx
+++ b/ui/src/tab.tsx
@@ -45,26 +45,20 @@ const
 export const
   View = bond(({ name, state, changed }: Model<State>) => {
     const
-      valueB = box<S | undefined>(state.value),
-      handleArgs = (name?: S, trigger: B = false) => {
-        if (!name) return
-        if (name.startsWith('#')) window.location.hash = name.substring(1)
-        else if (state.name) {
-          if (name === wave.args[state.name]) return
-          wave.args[state.name] = name
-          if (trigger) wave.push()
-        } else {
-          if (wave.args[name] === true) return
-          wave.args[name] = true
-          if (trigger) wave.push()
-        }
-      },
+      valueB = box<S | undefined>(state.value || state.items[0]?.name),
       onLinkClick = (item?: PivotItem) => {
         const name = item?.props.itemKey
-        if (!name) return
+        if (!name || valueB() === name) return
         state.value = name
         valueB(name)
-        handleArgs(name, true)
+
+        if (name.startsWith('#')) {
+          window.location.hash = name.substring(1)
+          return
+        }
+        if (state.name) wave.args[state.name] = name
+        else wave.args[name] = true
+        wave.push()
       },
       render = () => {
         const
@@ -79,9 +73,7 @@ export const
         )
       },
       update = (prevProps: Model<State>) => {
-        if (prevProps.state.value === valueB()) return
-        valueB(prevProps.state.value)
-        handleArgs(prevProps.state.value)
+        if (prevProps.state.value !== valueB()) valueB(prevProps.state.value)
       }
 
     return { render, changed, update, valueB }

--- a/ui/src/tab.tsx
+++ b/ui/src/tab.tsx
@@ -47,8 +47,8 @@ export const
     const
       valueB = box<S | undefined>(state.value),
       handleArgs = (name?: S, trigger: B = false) => {
-        if (!name) state.name ? wave.args[state.name] = null : wave.args = {}
-        else if (name.startsWith('#')) window.location.hash = name.substring(1)
+        if (!name) return
+        if (name.startsWith('#')) window.location.hash = name.substring(1)
         else if (state.name) {
           if (name === wave.args[state.name]) return
           wave.args[state.name] = name

--- a/ui/src/tab.tsx
+++ b/ui/src/tab.tsx
@@ -46,18 +46,28 @@ export const
   View = bond(({ name, state, changed }: Model<State>) => {
     const
       valueB = box<S | undefined>(state.value),
-      setArgs = (name: S) => {
-        if (name.startsWith('#')) window.location.hash = name.substring(1)
-        else if (state.name) wave.args[state.name] = name
-        else wave.args[name] = true
+      handleArgs = (name: S, trigger: B = false) => {
+        // TODO: name: undefined, m.name: 'name'
+        // TODO: name: undefined, m.name: ''
+        if (name.startsWith('#')) {
+          window.location.hash = name.substring(1)
+          return
+        }
+        if (state.name) {
+          if (name === wave.args[state.name]) return
+          wave.args[state.name] = name
+          if (trigger) wave.push()
+        } else {
+          wave.args[name] = true
+          if (trigger) wave.push()
+        }
       },
       onLinkClick = (item?: PivotItem) => {
         const name = item?.props.itemKey
         if (!name) return
         state.value = name
         valueB(name)
-        setArgs(name)
-        if (!name.startsWith('#')) wave.push()
+        handleArgs(name, true)
       },
       render = () => {
         const
@@ -74,7 +84,7 @@ export const
       update = (prevProps: Model<State>) => {
         if (prevProps.state.value === valueB()) return
         valueB(prevProps.state.value)
-        setArgs(prevProps.state.value || prevProps.state.items[0].name)
+        handleArgs(prevProps.state.value || prevProps.state.items[0].name)
       }
 
     return { render, changed, update, valueB }

--- a/ui/src/tabs.test.tsx
+++ b/ui/src/tabs.test.tsx
@@ -22,7 +22,10 @@ const hashName = `#${name}`
 const tabsProps: Tabs = { name, items: [{ name }] }
 
 describe('Tabs.tsx', () => {
-  beforeEach(() => { wave.args[name] = null })
+  beforeEach(() => {
+    wave.args = [] as any
+    wave.args[name] = null
+  })
 
   it('Renders data-test attr', () => {
     const { queryByTestId } = render(<XTabs model={tabsProps} />)
@@ -60,8 +63,21 @@ describe('Tabs.tsx', () => {
 
     props.value = 'tab2'
     rerender(<XTabs model={props} />)
-    // TODO: Not consistent with ui.tab_card - wave.args['tab2'].toBe(true)
     expect(wave.args[name]).toBe('tab2')
+    expect(wave.args['tab2']).toBeUndefined()
+  })
+
+  it('Set args when value is updated - name is an empty string', () => {
+    const items = [{ name: 'tab1' }, { name: 'tab2' }]
+    const props = { ...tabsProps, items, value: 'tab1', name: '' }
+    const { rerender, getAllByRole } = render(<XTabs model={props} />)
+    expect(getAllByRole('tab')[0]).toHaveClass('is-selected')
+    expect(wave.args['tab2']).toBeUndefined()
+
+    props.value = 'tab2'
+    rerender(<XTabs model={props} />)
+    expect(wave.args[name]).toBeUndefined()
+    expect(wave.args['tab2']).toBe(true)
   })
 
   it('Does not set args when value is updated - hash name', () => {

--- a/ui/src/tabs.test.tsx
+++ b/ui/src/tabs.test.tsx
@@ -19,92 +19,51 @@ import { wave } from './ui'
 
 const name = 'tabs'
 const hashName = `#${name}`
-const tabsProps: Tabs = { name, items: [{ name }] }
+const getProps = (): Tabs => ({ name, items: [{ name: 'tab1' }, { name: 'tab2' }] })
+const pushMock = jest.fn()
 
 describe('Tabs.tsx', () => {
+  beforeAll(() => {
+    wave.push = pushMock
+  })
   beforeEach(() => {
     wave.args = [] as any
     wave.args[name] = null
+    pushMock.mockReset()
   })
 
   it('Renders data-test attr', () => {
-    const { queryByTestId } = render(<XTabs model={tabsProps} />)
+    const { queryByTestId } = render(<XTabs model={getProps()} />)
     expect(queryByTestId(name)).toBeInTheDocument()
   })
 
-  it('Sets args and calls sync on click', () => {
-    const pushMock = jest.fn()
-    wave.push = pushMock
+  it('Sets args and calls push on click - name is an empty string', () => {
+    const { getAllByRole } = render(<XTabs model={{ ...getProps(), name: '' }} />)
+    fireEvent.click(getAllByRole('tab')[1])
 
-    const { getByRole } = render(<XTabs model={tabsProps} />)
-    fireEvent.click(getByRole('tab'))
-
-    expect(wave.args[name]).toBe(name)
-    expect(pushMock).toHaveBeenCalled()
-  })
-
-  it('Sets args and calls sync on click - name is an empty string', () => {
-    const pushMock = jest.fn()
-    wave.push = pushMock
-
-    const { getByRole } = render(<XTabs model={{ ...tabsProps, name: '' }} />)
-    fireEvent.click(getByRole('tab'))
-
-    expect(wave.args[name]).toBe(true)
-    expect(pushMock).toHaveBeenCalled()
-  })
-
-  it('Does not call sync on click - args not changed', () => {
-    const pushMock = jest.fn()
-    wave.push = pushMock
-
-    const { getByRole } = render(<XTabs model={tabsProps} />)
-    wave.args[name] = name
-    fireEvent.click(getByRole('tab'))
-
-    expect(pushMock).toHaveBeenCalledTimes(0)
-  })
-
-  it('Does not call sync on click - args not changed - name is an empty string', () => {
-    const pushMock = jest.fn()
-    wave.push = pushMock
-
-    const { getByRole } = render(<XTabs model={{ ...tabsProps, name: '' }} />)
-    wave.args[name] = true
-    fireEvent.click(getByRole('tab'))
-
-    expect(pushMock).toHaveBeenCalledTimes(0)
-  })
-
-  it('Set args when value is updated', () => {
-    const items = [{ name: 'tab1' }, { name: 'tab2' }]
-    const props = { ...tabsProps, items, value: 'tab1' }
-    const { rerender, getAllByRole } = render(<XTabs model={props} />)
-    expect(getAllByRole('tab')[0]).toHaveClass('is-selected')
-    expect(wave.args['tab2']).toBeUndefined()
-
-    props.value = 'tab2'
-    rerender(<XTabs model={props} />)
-    expect(wave.args[name]).toBe('tab2')
-    expect(wave.args['tab2']).toBeUndefined()
-  })
-
-  it('Set args when value is updated - name is an empty string', () => {
-    const items = [{ name: 'tab1' }, { name: 'tab2' }]
-    const props = { ...tabsProps, items, value: 'tab1', name: '' }
-    const { rerender, getAllByRole } = render(<XTabs model={props} />)
-    expect(getAllByRole('tab')[0]).toHaveClass('is-selected')
-    expect(wave.args['tab2']).toBeUndefined()
-
-    props.value = 'tab2'
-    rerender(<XTabs model={props} />)
-    expect(wave.args[name]).toBeNull()
     expect(wave.args['tab2']).toBe(true)
+    expect(pushMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('Sets args and calls push on click', () => {
+    const { getAllByRole } = render(<XTabs model={getProps()} />)
+    fireEvent.click(getAllByRole('tab')[1])
+
+    expect(wave.args[name]).toBe('tab2')
+    expect(wave.args['tab1']).toBeUndefined()
+    expect(pushMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('Does not call push on click selecting already selected', () => {
+    const { getAllByRole } = render(<XTabs model={getProps()} />)
+    fireEvent.click(getAllByRole('tab')[0])
+
+    expect(pushMock).toHaveBeenCalledTimes(0)
   })
 
   it('Does not set args when value is updated - hash name', () => {
     const items = [{ name: '#tab1' }, { name: '#tab2' }]
-    const props = { ...tabsProps, items, value: '#tab1' }
+    const props = { ...getProps(), items, value: '#tab1' }
     const { rerender } = render(<XTabs model={props} />)
     expect(wave.args[name]).toBeNull()
 
@@ -112,59 +71,69 @@ describe('Tabs.tsx', () => {
     rerender(<XTabs model={props} />)
 
     expect(wave.args[name]).toBeNull()
+    expect(pushMock).toHaveBeenCalledTimes(0)
   })
 
   it('Selects tab when value is updated', () => {
     const items = [{ name: 'tab1' }, { name: 'tab2' }]
-    const props = { ...tabsProps, items, value: 'tab1' }
+    const props = { ...getProps(), items, value: 'tab1' }
     const { rerender, getAllByRole } = render(<XTabs model={props} />)
     expect(getAllByRole('tab')[0]).toHaveClass('is-selected')
     expect(getAllByRole('tab')[1]).not.toHaveClass('is-selected')
+    expect(pushMock).toHaveBeenCalledTimes(0)
 
     props.value = 'tab2'
     rerender(<XTabs model={props} />)
     expect(getAllByRole('tab')[0]).not.toHaveClass('is-selected')
     expect(getAllByRole('tab')[1]).toHaveClass('is-selected')
+    expect(pushMock).toHaveBeenCalledTimes(0)
   })
 
   it('Selects tab when value is updated twice to the same value', () => {
     const items = [{ name: 'tab1' }, { name: 'tab2' }]
-    const props = { ...tabsProps, items, value: 'tab1' }
+    const props = { ...getProps(), items, value: 'tab1' }
     const { rerender, getAllByRole } = render(<XTabs model={props} />)
     expect(getAllByRole('tab')[0]).toHaveClass('is-selected')
     expect(getAllByRole('tab')[1]).not.toHaveClass('is-selected')
+    expect(pushMock).toHaveBeenCalledTimes(0)
 
     props.value = 'tab2'
     rerender(<XTabs model={props} />)
     expect(getAllByRole('tab')[0]).not.toHaveClass('is-selected')
     expect(getAllByRole('tab')[1]).toHaveClass('is-selected')
+    expect(pushMock).toHaveBeenCalledTimes(0)
 
     fireEvent.click(getAllByRole('tab')[0])
     expect(getAllByRole('tab')[0]).toHaveClass('is-selected')
     expect(getAllByRole('tab')[1]).not.toHaveClass('is-selected')
+    expect(pushMock).toHaveBeenCalledTimes(1)
+    pushMock.mockReset()
 
     props.value = 'tab2'
     rerender(<XTabs model={props} />)
     expect(getAllByRole('tab')[0]).not.toHaveClass('is-selected')
     expect(getAllByRole('tab')[1]).toHaveClass('is-selected')
+    expect(pushMock).toHaveBeenCalledTimes(0)
   })
 
   it('Selects tab when value is updated - hash name', () => {
     const items = [{ name: '#tab1' }, { name: '#tab2' }]
-    const props = { ...tabsProps, items, value: '#tab1' }
+    const props = { ...getProps(), items, value: '#tab1' }
     const { rerender, getAllByRole } = render(<XTabs model={props} />)
     expect(getAllByRole('tab')[0]).toHaveClass('is-selected')
     expect(getAllByRole('tab')[1]).not.toHaveClass('is-selected')
+    expect(pushMock).toHaveBeenCalledTimes(0)
 
     props.value = '#tab2'
     rerender(<XTabs model={props} />)
     expect(getAllByRole('tab')[0]).not.toHaveClass('is-selected')
     expect(getAllByRole('tab')[1]).toHaveClass('is-selected')
+    expect(pushMock).toHaveBeenCalledTimes(0)
   })
 
   it('Selects tab when value is updated twice to the same value - hash name', () => {
     const items = [{ name: '#tab1' }, { name: '#tab2' }]
-    const props = { ...tabsProps, items, value: '#tab1' }
+    const props = { ...getProps(), items, value: '#tab1' }
     const { rerender, getAllByRole } = render(<XTabs model={props} />)
     expect(getAllByRole('tab')[0]).toHaveClass('is-selected')
     expect(getAllByRole('tab')[1]).not.toHaveClass('is-selected')
@@ -173,6 +142,7 @@ describe('Tabs.tsx', () => {
     rerender(<XTabs model={props} />)
     expect(getAllByRole('tab')[0]).not.toHaveClass('is-selected')
     expect(getAllByRole('tab')[1]).toHaveClass('is-selected')
+    expect(pushMock).toHaveBeenCalledTimes(0)
 
     fireEvent.click(getAllByRole('tab')[0])
     expect(getAllByRole('tab')[0]).toHaveClass('is-selected')
@@ -182,32 +152,28 @@ describe('Tabs.tsx', () => {
     rerender(<XTabs model={props} />)
     expect(getAllByRole('tab')[0]).not.toHaveClass('is-selected')
     expect(getAllByRole('tab')[1]).toHaveClass('is-selected')
+    expect(pushMock).toHaveBeenCalledTimes(0)
   })
 
   it('Sets url hash - hash name', () => {
-    const { getByRole } = render(<XTabs model={{ ...tabsProps, items: [{ name: hashName }] }} />)
+    const { getByRole } = render(<XTabs model={{ ...getProps(), items: [{ name: hashName }] }} />)
     fireEvent.click(getByRole('tab'))
 
     expect(window.location.hash).toBe(hashName)
   })
 
-  it('Sets url hash when value is updated - hash name', () => {
-    window.location.hash = ''
-    const items = [{ name: '#tab1' }, { name: '#tab2' }]
-    const props = { ...{ ...tabsProps, items, value: '#tab1' } }
-    const { rerender } = render(<XTabs model={props} />)
-    expect(window.location.hash).toBe('')
-
-    props.value = '#tab2'
-    rerender(<XTabs model={props} />)
-    expect(window.location.hash).toBe('#tab2')
-  })
-
   it('Sets default tab', () => {
     const items = [{ name: 'tab1' }, { name: 'tab2' }]
-    const { getAllByRole } = render(<XTabs model={{ ...tabsProps, items, value: 'tab2' }} />)
+    const { getAllByRole } = render(<XTabs model={{ ...getProps(), items, value: 'tab2' }} />)
 
     expect(getAllByRole('tab')[1]).toHaveClass('is-selected')
+  })
+
+  it('Selects first tab if value not defined', () => {
+    const items = [{ name: 'tab1' }, { name: 'tab2' }]
+    const { getAllByRole } = render(<XTabs model={{ ...getProps(), items }} />)
+
+    expect(getAllByRole('tab')[0]).toHaveClass('is-selected')
   })
 
 })

--- a/ui/src/tabs.test.tsx
+++ b/ui/src/tabs.test.tsx
@@ -65,6 +65,17 @@ describe('Tabs.tsx', () => {
     expect(pushMock).toHaveBeenCalledTimes(0)
   })
 
+  it('Does not call sync on click - args not changed - name is an empty string', () => {
+    const pushMock = jest.fn()
+    wave.push = pushMock
+
+    const { getByRole } = render(<XTabs model={{ ...tabsProps, name: '' }} />)
+    wave.args[name] = true
+    fireEvent.click(getByRole('tab'))
+
+    expect(pushMock).toHaveBeenCalledTimes(0)
+  })
+
   it('Set args when value is updated', () => {
     const items = [{ name: 'tab1' }, { name: 'tab2' }]
     const props = { ...tabsProps, items, value: 'tab1' }

--- a/ui/src/tabs.test.tsx
+++ b/ui/src/tabs.test.tsx
@@ -18,10 +18,14 @@ import { Tabs, XTabs } from './tabs'
 import { wave } from './ui'
 
 const name = 'tabs'
+const hashName = `#${name}`
 const tabsProps: Tabs = { name, items: [{ name }] }
 
 describe('Tabs.tsx', () => {
-  beforeEach(() => { wave.args[name] = null })
+  beforeEach(() => {
+    window.location.hash = ''
+    wave.args[name] = null
+  })
 
   it('Renders data-test attr', () => {
     const { queryByTestId } = render(<XTabs model={tabsProps} />)
@@ -38,15 +42,137 @@ describe('Tabs.tsx', () => {
     expect(wave.args[name]).toBe(name)
     expect(pushMock).toHaveBeenCalled()
   })
+
   it('Does not call sync on click - args not changed', () => {
     const pushMock = jest.fn()
     wave.push = pushMock
-    wave.args[name] = name
 
     const { getByRole } = render(<XTabs model={tabsProps} />)
+    wave.args[name] = name
     fireEvent.click(getByRole('tab'))
 
     expect(pushMock).toHaveBeenCalledTimes(0)
+  })
+
+  it('Set args when value is updated', () => {
+    const items = [{ name: 'tab1' }, { name: 'tab2' }]
+    const props = { ...tabsProps, items, value: 'tab1' }
+    const { rerender, getAllByRole } = render(<XTabs model={props} />)
+    expect(getAllByRole('tab')[0]).toHaveClass('is-selected')
+    expect(wave.args['tab2']).toBeUndefined()
+
+    props.value = 'tab2'
+    rerender(<XTabs model={props} />)
+    // TODO: Not consistent with ui.tab_card - wave.args['tab2'].toBe(true)
+    expect(wave.args[name]).toBe('tab2')
+  })
+
+  it('Does not set args when value is updated - hash name', () => {
+    const items = [{ name: '#tab1' }, { name: '#tab2' }]
+    const props = { ...tabsProps, items, value: '#tab1' }
+    const { rerender } = render(<XTabs model={props} />)
+    expect(wave.args[name]).toBeNull()
+
+    props.value = '#tab2'
+    rerender(<XTabs model={props} />)
+
+    expect(wave.args[name]).toBeNull()
+  })
+
+  it('Selects tab when value is updated', () => {
+    const items = [{ name: 'tab1' }, { name: 'tab2' }]
+    const props = { ...tabsProps, items, value: 'tab1' }
+    const { rerender, getAllByRole } = render(<XTabs model={props} />)
+    expect(getAllByRole('tab')[0]).toHaveClass('is-selected')
+    expect(getAllByRole('tab')[1]).not.toHaveClass('is-selected')
+
+    props.value = 'tab2'
+    rerender(<XTabs model={props} />)
+    expect(getAllByRole('tab')[0]).not.toHaveClass('is-selected')
+    expect(getAllByRole('tab')[1]).toHaveClass('is-selected')
+  })
+
+  it('Selects tab when value is updated twice to the same value', () => {
+    const items = [{ name: 'tab1' }, { name: 'tab2' }]
+    const props = { ...tabsProps, items, value: 'tab1' }
+    const { rerender, getAllByRole } = render(<XTabs model={props} />)
+    expect(getAllByRole('tab')[0]).toHaveClass('is-selected')
+    expect(getAllByRole('tab')[1]).not.toHaveClass('is-selected')
+
+    props.value = 'tab2'
+    rerender(<XTabs model={props} />)
+    expect(getAllByRole('tab')[0]).not.toHaveClass('is-selected')
+    expect(getAllByRole('tab')[1]).toHaveClass('is-selected')
+
+    fireEvent.click(getAllByRole('tab')[0])
+    expect(getAllByRole('tab')[0]).toHaveClass('is-selected')
+    expect(getAllByRole('tab')[1]).not.toHaveClass('is-selected')
+
+    props.value = 'tab2'
+    rerender(<XTabs model={props} />)
+    expect(getAllByRole('tab')[0]).not.toHaveClass('is-selected')
+    expect(getAllByRole('tab')[1]).toHaveClass('is-selected')
+  })
+
+  it('Selects tab when value is updated - hash name', () => {
+    const items = [{ name: '#tab1' }, { name: '#tab2' }]
+    const props = { ...tabsProps, items, value: '#tab1' }
+    const { rerender, getAllByRole } = render(<XTabs model={props} />)
+    expect(getAllByRole('tab')[0]).toHaveClass('is-selected')
+    expect(getAllByRole('tab')[1]).not.toHaveClass('is-selected')
+
+    props.value = '#tab2'
+    rerender(<XTabs model={props} />)
+    expect(getAllByRole('tab')[0]).not.toHaveClass('is-selected')
+    expect(getAllByRole('tab')[1]).toHaveClass('is-selected')
+  })
+
+  it('Selects tab when value is updated twice to the same value - hash name', () => {
+    const items = [{ name: '#tab1' }, { name: '#tab2' }]
+    const props = { ...tabsProps, items, value: '#tab1' }
+    const { rerender, getAllByRole } = render(<XTabs model={props} />)
+    expect(getAllByRole('tab')[0]).toHaveClass('is-selected')
+    expect(getAllByRole('tab')[1]).not.toHaveClass('is-selected')
+
+    props.value = '#tab2'
+    rerender(<XTabs model={props} />)
+    expect(getAllByRole('tab')[0]).not.toHaveClass('is-selected')
+    expect(getAllByRole('tab')[1]).toHaveClass('is-selected')
+
+    fireEvent.click(getAllByRole('tab')[0])
+    expect(getAllByRole('tab')[0]).toHaveClass('is-selected')
+    expect(getAllByRole('tab')[1]).not.toHaveClass('is-selected')
+
+    props.value = '#tab2'
+    rerender(<XTabs model={props} />)
+    expect(getAllByRole('tab')[0]).not.toHaveClass('is-selected')
+    expect(getAllByRole('tab')[1]).toHaveClass('is-selected')
+  })
+
+  it('Sets url hash - hash name', () => {
+    const { getByRole } = render(<XTabs model={{ ...tabsProps, items: [{ name: hashName }] }} />)
+    fireEvent.click(getByRole('tab'))
+
+    expect(window.location.hash).toBe(hashName)
+  })
+
+  // TODO: Fix.
+  it('Sets url hash when value is updated - hash name', () => {
+    const items = [{ name: '#tab1' }, { name: '#tab2' }]
+    const props = { ...{ ...tabsProps, items, value: '#tab1' } }
+    const { rerender } = render(<XTabs model={props} />)
+    expect(window.location.hash).toBe('')
+
+    props.value = '#tab2'
+    rerender(<XTabs model={props} />)
+    expect(window.location.hash).toBe('#tab2')
+  })
+
+  it('Sets default tab', () => {
+    const items = [{ name: 'tab1' }, { name: 'tab2' }]
+    const { getAllByRole } = render(<XTabs model={{ ...tabsProps, items, value: 'tab2' }} />)
+
+    expect(getAllByRole('tab')[1]).toHaveClass('is-selected')
   })
 
 })

--- a/ui/src/tabs.test.tsx
+++ b/ui/src/tabs.test.tsx
@@ -43,6 +43,17 @@ describe('Tabs.tsx', () => {
     expect(pushMock).toHaveBeenCalled()
   })
 
+  it('Sets args and calls sync on click - name is an empty string', () => {
+    const pushMock = jest.fn()
+    wave.push = pushMock
+
+    const { getByRole } = render(<XTabs model={{ ...tabsProps, name: '' }} />)
+    fireEvent.click(getByRole('tab'))
+
+    expect(wave.args[name]).toBe(true)
+    expect(pushMock).toHaveBeenCalled()
+  })
+
   it('Does not call sync on click - args not changed', () => {
     const pushMock = jest.fn()
     wave.push = pushMock
@@ -76,7 +87,7 @@ describe('Tabs.tsx', () => {
 
     props.value = 'tab2'
     rerender(<XTabs model={props} />)
-    expect(wave.args[name]).toBeUndefined()
+    expect(wave.args[name]).toBeNull()
     expect(wave.args['tab2']).toBe(true)
   })
 

--- a/ui/src/tabs.test.tsx
+++ b/ui/src/tabs.test.tsx
@@ -22,10 +22,7 @@ const hashName = `#${name}`
 const tabsProps: Tabs = { name, items: [{ name }] }
 
 describe('Tabs.tsx', () => {
-  beforeEach(() => {
-    window.location.hash = ''
-    wave.args[name] = null
-  })
+  beforeEach(() => { wave.args[name] = null })
 
   it('Renders data-test attr', () => {
     const { queryByTestId } = render(<XTabs model={tabsProps} />)
@@ -156,8 +153,8 @@ describe('Tabs.tsx', () => {
     expect(window.location.hash).toBe(hashName)
   })
 
-  // TODO: Fix.
   it('Sets url hash when value is updated - hash name', () => {
+    window.location.hash = ''
     const items = [{ name: '#tab1' }, { name: '#tab2' }]
     const props = { ...{ ...tabsProps, items, value: '#tab1' } }
     const { rerender } = render(<XTabs model={props} />)

--- a/ui/src/tabs.tsx
+++ b/ui/src/tabs.tsx
@@ -65,15 +65,9 @@ export const
   XTabs = ({ model: m }: { model: Tabs }) => {
     const
       handleArgs = (name?: S, trigger: B = false) => {
-        if (!name) {
-          m.name ? wave.args[m.name] = null : wave.args = {}
-          return
-        }
-        if (name.startsWith('#')) {
-          window.location.hash = name.substring(1)
-          return
-        }
-        if (m.name) {
+        if (!name) m.name ? wave.args[m.name] = null : wave.args = {}
+        else if (name.startsWith('#')) window.location.hash = name.substring(1)
+        else if (m.name) {
           if (name === wave.args[m.name]) return
           wave.args[m.name] = name
           if (trigger) wave.push()

--- a/ui/src/tabs.tsx
+++ b/ui/src/tabs.tsx
@@ -64,9 +64,11 @@ const
 export const
   XTabs = ({ model: m }: { model: Tabs }) => {
     const
-      handleArgs = (name: S, trigger: B = false) => {
-        // TODO: name: undefined, m.name: 'name'
-        // TODO: name: undefined, m.name: ''
+      handleArgs = (name?: S, trigger: B = false) => {
+        if (!name) {
+          m.name ? wave.args[m.name] = null : wave.args = {}
+          return
+        }
         if (name.startsWith('#')) {
           window.location.hash = name.substring(1)
           return
@@ -76,6 +78,7 @@ export const
           wave.args[m.name] = name
           if (trigger) wave.push()
         } else {
+          if (wave.args[name] === true) return
           wave.args[name] = true
           if (trigger) wave.push()
         }

--- a/ui/src/tabs.tsx
+++ b/ui/src/tabs.tsx
@@ -17,6 +17,7 @@ import { B, Id, S } from 'h2o-wave'
 import React from 'react'
 import { stylesheet } from 'typestyle'
 import { wave } from './ui'
+import useUpdateOnlyEffect from './parts/useUpdateOnlyEffectHook'
 
 /**
  * Create a tab.
@@ -85,7 +86,7 @@ export const
       tabs = m.items?.map(t => <Fluent.PivotItem key={t.name} itemIcon={t.icon} itemKey={t.name} headerText={t.label} />),
       [selected, setSelected] = React.useState(m.value)
 
-    React.useEffect(() => {
+    useUpdateOnlyEffect(() => {
       setSelected(m.value)
       if (!m.value) wave.args[m.name] = null
       else if (m.value.startsWith('#')) window.location.hash = m.value.substring(1)

--- a/ui/src/tabs.tsx
+++ b/ui/src/tabs.tsx
@@ -64,33 +64,35 @@ const
 export const
   XTabs = ({ model: m }: { model: Tabs }) => {
     const
-      onLinkClick = (item?: Fluent.PivotItem) => {
-        const name = item?.props.itemKey
-        if (!name) return
-        m.value = name
-        setSelected(name)
+      handleArgs = (name: S, trigger: B = false) => {
+        // TODO: name: undefined, m.name: 'name'
+        // TODO: name: undefined, m.name: ''
         if (name.startsWith('#')) {
           window.location.hash = name.substring(1)
           return
         }
         if (m.name) {
-          if (name !== wave.args[m.name]) {
-            wave.args[m.name] = name
-            wave.push()
-          }
+          if (name === wave.args[m.name]) return
+          wave.args[m.name] = name
+          if (trigger) wave.push()
         } else {
           wave.args[name] = true
-          wave.push()
+          if (trigger) wave.push()
         }
+      },
+      onLinkClick = (item?: Fluent.PivotItem) => {
+        const name = item?.props.itemKey
+        if (!name) return
+        m.value = name
+        setSelected(name)
+        handleArgs(name, true)
       },
       tabs = m.items?.map(t => <Fluent.PivotItem key={t.name} itemIcon={t.icon} itemKey={t.name} headerText={t.label} />),
       [selected, setSelected] = React.useState(m.value)
 
     useUpdateOnlyEffect(() => {
       setSelected(m.value)
-      if (!m.value) wave.args[m.name] = null
-      else if (m.value.startsWith('#')) window.location.hash = m.value.substring(1)
-      else if (m.name && m.value !== wave.args[m.name]) wave.args[m.name] = m.value
+      handleArgs(m.value)
     }, [m.name, m.value])
 
     return (

--- a/ui/src/tabs.tsx
+++ b/ui/src/tabs.tsx
@@ -65,8 +65,8 @@ export const
   XTabs = ({ model: m }: { model: Tabs }) => {
     const
       handleArgs = (name?: S, trigger: B = false) => {
-        if (!name) m.name ? wave.args[m.name] = null : wave.args = {}
-        else if (name.startsWith('#')) window.location.hash = name.substring(1)
+        if (!name) return
+        if (name.startsWith('#')) window.location.hash = name.substring(1)
         else if (m.name) {
           if (name === wave.args[m.name]) return
           wave.args[m.name] = name

--- a/ui/src/tabs.tsx
+++ b/ui/src/tabs.tsx
@@ -66,6 +66,7 @@ export const
       onLinkClick = (item?: Fluent.PivotItem) => {
         const name = item?.props.itemKey
         if (!name) return
+        m.value = name
         setSelected(name)
         if (name.startsWith('#')) {
           window.location.hash = name.substring(1)
@@ -84,7 +85,12 @@ export const
       tabs = m.items?.map(t => <Fluent.PivotItem key={t.name} itemIcon={t.icon} itemKey={t.name} headerText={t.label} />),
       [selected, setSelected] = React.useState(m.value)
 
-    React.useEffect(() => setSelected(m.value), [m.value])
+    React.useEffect(() => {
+      setSelected(m.value)
+      if (!m.value) wave.args[m.name] = null
+      else if (m.value.startsWith('#')) window.location.hash = m.value.substring(1)
+      else if (m.name && m.value !== wave.args[m.name]) wave.args[m.name] = m.value
+    }, [m.name, m.value])
 
     return (
       <div className={css.pivot}>

--- a/ui/src/tabs.tsx
+++ b/ui/src/tabs.tsx
@@ -64,33 +64,29 @@ const
 export const
   XTabs = ({ model: m }: { model: Tabs }) => {
     const
-      handleArgs = (name?: S, trigger: B = false) => {
-        if (!name) return
-        if (name.startsWith('#')) window.location.hash = name.substring(1)
-        else if (m.name) {
-          if (name === wave.args[m.name]) return
-          wave.args[m.name] = name
-          if (trigger) wave.push()
-        } else {
-          if (wave.args[name] === true) return
-          wave.args[name] = true
-          if (trigger) wave.push()
-        }
-      },
       onLinkClick = (item?: Fluent.PivotItem) => {
         const name = item?.props.itemKey
         if (!name) return
-        m.value = name
         setSelected(name)
-        handleArgs(name, true)
+        m.value = name
+        if (name.startsWith('#')) {
+          window.location.hash = name.substring(1)
+          return
+        }
+        if (m.name) {
+          if (name !== selected) {
+            wave.args[m.name] = name
+            wave.push()
+          }
+        } else {
+          wave.args[name] = true
+          wave.push()
+        }
       },
       tabs = m.items?.map(t => <Fluent.PivotItem key={t.name} itemIcon={t.icon} itemKey={t.name} headerText={t.label} />),
-      [selected, setSelected] = React.useState(m.value)
+      [selected, setSelected] = React.useState(m.value || m.items?.[0].name)
 
-    useUpdateOnlyEffect(() => {
-      setSelected(m.value)
-      handleArgs(m.value)
-    }, [m.name, m.value])
+    useUpdateOnlyEffect(() => setSelected(m.value), [m.value])
 
     return (
       <div className={css.pivot}>


### PR DESCRIPTION
**The PR fulfills these requirements:** (check all that apply)

- [x] It's submitted to the `main` branch.
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `feat: Add a button #xxx`, where "xxx" is the issue number).
- [x] When resolving a specific issue, the PR description includes `Closes #xxx`, where "xxx" is the issue number.
- [x] If changes were made to `ui` folder, unit tests (`make test`) still pass.
- [x] New/updated tests are included

___

This PR addresses all issues found after final revision of #1154. Included issues are:

- **Checklist** - set values to `None`, select value manually, set values to `None` once again (unable to set to `None`)
- **Tabs** - dynamic value change is fully supported for `ui.tab_card` only, but not for `ui.tabs` - try to set value dynamically, select tab manually, set value dynamically to the same value as before (Tab is not switching)
- **Combobox single/multi** - when `choices` are set to `None` it leads to endless loop
- **Dropdown - dialog single/multi** - when `choices` are set to `None` it leads to endless loop
- **Nav** - user was unable to dynamically unselect all items by specifying `value=None` within the Wave app when component was initially rendered with some value

Also this PR adjusts the behavior of Nav/Tab/Tabs in following manner:
- Revert behavior for Menu - when value is set to `None`, no item is active
- Keep behavior for Tab/Tabs - when value is set to `None`, first item is active by default - we are not bringing support for #1776 
- Args setting is consistent

Closes #1154 
Closes #1776 

