### PR TITLE
fix: Use proper path for wave fetch. #2177

### DIFF
--- a/py/h2o_wave/hatch_build.py
+++ b/py/h2o_wave/hatch_build.py
@@ -42,7 +42,7 @@ class CustomBuildHook(BuildHookInterface):
         with open(os.path.join('h2o_wave', 'metadata.py'), 'w') as f:
             f.write(f'''
 # Generated in hatch_build.py.
-__platform__ = "{platform}"
+__platform__ = "{operating_system}"
 __arch__ = "{arch}"
         ''')
 


### PR DESCRIPTION
URL generated for fetching should be  of the format: `wave-{version}-{operating_system}-{arch}`

But the fetch url being generated was using `platform` instead of the `operating_system`.

Since this variable is set on the build time. Changed the `hatch_build.py` file. This will also change the `metadata.py` file that gets generated.

Closes h2oai#2177

**The PR fulfills these requirements:** (check all the apply)

- [x] It's submitted to the `main` branch.
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `feat: Add a button #xxx`, where "xxx" is the issue number).
- [ ] When resolving a specific issue, the PR description includes `Closes #xxx`, where "xxx" is the issue number.
- [ ] If changes were made to `ui` folder, unit tests (`make test`) still pass.
- [ ] New/updated tests are included
