### PR TITLE
fix: Make notification close button contrast for any theme #2241

### DIFF
--- a/ui/src/notification_bar.tsx
+++ b/ui/src/notification_bar.tsx
@@ -129,7 +129,7 @@ export const
                 iconContainer: { margin: 0, marginRight: 16, display: 'flex', alignItems: 'center' },
                 text: { margin: 0 },
                 innerText: { whiteSpace: important('initial') },
-                dismissal: { fontSize: 16, height: 'auto', marginLeft: 16, padding: 0, '.ms-Button-flexContainer': { display: 'block' } },
+                dismissal: { fontSize: 16, height: 'auto', marginLeft: 16, padding: 0, '.ms-Button-flexContainer': { display: 'block', '$nest': { '& svg': { fill: color } } } },
                 dismissSingleLine: { display: 'flex' },
                 actions: { margin: 0, marginTop: isMultiline ? 12 : undefined }
               }}


### PR DESCRIPTION
**The PR fulfills these requirements:** (check all the apply)

- [x] It's submitted to the `main` branch.
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `feat: Add a button #xxx`, where "xxx" is the issue number).
- [x] When resolving a specific issue, the PR description includes `Closes #xxx`, where "xxx" is the issue number.
- [x] If changes were made to `ui` folder, unit tests (`make test`) still pass.
- [ ] New/updated tests are included
____

Fix applies notification text color for the close icon.

<img width="708" alt="image" src="https://github.com/h2oai/wave/assets/23740173/348ea7e0-4eb3-496e-8f6a-f371c618be16">


Closes #2241 
