### PR TITLE
feat: Allow installing custom packages inside Wave Studio #2193

### DIFF
--- a/studio/static/studio.css
+++ b/studio/static/studio.css
@@ -15,6 +15,22 @@
   background-color: #ffffff;
 }
 
+span[data-test="pip_logs"] pre {
+  height: 80vh;
+  background-color: #282b2e;
+}
+
+span[data-test="pip_logs"] pre>code {
+  display: flex;
+  max-height: 80vh;
+}
+
+span[data-test="pip_logs"] code>code {
+  white-space: pre-wrap;
+  display: flex;
+  flex-direction: column-reverse;
+}
+
 #files {
   position: relative;
   font-family: 'Inter', sans-serif;

--- a/studio/studio.js
+++ b/studio/studio.js
@@ -28,13 +28,8 @@ const snippetToCompletionItem = item => ({
   insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
 })
 const capitalize = str => str.charAt(0).toUpperCase() + str.slice(1)
-const setLogsHeight = () => {
-  const logs = document.querySelector('span[data-test="pip_logs"]').parentElement
-  logs.style.maxHeight = '80vh'
-  logs.style.overflowY = 'scroll'
-}
-const scrollLogsToBottom = (elementSelector) => {
-  const logs = document.querySelector(elementSelector).parentElement
+const scrollLogsToBottom = () => {
+  const logs = document.querySelector('div[data-test="logs"]').parentElement
   logs.scrollTop = logs.scrollHeight
 }
 require(['vs/editor/editor.main', 'pyodide'], async () => {

--- a/studio/studio.js
+++ b/studio/studio.js
@@ -28,6 +28,15 @@ const snippetToCompletionItem = item => ({
   insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
 })
 const capitalize = str => str.charAt(0).toUpperCase() + str.slice(1)
+const setPipLogsHeight = () => {
+  const pipLogs = document.querySelector('span[data-test="pip_logs"]').parentElement
+  pipLogs.style.maxHeight = '80vh'
+  pipLogs.style.overflowY = 'scroll'
+}
+const scrollPipLogsToBottom = () => {
+  const pipLogs = document.querySelector('span[data-test="pip_logs"]').parentElement
+  pipLogs.scrollTop = pipLogs.scrollHeight
+}
 const scrollLogsToBottom = () => {
   const logs = document.querySelector('div[data-test="logs"]').parentElement
   logs.scrollTop = logs.scrollHeight

--- a/studio/studio.js
+++ b/studio/studio.js
@@ -28,17 +28,13 @@ const snippetToCompletionItem = item => ({
   insertTextRules: monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
 })
 const capitalize = str => str.charAt(0).toUpperCase() + str.slice(1)
-const setPipLogsHeight = () => {
-  const pipLogs = document.querySelector('span[data-test="pip_logs"]').parentElement
-  pipLogs.style.maxHeight = '80vh'
-  pipLogs.style.overflowY = 'scroll'
+const setLogsHeight = () => {
+  const logs = document.querySelector('span[data-test="pip_logs"]').parentElement
+  logs.style.maxHeight = '80vh'
+  logs.style.overflowY = 'scroll'
 }
-const scrollPipLogsToBottom = () => {
-  const pipLogs = document.querySelector('span[data-test="pip_logs"]').parentElement
-  pipLogs.scrollTop = pipLogs.scrollHeight
-}
-const scrollLogsToBottom = () => {
-  const logs = document.querySelector('div[data-test="logs"]').parentElement
+const scrollLogsToBottom = (elementSelector) => {
+  const logs = document.querySelector(elementSelector).parentElement
   logs.scrollTop = logs.scrollHeight
 }
 require(['vs/editor/editor.main', 'pyodide'], async () => {

--- a/studio/studio.py
+++ b/studio/studio.py
@@ -249,7 +249,8 @@ def get_output(output: str) -> str:
 '''
 
 def get_package_dialog_items():
-    packages_installed =  os.path.isfile('project/requirements.txt') and os.path.getsize('project/requirements.txt') > 0
+    file = open('project/requirements.txt', 'r') if os.path.exists('project/requirements.txt') else None
+    packages_installed =  os.stat("project/requirements.txt").st_size > 0 if file else False
     return [
         ui.text_l('Installed packages'),
         ui.inline(

--- a/studio/studio.py
+++ b/studio/studio.py
@@ -438,10 +438,7 @@ async def serve(q: Q):
         q.client.initialized = True
         await render_code(q)
 
-    if q.args.dropdown:
-        q.user.view = q.args.dropdown
-        q.page['header'].items[2].dropdown.value = q.args.dropdown
-    elif q.args.export_project:
+    if q.args.export_project:
         await export(q)
     elif q.args.import_project:
         q.page['meta'].dialog = ui.dialog(name='dialog', title='Import Project', events=['dismissed'], closable=True,
@@ -504,15 +501,17 @@ async def serve(q: Q):
         q.client.task.cancel()
     elif q.args.finish_message_dismiss:
         await on_pip_finish(q)
-    elif q.args.dropdown == 'code':
-        q.page['preview'].box = ui.box('main', width='0px')
-        q.page['code'].box = ui.box('main', width='100%')
-    elif q.args.dropdown == 'split':
-        q.page['preview'].box = ui.box('main', width='100%')
-        q.page['code'].box = ui.box('main', width='100%')
-    elif q.args.dropdown == 'preview':
-        q.page['preview'].box = ui.box('main', width='100%')
-        q.page['code'].box = ui.box('main', width='0px')
+    elif q.args.dropdown:
+        q.user.view = q.args.dropdown
+        if q.args.dropdown == 'code':
+            q.page['preview'].box = ui.box('main', width='0px')
+            q.page['code'].box = ui.box('main', width='100%')
+        if q.args.dropdown == 'split':
+            q.page['preview'].box = ui.box('main', width='100%')
+            q.page['code'].box = ui.box('main', width='100%')
+        if q.args.dropdown == 'preview':
+            q.page['preview'].box = ui.box('main', width='100%')
+            q.page['code'].box = ui.box('main', width='0px')
     elif q.args.console:
         q.page['preview'].box = ui.box('main', width='100%')
         q.page['code'].box = ui.box('main', width='0px')

--- a/studio/studio.py
+++ b/studio/studio.py
@@ -177,7 +177,7 @@ async def display_logs(q: Q) -> None:
             lines.append(line.decode('utf8'))
             code = ''.join(lines)
             q.page['logs'].content = f'```\n{code}\n```'
-            q.page['meta'].script = ui.inline_script('scrollLogsToBottom()')
+            q.page['meta'].script = ui.inline_script('scrollLogsToBottom(\'div[data-test="logs"]\')')
             await q.page.save()
         else:
             await q.sleep(0.5)
@@ -297,12 +297,12 @@ async def show_progress(q: Q, msg: str = ''):
         ui.text(name='pip_logs', content=f'```\n{msg}\n```', width='100%'),
         ui.button(name='cancel_pip_task', label='Cancel')
     ]
-    q.page['meta'].script = ui.inline_script('setPipLogsHeight()')
+    q.page['meta'].script = ui.inline_script('setLogsHeight()')
     await q.page.save()
 
 
 async def update_progress(q: Q, value: int):
-    q.page['meta'].script = ui.inline_script('scrollPipLogsToBottom()')
+    q.page['meta'].script = ui.inline_script('scrollLogsToBottom(\'span[data-test="pip_logs"]\')')
     q.page['meta'].side_panel.items[0].text.content = f'```\n{value}\n```'
     await q.page.save()
 

--- a/studio/studio.py
+++ b/studio/studio.py
@@ -404,7 +404,7 @@ async def on_requirements_install_error():
 
 async def show_packages_dialog(q: Q):
     q.page['meta'].dialog = ui.dialog(
-        name='package_dialog',
+        name='dialog',
         title='Manage packages',
         items=get_package_dialog_items(),
         closable=True,
@@ -489,8 +489,6 @@ async def serve(q: Q):
                 ]
     elif q.args.show_packages_dialog:
         await show_packages_dialog(q)
-    elif q.events.package_dialog and q.events.package_dialog.dismissed:
-        q.page['meta'].dialog = None
     elif q.args.show_add_requirements:
         q.page['meta'].dialog.items[2] = ui.file_upload(name='upload_requirements', file_extensions=['txt'],
                                                         label='Install packages',

--- a/studio/studio.py
+++ b/studio/studio.py
@@ -177,7 +177,7 @@ async def display_logs(q: Q) -> None:
             lines.append(line.decode('utf8'))
             code = ''.join(lines)
             q.page['logs'].content = f'```\n{code}\n```'
-            q.page['meta'].script = ui.inline_script('scrollLogsToBottom(\'div[data-test="logs"]\')')
+            q.page['meta'].script = ui.inline_script('scrollLogsToBottom()')
             await q.page.save()
         else:
             await q.sleep(0.5)
@@ -297,20 +297,18 @@ async def show_progress(q: Q, msg: str = ''):
         ui.text(name='pip_logs', content=f'```\n{msg}\n```', width='100%'),
         ui.button(name='cancel_pip_task', label='Cancel')
     ]
-    q.page['meta'].script = ui.inline_script('setLogsHeight()')
     await q.page.save()
 
 
 async def update_progress(q: Q, value: int | str):
-    q.page['meta'].script = ui.inline_script('scrollLogsToBottom(\'span[data-test="pip_logs"]\')')
     q.page['meta'].side_panel.items[0].text.content = f'```\n{value}\n```'
     await q.page.save()
 
 
 async def show_finish_message(q: Q, type: Literal['error', 'success'], title: str, output: str):
     q.page['meta'].side_panel.items = [
-        ui.message_bar(type=type, text=title),
         ui.text(name='pip_logs', content=f'```\n{output}\n```', width='100%'),
+        ui.message_bar(type=type, text=title),
         ui.button(name='finish_message_dismiss', label='Go to package manager')
     ]
     await q.page.save()

--- a/studio/studio.py
+++ b/studio/studio.py
@@ -492,9 +492,8 @@ async def serve(q: Q):
             q.page['meta'].side_panel.items[2].inline.items[0].textbox.error = 'Package name cannot be empty.'
         else:
             q.client.task = asyncio.create_task(install(q,q.args.package_name,q.args.package_version))
-    elif q.events.table and q.events.table.select:
+    elif q.events.table and q.events.table.select is not None:
         q.client.selected_packages = q.events.table.select
-        # TODO:
         q.page['meta'].side_panel.items[1].button.disabled = not bool(q.events.table.select)
     elif q.args.remove_selected:
         q.client.task = asyncio.create_task(uninstall(q, q.client.selected_packages))

--- a/studio/studio.py
+++ b/studio/studio.py
@@ -432,6 +432,29 @@ async def serve(q: Q):
                 editor.update_file_tree(q, project.dir)
                 await q.page.save()
                 editor.open_file(q, project.entry_point)
+                requirements_file = open('project/requirements.txt', 'r') if os.path.exists('project/requirements.txt') else None
+                if requirements_file:
+                    q.page['meta'].dialog = ui.dialog(
+                        name='package_dialog', 
+                        title='Manage packages', 
+                        items=get_package_dialog_items(), 
+                        closable=True, 
+                        events=['dismissed'],
+                    )
+                    q.page.save()
+                    # Install from requirements.txt
+                    q.client.task = asyncio.create_task(pip(
+                        q, 
+                        'install', 
+                        '-r', 
+                        'project/requirements.txt', 
+                        None, 
+                        'Installing packages from requirements.txt', 
+                        f'Packages from requirements.txt installed successfully.', 
+                        f'Error installing requirements.txt.',
+                        None, 
+                        on_requirements_install_error
+                    ))
             else:
                 q.page['meta'].dialog.items = [
                     ui.message_bar(type='error', text='There must be exactly 1 root folder.'),

--- a/studio/studio.py
+++ b/studio/studio.py
@@ -259,6 +259,7 @@ def get_tab_items(tab_name: str):
                 name='table',
                 multiple=True,
                 events=['select'],
+                height='calc(100vh - 200px)',
                 columns=[
                     ui.table_column(name='package_name', label='Package name'),
                     ui.table_column(name='package_version', label='Version'),
@@ -289,33 +290,27 @@ def get_side_panel_content(tab_name: str = 'installed'):
     return [ ui.tabs(name='tab_menu', value=tab_name, items=tabs) ] + get_tab_items(tab_name)
 
 
-def get_output(output: str) -> str:
-    return f'''
-```
-{output}
-```
-'''
-
-
 async def show_progress(q: Q, msg: str = ''):
     q.page['meta'].side_panel.closable = False
     q.page['meta'].side_panel.blocking = True
     q.page['meta'].side_panel.items = [
-        ui.text(name='console_out', content=get_output(msg), width='100%'),
+        ui.text(name='pip_logs', content=f'```\n{msg}\n```', width='100%'),
         ui.button(name='cancel_pip_task', label='Cancel')
     ]
+    q.page['meta'].script = ui.inline_script('setPipLogsHeight()')
     await q.page.save()
 
 
 async def update_progress(q: Q, value: int):
-    q.page['meta'].side_panel.items[0].text.content = get_output(value)
+    q.page['meta'].script = ui.inline_script('scrollPipLogsToBottom()')
+    q.page['meta'].side_panel.items[0].text.content = f'```\n{value}\n```'
     await q.page.save()
 
 
 async def show_finish_message(q: Q, type: Literal['error', 'success'], title: str, output: str):
     q.page['meta'].side_panel.items = [
         ui.message_bar(type=type, text=title),
-        ui.text(name='console_out', content=get_output(output), width='100%'),
+        ui.text(name='pip_logs', content=f'```\n{output}\n```', width='100%'),
         ui.button(name='finish_message_dismiss', label='Go to package manager')
     ]
     await q.page.save()


### PR DESCRIPTION
**The PR fulfills these requirements:** (check all the apply)

- [x] It's submitted to the `main` branch.
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `feat: Add a button #xxx`, where "xxx" is the issue number).
- [x] When resolving a specific issue, the PR description includes `Closes #xxx`, where "xxx" is the issue number.
- [ ] If changes were made to `ui` folder, unit tests (`make test`) still pass.
- [ ] New/updated tests are included

___

https://github.com/h2oai/wave/assets/23740173/1a7943b5-9471-4615-b33c-99107036e35f

# Code explanation

## The core concept

The core function doing the magic of package installation is our `pip` function which uses `subprocess.Popen`. In contrast to `subprocess.run` waiting for the result, Popen allows us to handle custom logic during its execution. This allows us to read its progress output and show display it to user. For reading the output from within the app, we forward stdout into `subprocess.PIPE`. We also use `text=True` attribute to get output as a string instead of bytes object. 
Popen is used inside context manager to properly close the pipes after the execution and handle other cleanup logic. Inside the Popen context we run the event loop checking whether task is finished. If it is not, it updates the current progress displayed to user. It it is finished - if `p.poll()` has some value - it shows success/error message.
The whole logic is wrapped inside `try` and `except` block to handle UI updates when task is cancelled.

The `pip` function has following arguments: `q: Q, command: str, args: [str], on_success: Callable = None, on_error: Callable = None, on_cancel: Callable = None`. The `q` is used for UI updates, `command` stands for `pip` command, in our case it is `install` or `uninstall`, `args` are additional arguments that can be passed into `pip` command, e.g. `-r` for installing from `requirements.txt` file or `-y` to automatically bypass questions with `yes` answers during uninstall process.

## Step by step

Clicking the button **Manage packages** in header items opens the side panel with the package management interface.

This interface consists of a table of currently installed packages loaded from `project/requirements.txt` file and two buttons - **Add package** and **Add from requirements.txt**. Please note that side panel items are obtained via `get_side_panel_items()` function. Having a separate function is useful when updating side panel with currently installed packages after install/uninstall.

### Installing single package

By clicking on `Add package` the `q.args.show_add_package_fields:` handler part is executed showing `package name` and an optional `package version` fields with the `Add` button triggering the installation process.

When the `Add` button is clicked and the package name field is not empty, the new asyncio task is created inside `q.args.add_package:` handler:
```py
q.client.task = asyncio.create_task(install(q, q.args.package_name, q.args.package_version))
```
Please note that return value is saved into `q.client.task` for having its reference in case one needs to cancel the execution.

The `install` function then calls our `pip` function, blocking the side panel, displaying current console progress to the user and running the `pip install` command.

Once the `pip` finishes successfuly, `on_install_success` is called,
which calls 
```py
update_requirements({f'{package_name}': version(package_name)})
```
The `update_requirements` function adds installed package into `requirements.txt` file if it exists otherwise new one is created. If the package was instaled before, but only the version has changed, the version is updated.

When the install process is finished, the appropriate (error or success) message is shown and one must press `Go back to package manager` button which calls the `q.args.finish_message_dismiss:` handler. The `on_pip_finish()` is called unblocking the side panel, making it closable again and updating it with currently installed packages.

### Installing from requirements.txt

By clicking on `Add from requirements.txt` the `q.args.show_add_requirements:` handler is called showing the file upload component. Once the requirements file is uploaded `q.args.upload_requirements:` handler is called saving the file into `project/requirements.txt` and running the `install` function.

The rest of the process is the same as during single package installation with the 2 differences. The `update_requirements` is called without any parameters just to update the uploaded requirements file with the installed versions. The second difference is that if the installation process fails, the requirements file is removed.

### Uninstalling the package(s)

Select the table rows containing packages you want to uninstall. The `Remove selected` button disabled state is based whether any item is selected using the table `select` event and the `q.events.table and q.events.table.select is not None:` handler. Once the buttons is clicked, `asyncio.create_task(uninstall(q, q.client.selected_packages))` is called.

Closes #2193 
