### PR TITLE
ci: Use latest Qemu as docker runtime to fix nightly macos jobs.

### DIFF
--- a/.github/workflows/release-wave-nightly.yml
+++ b/.github/workflows/release-wave-nightly.yml
@@ -122,9 +122,7 @@ jobs:
 
       - name: Install docker
         run: |
-          curl -OSL https://raw.githubusercontent.com/Homebrew/homebrew-core/dc0669eca9479e9eeb495397ba3a7480aaa45c2e/Formula/qemu.rb
-          brew unlink qemu
-          brew install ./qemu.rb
+          brew install qemu
           brew install docker
           colima start
 


### PR DESCRIPTION
Updates Qemu to the latest version.