### PR TITLE
fix: Support up to 1e-20 numbers in ui.spinbox #1525

### DIFF
--- a/ui/src/spinbox.test.tsx
+++ b/ui/src/spinbox.test.tsx
@@ -261,4 +261,69 @@ describe('Spinbox.tsx', () => {
     fireEvent.input(spinboxInput, { target: { value: '0.00011' } })
     expect(spinboxInput).toHaveValue('0.0001')
   })
+
+  it('Accept 1e-7 numbers and smaller', () => {
+    render(<XSpinbox model={{ ...spinboxProps, value: 0.00000001 }} />)
+    expect(wave.args[name]).toBe(0.00000001)
+  })
+
+  it('Increment 1e-7 numbers and smaller', () => {
+    const { container } = render(<XSpinbox model={{ ...spinboxProps, min: 0.00000001, step: 0.00000001, value: 0.00000001 }} />)
+    expect(wave.args[name]).toBe(0.00000001)
+    simulateClick(container.querySelector('.ms-UpButton') as HTMLButtonElement)
+    expect(wave.args[name]).toBe(0.00000002)
+  })
+
+  it('Accept 1e-7 numbers and smaller - scientific notation', () => {
+    render(<XSpinbox model={{ ...spinboxProps, value: 1e-15 }} />)
+    expect(wave.args[name]).toBe(0.000000000000001)
+  })
+
+  it('Accept 1e-7 numbers and smaller - scientific notation', () => {
+    render(<XSpinbox model={{ ...spinboxProps, value: 1e-15 }} />)
+    expect(wave.args[name]).toBe(0.000000000000001)
+  })
+
+  it('Increment 1e-7 numbers and smaller - scientific notation', () => {
+    const { container } = render(<XSpinbox model={{ ...spinboxProps, min: 1e-15, step: 1e-15, value: 1e-15 }} />)
+    expect(wave.args[name]).toBe(0.000000000000001)
+    simulateClick(container.querySelector('.ms-UpButton') as HTMLButtonElement)
+    expect(wave.args[name]).toBe(0.000000000000002)
+  })
+
+  it('Accept 1e7 numbers and greater', () => {
+    render(<XSpinbox model={{ ...spinboxProps, max: 100000000, value: 100000000, }} />)
+    expect(wave.args[name]).toBe(100000000)
+  })
+
+  it('Increment 1e7 numbers and greater', () => {
+    const { container } = render(<XSpinbox model={{ ...spinboxProps, min: 100000000, max: 300000000, step: 100000000, value: 100000000 }} />)
+    expect(wave.args[name]).toBe(100000000)
+    simulateClick(container.querySelector('.ms-UpButton') as HTMLButtonElement)
+    expect(wave.args[name]).toBe(200000000)
+  })
+
+  it('Accept 1e7 numbers and greater - scientific notation', () => {
+    render(<XSpinbox model={{ ...spinboxProps, max: 1e8, value: 1e8 }} />)
+    expect(wave.args[name]).toBe(100000000)
+  })
+
+  it('Increment 1e7 numbers and greater - scientific notation', () => {
+    const { container } = render(<XSpinbox model={{ ...spinboxProps, min: 1e8, max: 3e8, step: 1e8, value: 1e8 }} />)
+    expect(wave.args[name]).toBe(100000000)
+    simulateClick(container.querySelector('.ms-UpButton') as HTMLButtonElement)
+    expect(wave.args[name]).toBe(200000000)
+  })
+
+  it('Do not allow entering decimal point after scientific notation', () => {
+    const { container, getByRole } = render(<XSpinbox model={{ ...spinboxProps, min: 1e-7, step: 1e-7, value: 1e-7 }} />)
+
+    expect(wave.args[name]).toBe(0.0000001)
+    expect(getByRole('spinbutton')).toHaveValue('1e-7')
+
+    fireEvent.input(container.querySelector('.ms-spinButton-input') as HTMLInputElement, { target: { value: '1e-7.' } })
+
+    expect(wave.args[name]).toBe(0.0000001)
+    expect(getByRole('spinbutton')).toHaveValue('1e-7')
+  })
 })

--- a/ui/src/spinbox.tsx
+++ b/ui/src/spinbox.tsx
@@ -52,6 +52,14 @@ const
     const exp = Math.pow(10, precision)
     return Math.round(value * exp) / exp
   },
+  isScientificNotation = /\d+\.?\d*e[+-]*\d+/i,
+  scientificToDecimal = (value: F) => {
+    // Check if value is in scientific notation.
+    return isScientificNotation.test(String(value))
+      // Supports up to 20 digits after the decimal point.
+      ? value.toFixed(20).replace(/\.?0+$/, '')
+      : String(value)
+  },
   // Source: https://github.com/microsoft/fluentui/blob/ecb0e9b12665a05353f64f1b69981584c3addbc0/packages/utilities/src/math.ts#L91.
   calculatePrecision = (value: F) => {
     /**
@@ -60,7 +68,7 @@ const
      * Group 2:
      * \.([0-9]*) matches all digits after a decimal point.
      */
-    const groups = /[1-9]([0]+$)|\.([0-9]*)/.exec(String(value))
+    const groups = /[1-9]([0]+$)|\.([0-9]*)/.exec(scientificToDecimal(value))
     if (!groups) return 0
     return -groups[1]?.length || groups[2]?.length || 0
   }
@@ -101,7 +109,7 @@ export const
               : value
         if (val === '-') setVal('-')
         else if (!precision) setVal(String(newValue).split('.')[0])
-        else if (isLastCharDotOrTraillingZero.test(val)) {
+        else if (isLastCharDotOrTraillingZero.test(val) && !isScientificNotation.test(val)) {
           // We can't use parseValue because it requires casting to number which will remove the trailling zeros.
           const [head, tail = ''] = val.split('.')
           setVal(`${head}.${tail.slice(0, precision)}`)


### PR DESCRIPTION
**The PR fulfills these requirements:** (check all the apply)

- [x] It's submitted to the `main` branch.
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `feat: Add a button #xxx`, where "xxx" is the issue number).
- [x] When resolving a specific issue, the PR description includes `Closes #xxx`, where "xxx" is the issue number.
- [x] If changes were made to `ui` folder, unit tests (`make test`) still pass.
- [x] New/updated tests are included
___ 

The problem was with `calculatePrecision` function not working with scientific (exponential) notation numbers.

The fix converts scientific notation numbers to regular decimal numbers and it uses `Number.toFixed()` for conversion. 

This solution is simple but works for numbers with up to 20 decimal points. To support more decimal points, it would need more complicated solution (something like [this one](https://gist.github.com/jiggzson/b5f489af9ad931e3d186?permalink_comment_id=3723670#gistcomment-3723670) but more reliable).

I think 20 decimal points should be enough for now and if it won't, someone will open the new issue. Wdyt @mturoci ?

Closes #1525 
