### PR TITLE
fix: Clear dirty UI state across clients on broadcast/multicast user interaction for consistency. #1705

### DIFF
--- a/protocol.go
+++ b/protocol.go
@@ -22,6 +22,7 @@ type OpsD struct {
 	U string `json:"u,omitempty"` // redirect
 	E string `json:"e,omitempty"` // error
 	M *Meta  `json:"m,omitempty"` // metadata
+	C int    `json:"c,omitempty"` // clear UI state
 }
 
 // Meta represents metadata unrelated to commands

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -194,6 +194,7 @@ interface OpsD {
     u: S // active user's username
     e: B // can the user edit pages?
   }
+  c?: U // clear UI state
 }
 interface OpD {
   k?: S
@@ -327,6 +328,8 @@ export enum WaveEventType {
   Page,
   /** Daemon sent some data. */
   Data,
+  /** Daemon asked to clear any dirty state. */
+  Clear,
 }
 
 /** */
@@ -348,10 +351,13 @@ export type WaveEvent = {
   t: WaveEventType.Disconnect, retry: U
 } | {
   t: WaveEventType.Data
+} | {
+  t: WaveEventType.Clear
 }
 const
   connectEvent: WaveEvent = { t: WaveEventType.Connect },
   resetEvent: WaveEvent = { t: WaveEventType.Reset },
+  clearEvent: WaveEvent = { t: WaveEventType.Clear },
   dataEvent: WaveEvent = { t: WaveEventType.Data }
 
 type WaveEventHandler = (e: WaveEvent) => void
@@ -976,6 +982,8 @@ export const
                 handle({ t: WaveEventType.Page, page })
               } else if (msg.e) {
                 handle({ t: WaveEventType.Error, code: errorCodes[msg.e] || WaveErrorCode.Unknown })
+              } else if (msg.c) {
+                handle(clearEvent)
               } else if (msg.r) {
                 handle(resetEvent)
               } else if (msg.u) {

--- a/ui/src/ui.ts
+++ b/ui/src/ui.ts
@@ -141,6 +141,9 @@ export const
         case WaveEventType.Data:
           busyB(false)
           break
+        case WaveEventType.Clear:
+          clearRec(args)
+          break
       }
     })
   },
@@ -149,7 +152,7 @@ export const
 
     // Unconditionally set location hash so that the app doesn't have to track changes.
     const h = window.location.hash
-    if (h?.length > 1) args['#'] = h.substr(1)
+    if (h?.length > 1) args['#'] = h.substring(1)
 
     const d: Dict<any> = { ...args } // shallow clone
     clearRec(args) // clear


### PR DESCRIPTION
The root cause of the problem described in the corresponding issue was:

* Client1 renders a form with value.
* UI changes are propagated to the rest of connected clients, (client2).
* UI state is set as dirty in the browser side, due to explicit textbox value. State is same across all clients.
* Client1 clicks the button, q.args with the correct state (btn + textbox) is submitted and cleared.
* UI changes are propagated to all the clients again, but now client1 has fresh UI state, while client2 has the old one still as there was no user interaction that would submit and clear the local args (local state).

This PR sends a clear event to all the connected clients whenever user interaction happens on any of them.

Closes #1705