### PR TITLE
fix: Make conda package support multiple python versions #2227

### DIFF
--- a/.github/workflows/publish-conda.yml
+++ b/.github/workflows/publish-conda.yml
@@ -23,7 +23,10 @@ jobs:
       - name: Publish to Conda
         uses: amauryval/publish_conda_package_action@2.0.3
         with:
-          CondaDir: 'py/conda'
+          CondaDir: 'py/h2o_wave/conda'
           Platforms: 'noarch'
           CondaUsername: ${{ secrets.CONDA_USERNAME }}
           CondaPassword: ${{ secrets.CONDA_PASSWORD }}
+        env:
+          # VERSION clashes with conda build. Use PKG_VERSION instead.
+          PKG_VERSION: ${{ env.VERSION }}

--- a/.github/workflows/release-wave.yml
+++ b/.github/workflows/release-wave.yml
@@ -75,9 +75,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish to Conda
-        uses: amauryval/publish_conda_package_action@1.1.0
+        uses: amauryval/publish_conda_package_action@2.0.3
         with:
           CondaDir: 'py/h2o_wave/conda'
+          Platforms: 'noarch'
           CondaUsername: ${{ secrets.CONDA_USERNAME }}
           CondaPassword: ${{ secrets.CONDA_PASSWORD }}
         env:

--- a/py/h2o_wave/conda/meta.yaml
+++ b/py/h2o_wave/conda/meta.yaml
@@ -26,6 +26,7 @@ source:
   path: ..
 
 build:
+  noarch: python
   script: python -m pip install . -vv
   entry_points:
     {% for module, entrypoints in project['scripts'].items() %}


### PR DESCRIPTION
**The PR fulfills these requirements:** (check all the apply)

- [x] It's submitted to the `main` branch.
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `feat: Add a button #xxx`, where "xxx" is the issue number).
- [x] When resolving a specific issue, the PR description includes `Closes #xxx`, where "xxx" is the issue number.
- [ ] If changes were made to `ui` folder, unit tests (`make test`) still pass.
- [ ] New/updated tests are included
____

The problem was that the package only supports the version of python it was built in. It can be solved by specifying `noarch: python` inside `meta.yaml` conda config file. The result is the single platform independent package supporting multiple python versions.

Also update of the pipeline build action (`amauryval/publish_conda_package_action`) to version 2.0.3 is necessary, because it allows specifying `noarch` value as the `Platforms` parameter.

Closes #2227 
