### PR TITLE
fix: Raise error if waved cannot find public/private dir #2130

### DIFF
--- a/server.go
+++ b/server.go
@@ -22,6 +22,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
 	"path"
 	"path/filepath"
 	"strings"
@@ -70,6 +71,13 @@ func printLaunchBar(addr, baseURL string, isTLS bool) {
 	log.Println("# └" + bar + "┘")
 }
 
+// check if the directory is accessible
+func checkDirectory(path string) {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		log.Fatalf("Directory does not exist: %s", path)
+	}
+}
+
 // Run runs the HTTP server.
 func Run(conf ServerConf) {
 	for _, line := range strings.Split(fmt.Sprintf(logo, conf.Version, conf.BuildDate), "\n") {
@@ -113,20 +121,15 @@ func Run(conf ServerConf) {
 	handle("_f/", newFileServer(fileDir, conf.Keychain, auth, conf.BaseURL+"_f"))
 	for _, dir := range conf.PrivateDirs {
 
+		checkDirectory(dir)
 		prefix, src := splitDirMapping(dir)
-		err := newDirServer(src, conf.Keychain, auth)
-		if err != nil {
-			log.Fatalf("Failed to start server due to directory issue: %v", err)
-		}
 		echo(Log{"t": "private_dir", "source": src, "address": prefix})
 		handle(prefix, http.StripPrefix(conf.BaseURL+prefix, newDirServer(src, conf.Keychain, auth)))
 	}
 	for _, dir := range conf.PublicDirs {
+
+		checkDirectory(dir)
 		prefix, src := splitDirMapping(dir)
-		err := newDirServer(src, conf.Keychain, auth)
-		if err != nil {
-			log.Fatalf("Failed to start server due to directory issue: %v", err)
-		}
 		echo(Log{"t": "public_dir", "source": src, "address": prefix})
 		handle(prefix, http.StripPrefix(conf.BaseURL+prefix, http.FileServer(http.Dir(src))))
 	}

--- a/server.go
+++ b/server.go
@@ -112,12 +112,21 @@ func Run(conf ServerConf) {
 	fileDir := filepath.Join(conf.DataDir, "f")
 	handle("_f/", newFileServer(fileDir, conf.Keychain, auth, conf.BaseURL+"_f"))
 	for _, dir := range conf.PrivateDirs {
+
 		prefix, src := splitDirMapping(dir)
+		err := newDirServer(src, conf.Keychain, auth)
+		if err != nil {
+			log.Fatalf("Failed to start server due to directory issue: %v", err)
+		}
 		echo(Log{"t": "private_dir", "source": src, "address": prefix})
 		handle(prefix, http.StripPrefix(conf.BaseURL+prefix, newDirServer(src, conf.Keychain, auth)))
 	}
 	for _, dir := range conf.PublicDirs {
 		prefix, src := splitDirMapping(dir)
+		err := newDirServer(src, conf.Keychain, auth)
+		if err != nil {
+			log.Fatalf("Failed to start server due to directory issue: %v", err)
+		}
 		echo(Log{"t": "public_dir", "source": src, "address": prefix})
 		handle(prefix, http.StripPrefix(conf.BaseURL+prefix, http.FileServer(http.Dir(src))))
 	}

--- a/server.go
+++ b/server.go
@@ -186,6 +186,11 @@ func splitDirMapping(m string) (string, string) {
 		xs[0] = xs[0][2:]
 	}
 
+	// Check if the directory is accessible
+	if _, err := os.Stat(xs[1]); os.IsNotExist(err) {
+		panic(fmt.Sprintf("Directory does not exist: %s", xs[1]))
+	}
+
 	return strings.TrimLeft(xs[0], "/"), xs[1]
 }
 


### PR DESCRIPTION
**The PR fulfills these requirements:** (check all the apply)

- [x] It's submitted to the `main` branch.
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `feat: Add a button #xxx`, where "xxx" is the issue number).
- [x] When resolving a specific issue, the PR description includes `Closes #xxx`, where "xxx" is the issue number.
- [ ] If changes were made to `ui` folder, unit tests (`make test`) still pass.
- [ ] New/updated tests are included


Related issue #2130 

Overview: 
This pull request addresses the issue #2130 , where waved would start without error even if the specified public/private directories were missing or incorrectly configured. The changes introduce error checking during server startup to ensure these directories exist and are accessible.

Changes: 
- Added a `checkDirectory` function in `server.go` to validate the existence of public and private directories.
- Integrated directory checks during the server initialization phase.
- Server now fails to start with a clear error message if either directory is missing or inaccessible.

Testing
- Tested server startup with current directory paths, an error message is seen on the terminal.
<img width="713" alt="Screenshot 2023-12-06 at 2 37 48 PM" src="https://github.com/h2oai/wave/assets/122259338/3faced30-721d-43d6-9c93-cda3e3b4addf">

Closes #2130

