### PR TITLE
chore: Use maximum available space in ui.inline instead of hardcoded constant. #1974

### DIFF
--- a/py/examples/background_progress.py
+++ b/py/examples/background_progress.py
@@ -44,7 +44,7 @@ async def serve(q: Q):
     # Unimportant, draw initial UI.
     if not q.client.initialized:
         q.page['form'] = ui.form_card(box='1 1 3 2', items=[
-            ui.inline([
+            ui.buttons([
                 ui.button(name='start_job', label='Start job'),
                 ui.button(name='cancel', label='Cancel')
             ]),

--- a/py/examples/form_visibility.py
+++ b/py/examples/form_visibility.py
@@ -12,7 +12,7 @@ async def serve(q: Q):
             ui.text_l(name='text_l', content='Second text'),
             ui.text_m(name='text_m', content='Third text'),
             ui.text_s(name='text_s', content='Fourth text'),
-            ui.inline([
+            ui.buttons([
                 ui.button(name='left1', label='Left1'),
                 ui.button(name='left2', label='Left2'),
                 ui.button(name='left3', label='Left3'),

--- a/ui/src/form.tsx
+++ b/ui/src/form.tsx
@@ -261,7 +261,7 @@ export const
             key={name || `${componentKey}-${i}`}
             data-visible={visible}
             className={height === '1' ? css.fullHeight : ''}
-            style={{ ...visibleStyles, width, alignSelf, flexGrow: shouldParentGrow ? 1 : undefined }}
+            style={{ ...visibleStyles, width, minWidth: width, alignSelf, flexGrow: shouldParentGrow ? 1 : undefined }}
           >
             <XComponent model={m} />
           </div>

--- a/ui/src/form.tsx
+++ b/ui/src/form.tsx
@@ -283,7 +283,7 @@ export const
     <XComponents
       items={m.items}
       justify={m.justify}
-      align={m.align || m.direction === 'row' ? 'center' : undefined}
+      align={m.align || (m.direction === 'row' ? 'center' : undefined)}
       inset={m.inset}
       height={m.height}
       direction={m.direction || 'row'}

--- a/ui/src/header.tsx
+++ b/ui/src/header.tsx
@@ -16,13 +16,13 @@ import * as Fluent from '@fluentui/react'
 import { B, Box, box, Model, S } from 'h2o-wave'
 import React from 'react'
 import { stylesheet } from 'typestyle'
-import { Component, XInline } from './form'
+import { Component, XComponents } from './form'
 import { CardEffect, cards, getEffectClass, toCardEffect } from './layout'
 import { NavGroup, XNav } from './nav'
+import { Z_INDEX } from './parts/styleConstants'
 import { centerMixin, clas, cssVar, important, padding, px } from './theme'
 import { Command } from './toolbar'
 import { bond } from './ui'
-import { Z_INDEX } from './parts/styleConstants'
 
 const css = stylesheet({
   card: {
@@ -141,8 +141,12 @@ export const View = bond(({ name, state, changed }: Model<State & { commands: Co
               {subtitle && <div className={clas(css.nudgeUp, 'wave-s12')}>{subtitle}</div>}
             </div>
           </div>
-          {secondary_items && <div className={css.center}><XInline model={{ items: secondary_items }} /></div>}
-          {items && <div style={{ zIndex: Z_INDEX.HEADER, marginRight: state.commands ? 30 : undefined }}><XInline model={{ items }} /></div>}
+          {secondary_items && <div className={css.center}><XComponents items={secondary_items} justify='start' align='center' direction='row' /></div>}
+          {items && (
+            <div style={{ zIndex: Z_INDEX.HEADER, marginRight: state.commands ? 30 : undefined }}>
+              <XComponents items={items} justify='start' align='center' direction='row' />
+            </div>
+          )}
           {nav && <Navigation items={nav} isOpenB={navB} />}
         </div>
       )

--- a/website/widgets/form/inline.md
+++ b/website/widgets/form/inline.md
@@ -21,6 +21,8 @@ q.page['form'] = ui.form_card(
 )
 ```
 
+All components will try to take all the available space by default. This behavior can be controlled by specifying `width` and `height` component properties explicitly.
+
 Check the full API at [ui.inline](/docs/api/ui#inline).
 
 ## Horizontal alignment (`justify`)
@@ -71,7 +73,7 @@ It's also possible to specify `1` to fill the remaining card space. Useful for d
 ```py
 q.page['example'] = ui.form_card(box='1 1 -1 -1', items=[
     ui.inline(
-        items=[ui.text('I am in the perfect center!')], 
+        items=[ui.text('I am in the perfect center!')],
         justify='center',
         align='center',
         height='1'
@@ -93,6 +95,7 @@ q.page['example'] = ui.form_card(box='1 1 -1 3', items=[
         items=[
             ui.inline(
                 direction='column',
+                align='center',
                 items=[
                     ui.text_l(content='Sub title 1'),
                     ui.text(content='Lorem ipsum dolor sit amet'),
@@ -100,6 +103,7 @@ q.page['example'] = ui.form_card(box='1 1 -1 3', items=[
             ),
             ui.inline(
                 direction='column',
+                align='center',
                 items=[
                     ui.text_l(content='Sub title 2'),
                     ui.text(content='Lorem ipsum dolor sit amet'),
@@ -107,6 +111,7 @@ q.page['example'] = ui.form_card(box='1 1 -1 3', items=[
             ),
             ui.inline(
                 direction='column',
+                align='center',
                 items=[
                     ui.text_l(content='Sub title 3'),
                     ui.text(content='Lorem ipsum dolor sit amet'),


### PR DESCRIPTION
@marek-mihok - can you make a code review and a thorough QA to check if everything works as expected?

This is a rewrite of #1988 for #1974.

The reason some components shrunk drastically was wrong use of default `align='center` for case when `direction='column'`. This PR sets the following defaults:

* All components should try to occupy all the available space unless explicitly specified otherwise. This rule is in sync with regular `form_card.items`.
* The above default does not apply for cases when explicit alignment for main axis (`justify`) is chosen. In such case, the default width should correspond to the component's content, be it a label or anything else.