### PR TITLE
fix/feat: Adjust progress_table_cell_type not to increase table row height #1921

### DIFF
--- a/py/examples/table.py
+++ b/py/examples/table.py
@@ -43,7 +43,7 @@ columns = [
     ui.table_column(name='status', label='Status', filterable=True),
     ui.table_column(name='done', label='Done', cell_type=ui.icon_table_cell_type()),
     ui.table_column(name='views', label='Views', sortable=True, data_type='number'),
-    ui.table_column(name='progress', label='Progress', cell_type=ui.progress_table_cell_type(type='spinner')),
+    ui.table_column(name='progress', label='Progress', cell_type=ui.progress_table_cell_type(type='bar')),
     ui.table_column(name='tag', label='State', min_width='170px', cell_type=ui.tag_table_cell_type(name='tags', tags=[
                     ui.tag(label='RUNNING', color='#D2E3F8'),
                     ui.tag(label='DONE', color='$red'),

--- a/py/examples/table.py
+++ b/py/examples/table.py
@@ -43,7 +43,7 @@ columns = [
     ui.table_column(name='status', label='Status', filterable=True),
     ui.table_column(name='done', label='Done', cell_type=ui.icon_table_cell_type()),
     ui.table_column(name='views', label='Views', sortable=True, data_type='number'),
-    ui.table_column(name='progress', label='Progress', cell_type=ui.progress_table_cell_type()),
+    ui.table_column(name='progress', label='Progress', cell_type=ui.progress_table_cell_type(type='bar')),
     ui.table_column(name='tag', label='State', min_width='170px', cell_type=ui.tag_table_cell_type(name='tags', tags=[
                     ui.tag(label='RUNNING', color='#D2E3F8'),
                     ui.tag(label='DONE', color='$red'),

--- a/py/examples/table.py
+++ b/py/examples/table.py
@@ -43,7 +43,7 @@ columns = [
     ui.table_column(name='status', label='Status', filterable=True),
     ui.table_column(name='done', label='Done', cell_type=ui.icon_table_cell_type()),
     ui.table_column(name='views', label='Views', sortable=True, data_type='number'),
-    ui.table_column(name='progress', label='Progress', cell_type=ui.progress_table_cell_type(type='bar')),
+    ui.table_column(name='progress', label='Progress', cell_type=ui.progress_table_cell_type(type='spinner')),
     ui.table_column(name='tag', label='State', min_width='170px', cell_type=ui.tag_table_cell_type(name='tags', tags=[
                     ui.tag(label='RUNNING', color='#D2E3F8'),
                     ui.tag(label='DONE', color='$red'),

--- a/py/examples/table_progress.py
+++ b/py/examples/table_progress.py
@@ -1,0 +1,40 @@
+# Table / Tags
+# Use tags in order to emphasize a specific value. For multiple tags in a single row use `,` as a delimiter.
+# ---
+import random
+from faker import Faker
+from h2o_wave import main, app, Q, ui
+
+fake = Faker()
+
+_id = 0
+
+
+class Issue:
+    def __init__(self, text: str, progress: float):
+        global _id
+        _id += 1
+        self.id = f'I{_id}'
+        self.text = text
+        self.progress = progress
+
+
+# Create some issues
+issues = [Issue(text=fake.sentence(), progress=random.random()) for i in range(10)]
+
+columns = [
+    ui.table_column(name='text', label='Issue', min_width='400px'),
+    ui.table_column(name='progress', label='Progress', cell_type=ui.progress_table_cell_type(compact=True)),
+]
+
+
+@app('/demo')
+async def serve(q: Q):
+    q.page['example'] = ui.form_card(box='1 1 -1 -1', items=[
+        ui.table(
+            name='issues',
+            columns=columns,
+            rows=[ui.table_row(name=issue.id, cells=[issue.text, str(issue.progress)]) for issue in issues],
+        )
+    ])
+    await q.page.save()

--- a/py/h2o_lightwave/h2o_lightwave/types.py
+++ b/py/h2o_lightwave/h2o_lightwave/types.py
@@ -3060,27 +3060,27 @@ class ProgressTableCellType:
             self,
             color: Optional[str] = None,
             name: Optional[str] = None,
-            type: Optional[str] = None,
+            compact: Optional[bool] = None,
     ):
         _guard_scalar('ProgressTableCellType.color', color, (str,), False, True, False)
         _guard_scalar('ProgressTableCellType.name', name, (str,), False, True, False)
-        _guard_scalar('ProgressTableCellType.type', type, (str,), False, True, False)
+        _guard_scalar('ProgressTableCellType.compact', compact, (bool,), False, True, False)
         self.color = color
         """Color of the progress arc/bar."""
         self.name = name
         """An identifying name for this component."""
-        self.type = type
-        """The type of progress cell to be displayed. One of 'bar', 'spinner'. Defaults to 'spinner'."""
+        self.compact = compact
+        """True if the component should be displayed compactly as a bar. Defaults to False."""
 
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""
         _guard_scalar('ProgressTableCellType.color', self.color, (str,), False, True, False)
         _guard_scalar('ProgressTableCellType.name', self.name, (str,), False, True, False)
-        _guard_scalar('ProgressTableCellType.type', self.type, (str,), False, True, False)
+        _guard_scalar('ProgressTableCellType.compact', self.compact, (bool,), False, True, False)
         return _dump(
             color=self.color,
             name=self.name,
-            type=self.type,
+            compact=self.compact,
         )
 
     @staticmethod
@@ -3090,15 +3090,15 @@ class ProgressTableCellType:
         _guard_scalar('ProgressTableCellType.color', __d_color, (str,), False, True, False)
         __d_name: Any = __d.get('name')
         _guard_scalar('ProgressTableCellType.name', __d_name, (str,), False, True, False)
-        __d_type: Any = __d.get('type')
-        _guard_scalar('ProgressTableCellType.type', __d_type, (str,), False, True, False)
+        __d_compact: Any = __d.get('compact')
+        _guard_scalar('ProgressTableCellType.compact', __d_compact, (bool,), False, True, False)
         color: Optional[str] = __d_color
         name: Optional[str] = __d_name
-        type: Optional[str] = __d_type
+        compact: Optional[bool] = __d_compact
         return ProgressTableCellType(
             color,
             name,
-            type,
+            compact,
         )
 
 

--- a/py/h2o_lightwave/h2o_lightwave/types.py
+++ b/py/h2o_lightwave/h2o_lightwave/types.py
@@ -3060,21 +3060,27 @@ class ProgressTableCellType:
             self,
             color: Optional[str] = None,
             name: Optional[str] = None,
+            type: Optional[str] = None,
     ):
         _guard_scalar('ProgressTableCellType.color', color, (str,), False, True, False)
         _guard_scalar('ProgressTableCellType.name', name, (str,), False, True, False)
+        _guard_scalar('ProgressTableCellType.type', type, (str,), False, True, False)
         self.color = color
         """Color of the progress arc."""
         self.name = name
         """An identifying name for this component."""
+        self.type = type
+        """The type of progress bar to show"""
 
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""
         _guard_scalar('ProgressTableCellType.color', self.color, (str,), False, True, False)
         _guard_scalar('ProgressTableCellType.name', self.name, (str,), False, True, False)
+        _guard_scalar('ProgressTableCellType.type', self.type, (str,), False, True, False)
         return _dump(
             color=self.color,
             name=self.name,
+            type=self.type,
         )
 
     @staticmethod
@@ -3084,11 +3090,15 @@ class ProgressTableCellType:
         _guard_scalar('ProgressTableCellType.color', __d_color, (str,), False, True, False)
         __d_name: Any = __d.get('name')
         _guard_scalar('ProgressTableCellType.name', __d_name, (str,), False, True, False)
+        __d_type: Any = __d.get('type')
+        _guard_scalar('ProgressTableCellType.type', __d_type, (str,), False, True, False)
         color: Optional[str] = __d_color
         name: Optional[str] = __d_name
+        type: Optional[str] = __d_type
         return ProgressTableCellType(
             color,
             name,
+            type,
         )
 
 

--- a/py/h2o_lightwave/h2o_lightwave/ui.py
+++ b/py/h2o_lightwave/h2o_lightwave/ui.py
@@ -1167,7 +1167,7 @@ def file_upload(
 def progress_table_cell_type(
         color: Optional[str] = None,
         name: Optional[str] = None,
-        type: Optional[str] = None,
+        compact: Optional[bool] = None,
 ) -> TableCellType:
     """Create a cell type that renders a column's cells as progress bars instead of plain text.
     If set on a column, the cell value must be between 0.0 and 1.0.
@@ -1175,14 +1175,14 @@ def progress_table_cell_type(
     Args:
         color: Color of the progress arc/bar.
         name: An identifying name for this component.
-        type: The type of progress cell to be displayed. One of 'bar', 'spinner'. Defaults to 'spinner'.
+        type: True if the component should be displayed compactly as a bar. Defaults to False.
     Returns:
         A `h2o_wave.types.ProgressTableCellType` instance.
     """
     return TableCellType(progress=ProgressTableCellType(
         color,
         name,
-        type,
+        compact,
     ))
 
 

--- a/py/h2o_lightwave/h2o_lightwave/ui.py
+++ b/py/h2o_lightwave/h2o_lightwave/ui.py
@@ -1175,7 +1175,7 @@ def progress_table_cell_type(
     Args:
         color: Color of the progress arc/bar.
         name: An identifying name for this component.
-        type: True if the component should be displayed compactly as a bar. Defaults to False.
+        compact: True if the component should be displayed compactly as a bar. Defaults to False.
     Returns:
         A `h2o_wave.types.ProgressTableCellType` instance.
     """

--- a/py/h2o_lightwave/h2o_lightwave/ui.py
+++ b/py/h2o_lightwave/h2o_lightwave/ui.py
@@ -1167,6 +1167,7 @@ def file_upload(
 def progress_table_cell_type(
         color: Optional[str] = None,
         name: Optional[str] = None,
+        type: Optional[str] = None,
 ) -> TableCellType:
     """Create a cell type that renders a column's cells as progress bars instead of plain text.
     If set on a column, the cell value must be between 0.0 and 1.0.
@@ -1180,6 +1181,7 @@ def progress_table_cell_type(
     return TableCellType(progress=ProgressTableCellType(
         color,
         name,
+        type,
     ))
 
 

--- a/py/h2o_wave/h2o_wave/types.py
+++ b/py/h2o_wave/h2o_wave/types.py
@@ -3094,7 +3094,7 @@ class ProgressTableCellType:
         _guard_scalar('ProgressTableCellType.compact', __d_compact, (bool,), False, True, False)
         color: Optional[str] = __d_color
         name: Optional[str] = __d_name
-        compact: Optional[str] = __d_compact
+        compact: Optional[bool] = __d_compact
         return ProgressTableCellType(
             color,
             name,

--- a/py/h2o_wave/h2o_wave/types.py
+++ b/py/h2o_wave/h2o_wave/types.py
@@ -3060,21 +3060,27 @@ class ProgressTableCellType:
             self,
             color: Optional[str] = None,
             name: Optional[str] = None,
+            type: Optional[str] = None,
     ):
         _guard_scalar('ProgressTableCellType.color', color, (str,), False, True, False)
         _guard_scalar('ProgressTableCellType.name', name, (str,), False, True, False)
+        _guard_scalar('ProgressTableCellType.type', type, (str,), False, True, False)
         self.color = color
         """Color of the progress arc."""
         self.name = name
         """An identifying name for this component."""
+        self.type = type
+        """The type of progress bar to show"""
 
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""
         _guard_scalar('ProgressTableCellType.color', self.color, (str,), False, True, False)
         _guard_scalar('ProgressTableCellType.name', self.name, (str,), False, True, False)
+        _guard_scalar('ProgressTableCellType.type', self.type, (str,), False, True, False)
         return _dump(
             color=self.color,
             name=self.name,
+            type=self.type,
         )
 
     @staticmethod
@@ -3084,11 +3090,15 @@ class ProgressTableCellType:
         _guard_scalar('ProgressTableCellType.color', __d_color, (str,), False, True, False)
         __d_name: Any = __d.get('name')
         _guard_scalar('ProgressTableCellType.name', __d_name, (str,), False, True, False)
+        __d_type: Any = __d.get('type')
+        _guard_scalar('ProgressTableCellType.type', __d_type, (str,), False, True, False)
         color: Optional[str] = __d_color
         name: Optional[str] = __d_name
+        type: Optional[str] = __d_type
         return ProgressTableCellType(
             color,
             name,
+            type,
         )
 
 

--- a/py/h2o_wave/h2o_wave/types.py
+++ b/py/h2o_wave/h2o_wave/types.py
@@ -3060,27 +3060,27 @@ class ProgressTableCellType:
             self,
             color: Optional[str] = None,
             name: Optional[str] = None,
-            type: Optional[str] = None,
+            compact: Optional[bool] = None,
     ):
         _guard_scalar('ProgressTableCellType.color', color, (str,), False, True, False)
         _guard_scalar('ProgressTableCellType.name', name, (str,), False, True, False)
-        _guard_scalar('ProgressTableCellType.type', type, (str,), False, True, False)
+        _guard_scalar('ProgressTableCellType.compact', compact, (bool,), False, True, False)
         self.color = color
         """Color of the progress arc/bar."""
         self.name = name
         """An identifying name for this component."""
-        self.type = type
-        """The type of progress cell to be displayed. One of 'bar', 'spinner'. Defaults to 'spinner'."""
+        self.compact = compact
+        """True if the component should be displayed compactly as a bar. Defaults to False."""
 
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""
         _guard_scalar('ProgressTableCellType.color', self.color, (str,), False, True, False)
         _guard_scalar('ProgressTableCellType.name', self.name, (str,), False, True, False)
-        _guard_scalar('ProgressTableCellType.type', self.type, (str,), False, True, False)
+        _guard_scalar('ProgressTableCellType.compact', self.compact, (bool,), False, True, False)
         return _dump(
             color=self.color,
             name=self.name,
-            type=self.type,
+            compact=self.compact,
         )
 
     @staticmethod
@@ -3090,15 +3090,15 @@ class ProgressTableCellType:
         _guard_scalar('ProgressTableCellType.color', __d_color, (str,), False, True, False)
         __d_name: Any = __d.get('name')
         _guard_scalar('ProgressTableCellType.name', __d_name, (str,), False, True, False)
-        __d_type: Any = __d.get('type')
-        _guard_scalar('ProgressTableCellType.type', __d_type, (str,), False, True, False)
+        __d_compact: Any = __d.get('compact')
+        _guard_scalar('ProgressTableCellType.compact', __d_compact, (bool,), False, True, False)
         color: Optional[str] = __d_color
         name: Optional[str] = __d_name
-        type: Optional[str] = __d_type
+        compact: Optional[str] = __d_compact
         return ProgressTableCellType(
             color,
             name,
-            type,
+            compact,
         )
 
 

--- a/py/h2o_wave/h2o_wave/ui.py
+++ b/py/h2o_wave/h2o_wave/ui.py
@@ -1167,6 +1167,7 @@ def file_upload(
 def progress_table_cell_type(
         color: Optional[str] = None,
         name: Optional[str] = None,
+        type: Optional[str] = None,
 ) -> TableCellType:
     """Create a cell type that renders a column's cells as progress bars instead of plain text.
     If set on a column, the cell value must be between 0.0 and 1.0.
@@ -1180,6 +1181,7 @@ def progress_table_cell_type(
     return TableCellType(progress=ProgressTableCellType(
         color,
         name,
+        type,
     ))
 
 

--- a/py/h2o_wave/h2o_wave/ui.py
+++ b/py/h2o_wave/h2o_wave/ui.py
@@ -1167,7 +1167,7 @@ def file_upload(
 def progress_table_cell_type(
         color: Optional[str] = None,
         name: Optional[str] = None,
-        type: Optional[str] = None,
+        compact: Optional[bool] = None,
 ) -> TableCellType:
     """Create a cell type that renders a column's cells as progress bars instead of plain text.
     If set on a column, the cell value must be between 0.0 and 1.0.
@@ -1175,14 +1175,14 @@ def progress_table_cell_type(
     Args:
         color: Color of the progress arc/bar.
         name: An identifying name for this component.
-        type: The type of progress cell to be displayed. One of 'bar', 'spinner'. Defaults to 'spinner'.
+        compact: True if the component should be displayed compactly as a bar. Defaults to False.
     Returns:
         A `h2o_wave.types.ProgressTableCellType` instance.
     """
     return TableCellType(progress=ProgressTableCellType(
         color,
         name,
-        type,
+        compact,
     ))
 
 

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -1389,14 +1389,15 @@ ui_file_upload <- function(
 #' @export
 ui_progress_table_cell_type <- function(
   color = NULL,
-  name = NULL, 
+  name = NULL,
   compact = NULL) {
   .guard_scalar("color", "character", color)
   .guard_scalar("name", "character", name)
   .guard_scalar("compact", "logical", compact)
   .o <- list(progress=list(
     color=color,
-    name=name))
+    name=name,
+    compact=compact))
   class(.o) <- append(class(.o), c(.wave_obj, "WaveTableCellType"))
   return(.o)
 }

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -1384,16 +1384,16 @@ ui_file_upload <- function(
 #'
 #' @param color Color of the progress arc/bar.
 #' @param name An identifying name for this component.
-#' @param type The type of progress cell to be displayed. One of 'bar', 'spinner'. Defaults to 'spinner'.
+#' @param compact True if the component should be displayed compactly as a bar. Defaults to False.
 #' @return A ProgressTableCellType instance.
 #' @export
 ui_progress_table_cell_type <- function(
   color = NULL,
   name = NULL, 
-  type = NULL) {
+  compact = NULL) {
   .guard_scalar("color", "character", color)
   .guard_scalar("name", "character", name)
-  .guard_scalar("type", "character", type)
+  .guard_scalar("compact", "logical", compact)
   .o <- list(progress=list(
     color=color,
     name=name))

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -1388,9 +1388,11 @@ ui_file_upload <- function(
 #' @export
 ui_progress_table_cell_type <- function(
   color = NULL,
-  name = NULL) {
+  name = NULL, 
+  type = NULL) {
   .guard_scalar("color", "character", color)
   .guard_scalar("name", "character", name)
+  .guard_scalar("type", "character", type)
   .o <- list(progress=list(
     color=color,
     name=name))

--- a/tools/intellij-plugin/src/main/resources/templates/wave-components.xml
+++ b/tools/intellij-plugin/src/main/resources/templates/wave-components.xml
@@ -2091,9 +2091,10 @@
       <option name="Python" value="true"/>
     </context>
   </template>
-  <template name="w_full_progress_table_cell_type" value="ui.progress_table_cell_type(color='$color$',name='$name$'),$END$" description="Create Wave ProgressTableCellType with full attributes." toReformat="true" toShortenFQNames="true">
+  <template name="w_full_progress_table_cell_type" value="ui.progress_table_cell_type(color='$color$',name='$name$,type='$type$'),$END$" description="Create Wave ProgressTableCellType with full attributes." toReformat="true" toShortenFQNames="true">
     <variable name="color" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="name" expression="" defaultValue="" alwaysStopAt="true"/>
+    <variable name="type" expression="" defaultValue="spinner" alwaysStopAt="true"/>
     <context>
       <option name="Python" value="true"/>
     </context>

--- a/tools/intellij-plugin/src/main/resources/templates/wave-components.xml
+++ b/tools/intellij-plugin/src/main/resources/templates/wave-components.xml
@@ -2091,10 +2091,10 @@
       <option name="Python" value="true"/>
     </context>
   </template>
-  <template name="w_full_progress_table_cell_type" value="ui.progress_table_cell_type(color='$color$',name='$name$,type='$type$'),$END$" description="Create Wave ProgressTableCellType with full attributes." toReformat="true" toShortenFQNames="true">
+  <template name="w_full_progress_table_cell_type" value="ui.progress_table_cell_type(color='$color$',name='$name$,compact='$compact$'),$END$" description="Create Wave ProgressTableCellType with full attributes." toReformat="true" toShortenFQNames="true">
     <variable name="color" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="name" expression="" defaultValue="" alwaysStopAt="true"/>
-    <variable name="type" expression="" defaultValue="spinner" alwaysStopAt="true"/>
+    <variable name="compact" expression="" defaultValue="" alwaysStopAt="true"/>
     <context>
       <option name="Python" value="true"/>
     </context>

--- a/tools/intellij-plugin/src/main/resources/templates/wave-components.xml
+++ b/tools/intellij-plugin/src/main/resources/templates/wave-components.xml
@@ -2091,10 +2091,10 @@
       <option name="Python" value="true"/>
     </context>
   </template>
-  <template name="w_full_progress_table_cell_type" value="ui.progress_table_cell_type(color='$color$',name='$name$,compact='$compact$'),$END$" description="Create Wave ProgressTableCellType with full attributes." toReformat="true" toShortenFQNames="true">
+  <template name="w_full_progress_table_cell_type" value="ui.progress_table_cell_type(color='$color$',name='$name$',compact=$compact$),$END$" description="Create Wave ProgressTableCellType with full attributes." toReformat="true" toShortenFQNames="true">
     <variable name="color" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="name" expression="" defaultValue="" alwaysStopAt="true"/>
-    <variable name="compact" expression="" defaultValue="" alwaysStopAt="true"/>
+    <variable name="compact" expression="" defaultValue="&quot;False&quot;" alwaysStopAt="true"/>
     <context>
       <option name="Python" value="true"/>
     </context>

--- a/tools/vscode-extension/component-snippets.json
+++ b/tools/vscode-extension/component-snippets.json
@@ -1570,7 +1570,7 @@
   "Wave Full ProgressTableCellType": {
     "prefix": "w_full_progress_table_cell_type",
     "body": [
-      "ui.progress_table_cell_type(color='$1', name='$2'),$0"
+      "ui.progress_table_cell_type(color='$1', name='$2', compact=${3:False}),$0"
     ],
     "description": "Create a full Wave ProgressTableCellType."
   },

--- a/ui/src/progress_table_cell_type.tsx
+++ b/ui/src/progress_table_cell_type.tsx
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import * as Fluent from '@fluentui/react'
-import { F, S } from './core'
+import { B, F, S } from './core'
 import React from 'react'
 import { stylesheet } from 'typestyle'
 import { ProgressArc } from './parts/progress_arc'
@@ -62,14 +62,13 @@ export interface ProgressTableCellType {
   /** An identifying name for this component. */
   name?: S
   
-  // TO DO: use compact (boolean) instead of type
-  /**  The type of progress cell to be displayed. One of 'bar', 'spinner'. Defaults to 'spinner'. */
-  type?: 'bar' | 'spinner'
+  /** True if the component should be displayed compactly as a bar. Defaults to False (spinner). */
+  compact?: B
 }
 
 export const XProgressTableCellType = ({ model: m, progress }: { model: ProgressTableCellType, progress: F }) => (
   <div data-test={m.name}>
-    {m.type === 'bar' ? (
+    {m.compact ? (
       <div className={css.barContainer}>
         <div className={css.bar}>
           <ProgressBar thickness={2} color={cssVar(m.color || '$red')} value={progress}/>

--- a/ui/src/progress_table_cell_type.tsx
+++ b/ui/src/progress_table_cell_type.tsx
@@ -62,7 +62,7 @@ export interface ProgressTableCellType {
   /** An identifying name for this component. */
   name?: S
   
-  /** True if the component should be displayed compactly as a bar. Defaults to False (spinner). */
+  /** True if the component should be displayed compactly as a bar. Defaults to False. */
   compact?: B
 }
 

--- a/ui/src/progress_table_cell_type.tsx
+++ b/ui/src/progress_table_cell_type.tsx
@@ -25,37 +25,31 @@ const
     barContainer: {
       position: 'relative',
       display: 'inline-flex',
-      width: 100,
+    },
+
+    bar: {
+      width: 50,
+    },
+
+    barPercent: {
+      marginLeft: 50,
     },
 
     spinnerContainer: {
       position: 'relative',
-      display: 'inline-flex',
-      width: 100,
-      height: 50
+      width: 50,
+      height: 50,
+    },
+
+    percentContainer: {
+      position: 'absolute',
+      top: 0, left: 0, bottom: 0, right: 0,
     },
     
-    bar: {
-      position: 'absolute',
-      top: '50%', left: 0,
-      width: 50,
-    },
-
-    spinner: {
-      position: 'absolute',
-      top: 0, left: 0, bottom: 0, right: 0,
-      width: 50,
-      height: 50
-    },
-   
-    barPercent: {
-      position: 'absolute',
-      top: 0, left: 0, bottom: 0, right: 0,
-    },
-
     percent: {
       color: cssVar('$text6')
     },
+
   })
 
 /**
@@ -67,6 +61,8 @@ export interface ProgressTableCellType {
   color?: S
   /** An identifying name for this component. */
   name?: S
+  
+  // TO DO: use compact (boolean) instead of type
   /**  The type of progress cell to be displayed. One of 'bar', 'spinner'. Defaults to 'spinner'. */
   type?: 'bar' | 'spinner'
 }
@@ -76,18 +72,18 @@ export const XProgressTableCellType = ({ model: m, progress }: { model: Progress
     {m.type === 'bar' ? (
       <div className={css.barContainer}>
         <div className={css.bar}>
-          <ProgressBar thickness={2} color={cssVar(m.color || '$red')} value={progress} />
+          <ProgressBar thickness={2} color={cssVar(m.color || '$red')} value={progress}/>
         </div>
-        <Fluent.Stack horizontalAlign='end' verticalAlign='center' className={clas(css.barPercent, 'wave-s12')}>
-          <div className={css.percent}>{`${Math.round(progress * 100)}%`}</div>
-        </Fluent.Stack> 
+        <div className={css.barPercent}>
+          <Fluent.Stack horizontalAlign='end' verticalAlign='center' className={clas(css.percentContainer, 'wave-s12')}>
+            <div className={css.percent}>{`${Math.round(progress * 100)}%`}</div>
+          </Fluent.Stack>
+        </div> 
       </div>
     ) : (
       <div className={css.spinnerContainer}>
-        <div className={css.spinner}> 
-          <ProgressArc thickness={2} color={cssVar(m.color || '$red')} value={progress} />
-        </div>
-        <Fluent.Stack horizontalAlign='center' verticalAlign='center' className={clas(css.spinner, 'wave-s12')}>
+        <ProgressArc thickness={2} color={cssVar(m.color || '$red')} value={progress} />
+        <Fluent.Stack horizontalAlign='center' verticalAlign='center' className={clas(css.percentContainer, 'wave-s12')}>
           <div className={css.percent}>{`${Math.round(progress * 100)}%`}</div>
         </Fluent.Stack>
       </div>

--- a/ui/src/progress_table_cell_type.tsx
+++ b/ui/src/progress_table_cell_type.tsx
@@ -17,6 +17,7 @@ import { F, S } from './core'
 import React from 'react'
 import { stylesheet } from 'typestyle'
 import { ProgressArc } from './parts/progress_arc'
+import { ProgressBar } from './parts/progress_bar'
 import { clas, cssVar } from './theme'
 
 const
@@ -44,11 +45,14 @@ export interface ProgressTableCellType {
   color?: S
   /** An identifying name for this component. */
   name?: S
+  /**  The type of progress cell to be displayed. One of 'bar', 'spinner'. Defaults to 'spinner'. */
+  type?: 'bar' | 'spinner'
 }
 
 export const XProgressTableCellType = ({ model: m, progress }: { model: ProgressTableCellType, progress: F }) => (
   <div data-test={m.name} className={css.container}>
-    <ProgressArc thickness={2} color={cssVar(m.color || '$red')} value={progress} />
+    {m.type === 'bar' ? <ProgressBar thickness={2} color={cssVar(m.color || '$red')} value={progress} /> :
+    <ProgressArc thickness={2} color={cssVar(m.color || '$red')} value={progress} /> }
     <Fluent.Stack horizontalAlign='center' verticalAlign='center' className={clas(css.percentContainer, 'wave-s12')}>
       <div className={css.percent}>{`${Math.round(progress * 100)}%`}</div>
     </Fluent.Stack>

--- a/ui/src/progress_table_cell_type.tsx
+++ b/ui/src/progress_table_cell_type.tsx
@@ -22,31 +22,35 @@ import { clas, cssVar } from './theme'
 
 const
   css = stylesheet({
-    container: {
+    barContainer: {
+      position: 'relative',
+      display: 'inline-flex',
+      width: 100,
+    },
+
+    spinnerContainer: {
       position: 'relative',
       display: 'inline-flex',
       width: 100,
       height: 50
     },
     
-    barContainer: {
+    bar: {
       position: 'absolute',
       top: '50%', left: 0,
       width: 50,
-      height: 50
     },
 
-    spinnerContainer: {
+    spinner: {
       position: 'absolute',
       top: 0, left: 0, bottom: 0, right: 0,
       width: 50,
       height: 50
     },
    
-    barPercentContainer: {
+    barPercent: {
       position: 'absolute',
       top: 0, left: 0, bottom: 0, right: 0,
-      height: 50,
     },
 
     percent: {
@@ -68,28 +72,25 @@ export interface ProgressTableCellType {
 }
 
 export const XProgressTableCellType = ({ model: m, progress }: { model: ProgressTableCellType, progress: F }) => (
-  <div data-test={m.name} className={css.container}>
-    <div>
-      {m.type === 'bar' ? (
-        <div className={css.barContainer}>
+  <div data-test={m.name}>
+    {m.type === 'bar' ? (
+      <div className={css.barContainer}>
+        <div className={css.bar}>
           <ProgressBar thickness={2} color={cssVar(m.color || '$red')} value={progress} />
         </div>
-      ) : (
-        <div className={css.spinnerContainer}> 
+        <Fluent.Stack horizontalAlign='end' verticalAlign='center' className={clas(css.barPercent, 'wave-s12')}>
+          <div className={css.percent}>{`${Math.round(progress * 100)}%`}</div>
+        </Fluent.Stack> 
+      </div>
+    ) : (
+      <div className={css.spinnerContainer}>
+        <div className={css.spinner}> 
           <ProgressArc thickness={2} color={cssVar(m.color || '$red')} value={progress} />
         </div>
-      )}
-
-      {m.type === 'bar' ? (
-        <Fluent.Stack horizontalAlign='end' verticalAlign='center' className={clas(css.barPercentContainer, 'wave-s12')}>
+        <Fluent.Stack horizontalAlign='center' verticalAlign='center' className={clas(css.spinner, 'wave-s12')}>
           <div className={css.percent}>{`${Math.round(progress * 100)}%`}</div>
         </Fluent.Stack>
-      ) : (
-        <Fluent.Stack horizontalAlign='center' verticalAlign='center' className={clas(css.spinnerContainer, 'wave-s12')}>
-          <div className={css.percent}>{`${Math.round(progress * 100)}%`}</div>
-        </Fluent.Stack>
-      )}
-
-    </div>
+      </div>
+    )}
   </div>
 )

--- a/ui/src/progress_table_cell_type.tsx
+++ b/ui/src/progress_table_cell_type.tsx
@@ -24,13 +24,31 @@ const
   css = stylesheet({
     container: {
       position: 'relative',
+      display: 'inline-flex',
+      width: 100,
+      height: 50
+    },
+    
+    barContainer: {
+      position: 'absolute',
+      top: '50%', left: 0,
       width: 50,
       height: 50
     },
-    percentContainer: {
+
+    spinnerContainer: {
       position: 'absolute',
-      top: 0, left: 0, bottom: 0, right: 0
+      top: 0, left: 0, bottom: 0, right: 0,
+      width: 50,
+      height: 50
     },
+   
+    barPercentContainer: {
+      position: 'absolute',
+      top: 0, left: 0, bottom: 0, right: 0,
+      height: 50,
+    },
+
     percent: {
       color: cssVar('$text6')
     },
@@ -51,10 +69,27 @@ export interface ProgressTableCellType {
 
 export const XProgressTableCellType = ({ model: m, progress }: { model: ProgressTableCellType, progress: F }) => (
   <div data-test={m.name} className={css.container}>
-    {m.type === 'bar' ? <ProgressBar thickness={2} color={cssVar(m.color || '$red')} value={progress} /> :
-    <ProgressArc thickness={2} color={cssVar(m.color || '$red')} value={progress} /> }
-    <Fluent.Stack horizontalAlign='center' verticalAlign='center' className={clas(css.percentContainer, 'wave-s12')}>
-      <div className={css.percent}>{`${Math.round(progress * 100)}%`}</div>
-    </Fluent.Stack>
-  </div >
+    <div>
+      {m.type === 'bar' ? (
+        <div className={css.barContainer}>
+          <ProgressBar thickness={2} color={cssVar(m.color || '$red')} value={progress} />
+        </div>
+      ) : (
+        <div className={css.spinnerContainer}> 
+          <ProgressArc thickness={2} color={cssVar(m.color || '$red')} value={progress} />
+        </div>
+      )}
+
+      {m.type === 'bar' ? (
+        <Fluent.Stack horizontalAlign='end' verticalAlign='center' className={clas(css.barPercentContainer, 'wave-s12')}>
+          <div className={css.percent}>{`${Math.round(progress * 100)}%`}</div>
+        </Fluent.Stack>
+      ) : (
+        <Fluent.Stack horizontalAlign='center' verticalAlign='center' className={clas(css.spinnerContainer, 'wave-s12')}>
+          <div className={css.percent}>{`${Math.round(progress * 100)}%`}</div>
+        </Fluent.Stack>
+      )}
+
+    </div>
+  </div>
 )

--- a/website/widgets/form/table.md
+++ b/website/widgets/form/table.md
@@ -330,6 +330,7 @@ q.page['example'] = ui.form_card(box='1 1 3 3', items=[
         ],
         rows=[
             ui.table_row(name='row1', cells=['Process1', '.70']),
+            ui.table_row(name='row2', cells=['Process2', '.25']),
         ])
 ])
 ```
@@ -347,6 +348,7 @@ q.page['example'] = ui.form_card(box='1 1 3 3', items=[
         ],
         rows=[
             ui.table_row(name='row1', cells=['Process1', '.70']),
+            ui.table_row(name='row2', cells=['Process2', '.25']),
         ])
 ])
 ```

--- a/website/widgets/form/table.md
+++ b/website/widgets/form/table.md
@@ -315,6 +315,42 @@ q.page['example'] = ui.form_card(box='1 1 3 3', items=[
 ])
 ```
 
+## With progress arc/bar
+
+Use a progress arc/bar to display a percentage. Defaults as a progress arc.
+
+```py
+q.page['example'] = ui.form_card(box='1 1 3 3', items=[
+    ui.table(
+        name='table', 
+        columns=[
+            ui.table_column(name='text', label='Process'),
+            ui.table_column(name='tag', label='Progress', 
+                cell_type=ui.progress_table_cell_type())
+        ],
+        rows=[
+            ui.table_row(name='row1', cells=['Process1', '.70']),
+        ])
+])
+```
+
+For a progress bar, set the `compact` attribute to `True`.
+
+```py
+q.page['example'] = ui.form_card(box='1 1 3 3', items=[
+    ui.table(
+        name='table', 
+        columns=[
+            ui.table_column(name='text', label='Process'),
+            ui.table_column(name='tag', label='Progress', 
+                cell_type=ui.progress_table_cell_type(compact=True))
+        ],
+        rows=[
+            ui.table_row(name='row1', cells=['Process1', '.70']),
+        ])
+])
+```
+
 ## With tags
 
 Use tags to emphasize a specific value, usually an enum value like a certain state for example. For multiple tags in a single row use `,` as a delimiter.


### PR DESCRIPTION
**The PR fulfills these requirements:** (check all the apply)

- [x] It's submitted to the `main` branch.
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `feat: Add a button #xxx`, where "xxx" is the issue number).
- [x] When resolving a specific issue, the PR description includes `Closes #xxx`, where "xxx" is the issue number.
- [x] If changes were made to `ui` folder, unit tests (`make test`) still pass.
- [ ] New/updated tests are included
---
@kellyycha and I fixed this issue by adding a new keyword argument `type` in the progress_table_cell_type that allows users to implement a bar style progress cell with the progress value indicated to the left of the bar, reducing the height of the row.

This is how the [table.py](../blob/master/py/examples/table.py) example looks originally:
![Screenshot 2023-12-06 at 12 14 35 PM](https://github.com/h2oai/wave/assets/84979255/3fe33b47-f58c-428e-9859-1c1667da6612)

Without the Progress column, the row height would look like this, which has a row height that is noticeably shorter than with the Progress:
<img width="1701" alt="Screen Shot 2023-12-06 at 1 21 50 AM" src="https://github.com/h2oai/wave/assets/84979255/c3b32ffd-09e9-4ea1-97ed-f96cdd5292ec">

Our implementation results in a bar that looks like the following and maintains a similar row height to the row without a progress cell:
![Screenshot 2023-12-06 at 12 14 21 PM](https://github.com/h2oai/wave/assets/84979255/24d795bf-987e-446e-9814-ad7f64879ac2)

We default `type` to the spinner/arc progress indicator so that previously implemented tables will continue to look the same.

The UI and unit tests still pass:
<img width="407" alt="Screen Shot 2023-12-06 at 7 25 58 PM" src="https://github.com/h2oai/wave/assets/84979255/f83e1837-a76f-44c0-8687-aee14dd6dde0">
<img width="427" alt="Screen Shot 2023-12-06 at 7 26 39 PM" src="https://github.com/h2oai/wave/assets/84979255/e7f3613f-09e9-483c-a0cf-d7d795a6e195">

Closes #1921 


