### PR TITLE
fix: Do not show selected tags in picker suggestions when no input is provided #1985

### DIFF
--- a/ui/src/picker.test.tsx
+++ b/ui/src/picker.test.tsx
@@ -160,15 +160,20 @@ describe('Picker.tsx', () => {
   })
 
   it('Filters correctly - does not offer already selected - without input provided', () => {
-    const { getByRole, queryByRole } = render(<XPicker model={pickerProps} />)
+    const { getByRole, queryByRole, getAllByRole } = render(<XPicker model={pickerProps} />)
     const input = (getByRole('combobox') as HTMLInputElement)
 
+    fireEvent.click(input)
+    expect(getAllByRole('option')).toHaveLength(2)
     typeToInput(input, name)
     fireEvent.click(getByRole('option'))
+
+    fireEvent.click(input)
+    expect(getAllByRole('option')).toHaveLength(1)
     typeToInput(input, altName)
     fireEvent.click(getByRole('option'))
-    fireEvent.click(input)
 
+    fireEvent.click(input)
     expect(queryByRole('option')?.querySelector('.ms-Suggestions-none')).toBeInTheDocument()
   })
 

--- a/ui/src/picker.test.tsx
+++ b/ui/src/picker.test.tsx
@@ -148,13 +148,26 @@ describe('Picker.tsx', () => {
     expect(getAllByRole('option')).toHaveLength(1)
   })
 
-  it('Filters correctly - does not offer already selected', () => {
+  it('Filters correctly - does not offer already selected - with input provided', () => {
     const { getByRole, queryByRole } = render(<XPicker model={pickerProps} />)
     const input = (getByRole('combobox') as HTMLInputElement)
 
     typeToInput(input, name)
     fireEvent.click(getByRole('option'))
     typeToInput(input, name)
+
+    expect(queryByRole('option')?.querySelector('.ms-Suggestions-none')).toBeInTheDocument()
+  })
+
+  it('Filters correctly - does not offer already selected - without input provided', () => {
+    const { getByRole, queryByRole } = render(<XPicker model={pickerProps} />)
+    const input = (getByRole('combobox') as HTMLInputElement)
+
+    typeToInput(input, name)
+    fireEvent.click(getByRole('option'))
+    typeToInput(input, altName)
+    fireEvent.click(getByRole('option'))
+    fireEvent.click(input)
 
     expect(queryByRole('option')?.querySelector('.ms-Suggestions-none')).toBeInTheDocument()
   })

--- a/ui/src/picker.tsx
+++ b/ui/src/picker.tsx
@@ -67,7 +67,7 @@ export const XPicker = ({ model: m }: { model: Picker }) => {
       wave.args[m.name] = items ? items.map(({ key }) => key) : null
       if (m.trigger) wave.push()
     },
-    onEmptyResolveSuggestions = () => tags
+    onEmptyResolveSuggestions = () => tags.filter(tag => !selectedTags.includes(tag))
 
   React.useEffect(() => {
     wave.args[m.name] = m.values || null


### PR DESCRIPTION
**The PR fulfills these requirements:** (check all the apply)

- [x] It's submitted to the `main` branch.
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `feat: Add a button #xxx`, where "xxx" is the issue number).
- [x] When resolving a specific issue, the PR description includes `Closes #xxx`, where "xxx" is the issue number.
- [x] If changes were made to `ui` folder, unit tests (`make test`) still pass.
- [x] New/updated tests are included
___ 

The problem was the implementation of `onEmptyResolveSuggestions` callback. As Fluent API description says, it is

> A callback for what should happen when suggestions are shown without input provided. Returns the already selected items so the resolver can filter them out.

In our case it was returning initial tags (`() => tags`) instead of filtered ones.

https://github.com/h2oai/wave/assets/23740173/6c7ab461-ca83-418a-bed7-3c3d166d6b89

Closes #1985 
