### PR TITLE
feat: Make ui.command to support path and download props #2224

### DIFF
--- a/py/examples/toolbar.py
+++ b/py/examples/toolbar.py
@@ -18,7 +18,7 @@ async def serve(q: Q):
             ),
             ui.command(name='upload', label='Upload', icon='Upload'),
             ui.command(name='share', label='Share', icon='Share'),
-            ui.command(name='download', label='Download', icon='Download'),
+            ui.command(name='download', label='Download', icon='Download', path='https://wave.h2o.ai/img/logo.svg', download=True),
         ],
         secondary_items=[
             ui.command(name='tile', caption='Grid View', icon='Tiles'),

--- a/py/h2o_lightwave/h2o_lightwave/types.py
+++ b/py/h2o_lightwave/h2o_lightwave/types.py
@@ -160,6 +160,8 @@ class Command:
             icon: Optional[str] = None,
             items: Optional[List['Command']] = None,
             value: Optional[str] = None,
+            path: Optional[str] = None,
+            download: Optional[bool] = None,
     ):
         _guard_scalar('Command.name', name, (str,), True, False, False)
         _guard_scalar('Command.label', label, (str,), False, True, False)
@@ -167,6 +169,8 @@ class Command:
         _guard_scalar('Command.icon', icon, (str,), False, True, False)
         _guard_vector('Command.items', items, (Command,), False, True, False)
         _guard_scalar('Command.value', value, (str,), False, True, False)
+        _guard_scalar('Command.path', path, (str,), False, True, False)
+        _guard_scalar('Command.download', download, (bool,), False, True, False)
         self.name = name
         """An identifying name for this component. If the name is prefixed with a '#', the command sets the location hash to the name when executed."""
         self.label = label
@@ -179,6 +183,10 @@ class Command:
         """Sub-commands, if any"""
         self.value = value
         """Data associated with this command, if any."""
+        self.path = path
+        """The path or URL to link to. The 'items' and 'value' props are ignored when specified."""
+        self.download = download
+        """True if the link should prompt the user to save the linked URL instead of navigating to it."""
 
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""
@@ -188,6 +196,8 @@ class Command:
         _guard_scalar('Command.icon', self.icon, (str,), False, True, False)
         _guard_vector('Command.items', self.items, (Command,), False, True, False)
         _guard_scalar('Command.value', self.value, (str,), False, True, False)
+        _guard_scalar('Command.path', self.path, (str,), False, True, False)
+        _guard_scalar('Command.download', self.download, (bool,), False, True, False)
         return _dump(
             name=self.name,
             label=self.label,
@@ -195,6 +205,8 @@ class Command:
             icon=self.icon,
             items=None if self.items is None else [__e.dump() for __e in self.items],
             value=self.value,
+            path=self.path,
+            download=self.download,
         )
 
     @staticmethod
@@ -212,12 +224,18 @@ class Command:
         _guard_vector('Command.items', __d_items, (dict,), False, True, False)
         __d_value: Any = __d.get('value')
         _guard_scalar('Command.value', __d_value, (str,), False, True, False)
+        __d_path: Any = __d.get('path')
+        _guard_scalar('Command.path', __d_path, (str,), False, True, False)
+        __d_download: Any = __d.get('download')
+        _guard_scalar('Command.download', __d_download, (bool,), False, True, False)
         name: str = __d_name
         label: Optional[str] = __d_label
         caption: Optional[str] = __d_caption
         icon: Optional[str] = __d_icon
         items: Optional[List['Command']] = None if __d_items is None else [Command.load(__e) for __e in __d_items]
         value: Optional[str] = __d_value
+        path: Optional[str] = __d_path
+        download: Optional[bool] = __d_download
         return Command(
             name,
             label,
@@ -225,6 +243,8 @@ class Command:
             icon,
             items,
             value,
+            path,
+            download,
         )
 
 

--- a/py/h2o_lightwave/h2o_lightwave/ui.py
+++ b/py/h2o_lightwave/h2o_lightwave/ui.py
@@ -58,6 +58,8 @@ def command(
         icon: Optional[str] = None,
         items: Optional[List[Command]] = None,
         value: Optional[str] = None,
+        path: Optional[str] = None,
+        download: Optional[bool] = None,
 ) -> Command:
     """Create a command.
 
@@ -70,6 +72,8 @@ def command(
         icon: The icon to be displayed for this command.
         items: Sub-commands, if any
         value: Data associated with this command, if any.
+        path: The path or URL to link to. The 'items' and 'value' props are ignored when specified.
+        download: True if the link should prompt the user to save the linked URL instead of navigating to it.
     Returns:
         A `h2o_wave.types.Command` instance.
     """
@@ -80,6 +84,8 @@ def command(
         icon,
         items,
         value,
+        path,
+        download,
     )
 
 

--- a/py/h2o_wave/h2o_wave/types.py
+++ b/py/h2o_wave/h2o_wave/types.py
@@ -160,6 +160,8 @@ class Command:
             icon: Optional[str] = None,
             items: Optional[List['Command']] = None,
             value: Optional[str] = None,
+            path: Optional[str] = None,
+            download: Optional[bool] = None,
     ):
         _guard_scalar('Command.name', name, (str,), True, False, False)
         _guard_scalar('Command.label', label, (str,), False, True, False)
@@ -167,6 +169,8 @@ class Command:
         _guard_scalar('Command.icon', icon, (str,), False, True, False)
         _guard_vector('Command.items', items, (Command,), False, True, False)
         _guard_scalar('Command.value', value, (str,), False, True, False)
+        _guard_scalar('Command.path', path, (str,), False, True, False)
+        _guard_scalar('Command.download', download, (bool,), False, True, False)
         self.name = name
         """An identifying name for this component. If the name is prefixed with a '#', the command sets the location hash to the name when executed."""
         self.label = label
@@ -179,6 +183,10 @@ class Command:
         """Sub-commands, if any"""
         self.value = value
         """Data associated with this command, if any."""
+        self.path = path
+        """The path or URL to link to. The 'items' and 'value' props are ignored when specified."""
+        self.download = download
+        """True if the link should prompt the user to save the linked URL instead of navigating to it."""
 
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""
@@ -188,6 +196,8 @@ class Command:
         _guard_scalar('Command.icon', self.icon, (str,), False, True, False)
         _guard_vector('Command.items', self.items, (Command,), False, True, False)
         _guard_scalar('Command.value', self.value, (str,), False, True, False)
+        _guard_scalar('Command.path', self.path, (str,), False, True, False)
+        _guard_scalar('Command.download', self.download, (bool,), False, True, False)
         return _dump(
             name=self.name,
             label=self.label,
@@ -195,6 +205,8 @@ class Command:
             icon=self.icon,
             items=None if self.items is None else [__e.dump() for __e in self.items],
             value=self.value,
+            path=self.path,
+            download=self.download,
         )
 
     @staticmethod
@@ -212,12 +224,18 @@ class Command:
         _guard_vector('Command.items', __d_items, (dict,), False, True, False)
         __d_value: Any = __d.get('value')
         _guard_scalar('Command.value', __d_value, (str,), False, True, False)
+        __d_path: Any = __d.get('path')
+        _guard_scalar('Command.path', __d_path, (str,), False, True, False)
+        __d_download: Any = __d.get('download')
+        _guard_scalar('Command.download', __d_download, (bool,), False, True, False)
         name: str = __d_name
         label: Optional[str] = __d_label
         caption: Optional[str] = __d_caption
         icon: Optional[str] = __d_icon
         items: Optional[List['Command']] = None if __d_items is None else [Command.load(__e) for __e in __d_items]
         value: Optional[str] = __d_value
+        path: Optional[str] = __d_path
+        download: Optional[bool] = __d_download
         return Command(
             name,
             label,
@@ -225,6 +243,8 @@ class Command:
             icon,
             items,
             value,
+            path,
+            download,
         )
 
 

--- a/py/h2o_wave/h2o_wave/ui.py
+++ b/py/h2o_wave/h2o_wave/ui.py
@@ -58,6 +58,8 @@ def command(
         icon: Optional[str] = None,
         items: Optional[List[Command]] = None,
         value: Optional[str] = None,
+        path: Optional[str] = None,
+        download: Optional[bool] = None,
 ) -> Command:
     """Create a command.
 
@@ -70,6 +72,8 @@ def command(
         icon: The icon to be displayed for this command.
         items: Sub-commands, if any
         value: Data associated with this command, if any.
+        path: The path or URL to link to. The 'items' and 'value' props are ignored when specified.
+        download: True if the link should prompt the user to save the linked URL instead of navigating to it.
     Returns:
         A `h2o_wave.types.Command` instance.
     """
@@ -80,6 +84,8 @@ def command(
         icon,
         items,
         value,
+        path,
+        download,
     )
 
 

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -103,6 +103,8 @@ ui_text <- function(
 #' @param icon The icon to be displayed for this command.
 #' @param items Sub-commands, if any
 #' @param value Data associated with this command, if any.
+#' @param path The path or URL to link to. The 'items' and 'value' props are ignored when specified.
+#' @param download True if the link should prompt the user to save the linked URL instead of navigating to it.
 #' @return A Command instance.
 #' @export
 ui_command <- function(
@@ -111,20 +113,26 @@ ui_command <- function(
   caption = NULL,
   icon = NULL,
   items = NULL,
-  value = NULL) {
+  value = NULL,
+  path = NULL,
+  download = NULL) {
   .guard_scalar("name", "character", name)
   .guard_scalar("label", "character", label)
   .guard_scalar("caption", "character", caption)
   .guard_scalar("icon", "character", icon)
   .guard_vector("items", "WaveCommand", items)
   .guard_scalar("value", "character", value)
+  .guard_scalar("path", "character", path)
+  .guard_scalar("download", "logical", download)
   .o <- list(
     name=name,
     label=label,
     caption=caption,
     icon=icon,
     items=items,
-    value=value)
+    value=value,
+    path=path,
+    download=download)
   class(.o) <- append(class(.o), c(.wave_obj, "WaveCommand"))
   return(.o)
 }

--- a/tools/intellij-plugin/src/main/resources/templates/wave-components.xml
+++ b/tools/intellij-plugin/src/main/resources/templates/wave-components.xml
@@ -2680,12 +2680,14 @@
       <option name="Python" value="true"/>
     </context>
   </template>
-  <template name="w_full_command" value="ui.command(name='$name$',label='$label$',caption='$caption$',icon='$icon$',value='$value$',items=[&#10;	$items$	&#10;]),$END$" description="Create Wave Command with full attributes." toReformat="true" toShortenFQNames="true">
+  <template name="w_full_command" value="ui.command(name='$name$',label='$label$',caption='$caption$',icon='$icon$',value='$value$',path='$path$',download=$download$,items=[&#10;	$items$	&#10;]),$END$" description="Create Wave Command with full attributes." toReformat="true" toShortenFQNames="true">
     <variable name="name" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="label" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="caption" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="icon" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="value" expression="" defaultValue="" alwaysStopAt="true"/>
+    <variable name="path" expression="" defaultValue="" alwaysStopAt="true"/>
+    <variable name="download" expression="" defaultValue="&quot;False&quot;" alwaysStopAt="true"/>
     <variable name="items" expression="" defaultValue="" alwaysStopAt="true"/>
     <context>
       <option name="Python" value="true"/>

--- a/tools/vscode-extension/component-snippets.json
+++ b/tools/vscode-extension/component-snippets.json
@@ -1927,7 +1927,7 @@
   "Wave Full Command": {
     "prefix": "w_full_command",
     "body": [
-      "ui.command(name='$1', label='$2', caption='$3', icon='$4', value='$5', items=[\n\t\t$6\t\t\n]),$0"
+      "ui.command(name='$1', label='$2', caption='$3', icon='$4', value='$5', path='$6', download=${7:False}, items=[\n\t\t$8\t\t\n]),$0"
     ],
     "description": "Create a full Wave Command."
   },

--- a/ui/src/button.test.tsx
+++ b/ui/src/button.test.tsx
@@ -16,7 +16,6 @@ import { fireEvent, render } from '@testing-library/react'
 import React from 'react'
 import { Buttons, MiniButtons, XButtons, XMiniButtons } from './button'
 import { wave } from './ui'
-import userEvent from '@testing-library/user-event'
 
 const
   name = 'test-btn',
@@ -257,7 +256,7 @@ describe('Button.tsx', () => {
       expect(container.querySelector('i[data-icon-name="ChevronDown"]') as HTMLLIElement).not.toBeInTheDocument()
     })
 
-    it('Does not set args and calls sync on click when download link is specified', () => {
+    it('Does not set args and calls sync on click when command has download link specified', () => {
       // TODO: Use "true" only instead of value
       const
         value = 'value',
@@ -292,7 +291,7 @@ describe('Button.tsx', () => {
       expect(pushMock).toHaveBeenCalledTimes(1)
     })
 
-    it('Ignores items when download link is specified', () => {
+    it('Ignores items when command has download link specified', () => {
       const
         btnCommandDownloadProps: Buttons = {
           items: [{
@@ -322,7 +321,7 @@ describe('Button.tsx', () => {
       expect(queryByText('Command item 2')).not.toBeInTheDocument()
     })
 
-    it('Opens link in a new tab when path is specified', () => {
+    it('Opens link in a new tab when command has path specified', () => {
       const windowOpenMock = jest.fn()
       window.open = windowOpenMock
       const

--- a/ui/src/button.test.tsx
+++ b/ui/src/button.test.tsx
@@ -256,7 +256,7 @@ describe('Button.tsx', () => {
       expect(container.querySelector('i[data-icon-name="ChevronDown"]') as HTMLLIElement).not.toBeInTheDocument()
     })
 
-    it('Does not set args and calls sync on click when command has download link specified', () => {
+    it('Does not set args or calls sync on click when command has download link specified', () => {
       const
         btnCommandDownloadProps: Buttons = {
           items: [{

--- a/ui/src/button.test.tsx
+++ b/ui/src/button.test.tsx
@@ -257,17 +257,15 @@ describe('Button.tsx', () => {
     })
 
     it('Does not set args and calls sync on click when command has download link specified', () => {
-      // TODO: Use "true" only instead of value
       const
-        value = 'value',
         btnCommandDownloadProps: Buttons = {
           items: [{
             button: {
               name,
               label: name,
               commands: [
-                { name: 'command1', label: 'Command 1', value },
-                { name: 'command2', label: 'Command 2', path, download: true, value },
+                { name: 'command1', label: 'Command 1' },
+                { name: 'command2', label: 'Command 2', path, download: true },
               ]
             }
           }]
@@ -278,7 +276,7 @@ describe('Button.tsx', () => {
       expect(wave.args['command1']).toBe(false)
       fireEvent.click(contextMenuButton)
       fireEvent.click(getByText('Command 1'))
-      expect(wave.args['command1']).toBe(value)
+      expect(wave.args['command1']).toBe(true)
 
       expect(pushMock).toHaveBeenCalled()
       expect(pushMock).toHaveBeenCalledTimes(1)
@@ -286,7 +284,7 @@ describe('Button.tsx', () => {
       expect(wave.args['command2']).toBe(false)
       fireEvent.click(contextMenuButton)
       fireEvent.click(getByText('Command 2'))
-      expect(wave.args['command2']).not.toBe(value)
+      expect(wave.args['command2']).toBe(false)
 
       expect(pushMock).toHaveBeenCalledTimes(1)
     })

--- a/ui/src/button.test.tsx
+++ b/ui/src/button.test.tsx
@@ -16,6 +16,7 @@ import { fireEvent, render } from '@testing-library/react'
 import React from 'react'
 import { Buttons, MiniButtons, XButtons, XMiniButtons } from './button'
 import { wave } from './ui'
+import userEvent from '@testing-library/user-event'
 
 const
   name = 'test-btn',
@@ -124,6 +125,7 @@ describe('Button.tsx', () => {
   })
 
   describe('Commands button', () => {
+    const path = 'https://wave.h2o.ai/img/logo.svg'
     const buttonProps = {
       items: [{
         button: {
@@ -253,6 +255,96 @@ describe('Button.tsx', () => {
 
       expect(getByTestId(name)).toHaveClass('ms-Link')
       expect(container.querySelector('i[data-icon-name="ChevronDown"]') as HTMLLIElement).not.toBeInTheDocument()
+    })
+
+    it('Does not set args and calls sync on click when download link is specified', () => {
+      // TODO: Use "true" only instead of value
+      const
+        value = 'value',
+        btnCommandDownloadProps: Buttons = {
+          items: [{
+            button: {
+              name,
+              label: name,
+              commands: [
+                { name: 'command1', label: 'Command 1', value },
+                { name: 'command2', label: 'Command 2', path, download: true, value },
+              ]
+            }
+          }]
+        },
+        { container, getByText } = render(<XButtons model={btnCommandDownloadProps} />),
+        contextMenuButton = container.querySelector('i[data-icon-name="ChevronDown"]') as HTMLLIElement
+
+      expect(wave.args['command1']).toBe(false)
+      fireEvent.click(contextMenuButton)
+      fireEvent.click(getByText('Command 1'))
+      expect(wave.args['command1']).toBe(value)
+
+      expect(pushMock).toHaveBeenCalled()
+      expect(pushMock).toHaveBeenCalledTimes(1)
+
+      expect(wave.args['command2']).toBe(false)
+      fireEvent.click(contextMenuButton)
+      fireEvent.click(getByText('Command 2'))
+      expect(wave.args['command2']).not.toBe(value)
+
+      expect(pushMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('Ignores items when download link is specified', () => {
+      const
+        btnCommandDownloadProps: Buttons = {
+          items: [{
+            button: {
+              name,
+              label: name,
+              commands: [
+                { name: 'command1', label: 'Command 1', items: [{ name: 'commandItem1', label: 'Command item 1' }] },
+                { name: 'command2', label: 'Command 2', path, download: true, items: [{ name: 'commandItem2', label: 'Command item 2' }] },
+              ]
+            }
+          }]
+        },
+        { container, queryByText } = render(<XButtons model={btnCommandDownloadProps} />),
+        contextMenuButton = container.querySelector('i[data-icon-name="ChevronDown"]') as HTMLLIElement
+
+      fireEvent.click(contextMenuButton)
+
+      expect(queryByText('Command item 1')).not.toBeInTheDocument()
+      const menuItem1 = document.querySelectorAll('button.ms-ContextualMenu-link')[0] as HTMLButtonElement
+      fireEvent.click(menuItem1)
+      expect(queryByText('Command item 1')).toBeInTheDocument()
+
+      expect(queryByText('Command item 2')).not.toBeInTheDocument()
+      const menuItem2 = document.querySelectorAll('button.ms-ContextualMenu-link')[1] as HTMLButtonElement
+      fireEvent.click(menuItem2)
+      expect(queryByText('Command item 2')).not.toBeInTheDocument()
+    })
+
+    it('Opens link in a new tab when path is specified', () => {
+      const windowOpenMock = jest.fn()
+      window.open = windowOpenMock
+      const
+        btnCommandDownloadProps: Buttons = {
+          items: [{
+            button: {
+              name,
+              label: name,
+              commands: [
+                { name: 'command', label: 'Command', path },
+              ]
+            }
+          }]
+        },
+        { container, getByText } = render(<XButtons model={btnCommandDownloadProps} />),
+        contextMenuButton = container.querySelector('i[data-icon-name="ChevronDown"]') as HTMLLIElement
+
+      fireEvent.click(contextMenuButton)
+      fireEvent.click(getByText('Command'))
+
+      expect(windowOpenMock).toHaveBeenCalled()
+      expect(windowOpenMock).toHaveBeenCalledWith(path, '_blank')
     })
   })
 })

--- a/ui/src/card_menu.test.tsx
+++ b/ui/src/card_menu.test.tsx
@@ -68,7 +68,7 @@ describe('CardMenu.tsx', () => {
     expect(window.location.hash).toBe('#card')
   })
 
-  it('Does not set args and calls sync on click when download link is specified', () => {
+  it('Does not set args and calls sync on click when command has download link specified', () => {
     const pushMock = jest.fn()
     wave.push = pushMock
     card.state.commands = [{ name: 'card', download: true, path, value: 'value' }]
@@ -80,7 +80,7 @@ describe('CardMenu.tsx', () => {
     expect(wave.args[name]).toBeNull()
   })
 
-  it('Ignores items when download link is specified', () => {
+  it('Ignores items when command has download link specified', () => {
     card.state.commands = [{
       name: 'card',
       download: true, path,
@@ -96,7 +96,7 @@ describe('CardMenu.tsx', () => {
     expect(queryByText('subcommand')).not.toBeInTheDocument()
   })
 
-  it('Opens link in a new tab when path is specified', () => {
+  it('Opens link in a new tab when command has path specified', () => {
     const windowOpenMock = jest.fn()
     window.open = windowOpenMock
     card.state.commands = [{ name: 'card', path }]

--- a/ui/src/card_menu.test.tsx
+++ b/ui/src/card_menu.test.tsx
@@ -68,7 +68,7 @@ describe('CardMenu.tsx', () => {
     expect(window.location.hash).toBe('#card')
   })
 
-  it('Does not set args and calls sync on click when command has download link specified', () => {
+  it('Does not set args or calls sync on click when command has download link specified', () => {
     const pushMock = jest.fn()
     wave.push = pushMock
     card.state.commands = [{ name: 'card', download: true, path, value: 'value' }]

--- a/ui/src/card_menu.test.tsx
+++ b/ui/src/card_menu.test.tsx
@@ -81,19 +81,24 @@ describe('CardMenu.tsx', () => {
   })
 
   it('Ignores items when command has download link specified', () => {
-    card.state.commands = [{
-      name: 'card',
-      download: true, path,
-      items: [{ name: 'subcommand' }]
-    }]
-    const { getByTestId, getByText, queryByText } = render(<CardMenu card={card} />)
-    expect(queryByText('subcommand')).not.toBeInTheDocument()
+    card.state.commands = [
+      { name: 'command1', items: [{ name: 'subcommand1', label: "Subcommand 1" }] },
+      { name: 'command2', path, download: true, items: [{ name: 'subcommand2', label: "Subcommand 2" }] }
+    ]
+    const { container, queryByText } = render(<CardMenu card={card} />)
 
-    fireEvent.click(getByTestId(name))
-    fireEvent.mouseOver(getByText('card'))
+    const contextMenuButton = container.querySelectorAll('i[data-icon-name="MoreVertical"]')[0] as HTMLLIElement
+    fireEvent.click(contextMenuButton)
 
-    // TODO: Works when "download: true" and "path" are not specified as well.
-    expect(queryByText('subcommand')).not.toBeInTheDocument()
+    expect(queryByText('Subcommand 1')).not.toBeInTheDocument()
+    const menuItem1 = document.querySelectorAll('button.ms-ContextualMenu-link')[0] as HTMLButtonElement
+    fireEvent.click(menuItem1)
+    expect(queryByText('Subcommand 1')).toBeInTheDocument()
+
+    expect(queryByText('Subcommand 2')).not.toBeInTheDocument()
+    const menuItem2 = document.querySelectorAll('button.ms-ContextualMenu-link')[1] as HTMLButtonElement
+    fireEvent.click(menuItem2)
+    expect(queryByText('Subcommand 2')).not.toBeInTheDocument()
   })
 
   it('Opens link in a new tab when command has path specified', () => {

--- a/ui/src/card_menu.tsx
+++ b/ui/src/card_menu.tsx
@@ -21,6 +21,7 @@ import { fixMenuOverflowStyles } from './parts/utils'
 import { clas, cssVar } from './theme'
 import { Command } from './toolbar'
 import { bond, wave } from './ui'
+import { forceFileDownload } from './link'
 
 const
   css = stylesheet({
@@ -57,7 +58,16 @@ const
   deleteCommand = '__delete__',
   toContextMenuItem = (c: Command): IContextualMenuItem => {
     const
-      onClick = () => {
+      onClick = (ev?: React.MouseEvent<HTMLElement, MouseEvent> | React.KeyboardEvent<HTMLElement>) => {
+        if (ev && c.download && c.path) {
+          ev.preventDefault()
+          forceFileDownload(c.path)
+          return
+        }
+        if (c.path) {
+          window.open(c.path, '_blank')
+          return
+        }
         if (c.name === editCommand) {
           if (c.value) editCard(c.value)
           return
@@ -78,7 +88,7 @@ const
       text: c.label || c.name || 'Untitled',
       iconProps: c.icon ? { iconName: c.icon } : undefined,
       title: c.caption || undefined,
-      subMenuProps: c.items ? { items: c.items.map(toContextMenuItem), styles: fixMenuOverflowStyles } : undefined,
+      subMenuProps: c.items && !c.path ? { items: c.items.map(toContextMenuItem), styles: fixMenuOverflowStyles } : undefined,
       onClick,
     }
   }

--- a/ui/src/card_menu.tsx
+++ b/ui/src/card_menu.tsx
@@ -56,39 +56,32 @@ const
 const
   editCommand = '__edit__',
   deleteCommand = '__delete__',
-  toContextMenuItem = (c: Command): IContextualMenuItem => {
+  toContextMenuItem = ({ name, label, value, items, caption, icon, download, path }: Command): IContextualMenuItem => {
     const
       onClick = (ev?: React.MouseEvent<HTMLElement, MouseEvent> | React.KeyboardEvent<HTMLElement>) => {
-        if (ev && c.download && c.path) {
+        if (ev && download && path) {
           ev.preventDefault()
-          forceFileDownload(c.path)
-          return
+          forceFileDownload(path)
         }
-        if (c.path) {
-          window.open(c.path, '_blank')
-          return
+        else if (path) window.open(path, '_blank')
+        else if (name === editCommand) {
+          if (value) editCard(value)
         }
-        if (c.name === editCommand) {
-          if (c.value) editCard(c.value)
-          return
+        else if (name === deleteCommand) {
+          if (value) deleteCard(value)
         }
-        if (c.name === deleteCommand) {
-          if (c.value) deleteCard(c.value)
-          return
+        else if (name.startsWith('#')) window.location.hash = name.substring(1)
+        else {
+          wave.args[name] = value ?? true
+          wave.push()
         }
-        if (c.name.startsWith('#')) {
-          window.location.hash = c.name.substring(1)
-          return
-        }
-        wave.args[c.name] = c.value ?? true
-        wave.push()
       }
     return {
-      key: c.name,
-      text: c.label || c.name || 'Untitled',
-      iconProps: c.icon ? { iconName: c.icon } : undefined,
-      title: c.caption || undefined,
-      subMenuProps: c.items && !c.path ? { items: c.items.map(toContextMenuItem), styles: fixMenuOverflowStyles } : undefined,
+      key: name,
+      text: label || name || 'Untitled',
+      iconProps: icon ? { iconName: icon } : undefined,
+      title: caption || undefined,
+      subMenuProps: items && !path ? { items: items.map(toContextMenuItem), styles: fixMenuOverflowStyles } : undefined,
       onClick,
     }
   }

--- a/ui/src/link.tsx
+++ b/ui/src/link.tsx
@@ -89,7 +89,7 @@ export interface Links {
   /** The width of the links, e.g. '100px'. */
   width?: S
 }
-const forceFileDownload = (path: S) => {
+export const forceFileDownload = (path: S) => {
   const anchor = document.createElement('a')
   anchor.href = path
   anchor.download = path.split('/').pop()!

--- a/ui/src/table.test.tsx
+++ b/ui/src/table.test.tsx
@@ -160,15 +160,14 @@ describe('Table.tsx', () => {
     }
     const { container, queryByText } = render(<XTable model={tableProps} />)
     const contextMenuButton = container.querySelectorAll('i[data-icon-name="MoreVertical"]')[0] as HTMLLIElement
+    fireEvent.click(contextMenuButton)
 
     expect(queryByText('Command item 1')).not.toBeInTheDocument()
-    fireEvent.click(contextMenuButton)
     const menuItem1 = document.querySelectorAll('button.ms-ContextualMenu-link')[0] as HTMLButtonElement
     fireEvent.click(menuItem1)
     expect(queryByText('Command item 1')).toBeInTheDocument()
 
     expect(queryByText('Command item 2')).not.toBeInTheDocument()
-    fireEvent.click(contextMenuButton)
     const menuItem2 = document.querySelectorAll('button.ms-ContextualMenu-link')[1] as HTMLButtonElement
     fireEvent.click(menuItem2)
     expect(queryByText('Command item 2')).not.toBeInTheDocument()

--- a/ui/src/toolbar.test.tsx
+++ b/ui/src/toolbar.test.tsx
@@ -21,6 +21,7 @@ import { wave } from './ui'
 const
   name = 'toolbar',
   label = name,
+  path = 'https://wave.h2o.ai/img/logo.svg',
   toolbarProps: Model<any> = {
     name,
     state: { items: [{ name, label }] },
@@ -69,4 +70,43 @@ describe('Toolbar.tsx', () => {
     expect(window.location.hash).toBe(hashName)
   })
 
+  it('Does not set args and calls sync on click when download link is specified', () => {
+    const value = 'value'
+    const { getByText } = render(<Toolbar {...{ ...toolbarProps, state: { items: [{ name, value, label, path, download: true }] } }} />)
+    fireEvent.click(getByText(label))
+
+    expect(pushMock).not.toHaveBeenCalled()
+    expect(wave.args[name]).toBe(false)
+  })
+
+  it('Ignores items when download link is specified', () => {
+    const props = {
+      ...toolbarProps, state: {
+        items: [{
+          name,
+          label,
+          path,
+          download: true,
+          items: [{ name: 'item', label: 'item' }]
+        }]
+      }
+    }
+    const { queryByText, getByText } = render(<Toolbar {...props} />)
+
+    expect(queryByText('item')).not.toBeInTheDocument()
+    fireEvent.click(getByText(label))
+
+    expect(queryByText('item')).not.toBeInTheDocument()
+  })
+
+  it('Opens link in a new tab when path is specified', () => {
+    const windowOpenMock = jest.fn()
+    window.open = windowOpenMock
+    const { getByText } = render(<Toolbar {...{ ...toolbarProps, state: { items: [{ name, label, path }] } }} />)
+
+    fireEvent.click(getByText(label))
+
+    expect(windowOpenMock).toHaveBeenCalled()
+    expect(windowOpenMock).toHaveBeenCalledWith(path, '_blank')
+  })
 })

--- a/ui/src/toolbar.test.tsx
+++ b/ui/src/toolbar.test.tsx
@@ -70,7 +70,7 @@ describe('Toolbar.tsx', () => {
     expect(window.location.hash).toBe(hashName)
   })
 
-  it('Does not set args and calls sync on click when download link is specified', () => {
+  it('Does not set args and calls sync on click when command has download link specified', () => {
     const value = 'value'
     const { getByText } = render(<Toolbar {...{ ...toolbarProps, state: { items: [{ name, value, label, path, download: true }] } }} />)
     fireEvent.click(getByText(label))
@@ -79,7 +79,7 @@ describe('Toolbar.tsx', () => {
     expect(wave.args[name]).toBe(false)
   })
 
-  it('Ignores items when download link is specified', () => {
+  it('Ignores items when command has download link specified', () => {
     const props = {
       ...toolbarProps, state: {
         items: [{
@@ -99,7 +99,7 @@ describe('Toolbar.tsx', () => {
     expect(queryByText('item')).not.toBeInTheDocument()
   })
 
-  it('Opens link in a new tab when path is specified', () => {
+  it('Opens link in a new tab when command has path specified', () => {
     const windowOpenMock = jest.fn()
     window.open = windowOpenMock
     const { getByText } = render(<Toolbar {...{ ...toolbarProps, state: { items: [{ name, label, path }] } }} />)

--- a/ui/src/toolbar.test.tsx
+++ b/ui/src/toolbar.test.tsx
@@ -70,7 +70,7 @@ describe('Toolbar.tsx', () => {
     expect(window.location.hash).toBe(hashName)
   })
 
-  it('Does not set args and calls sync on click when command has download link specified', () => {
+  it('Does not set args or calls sync on click when command has download link specified', () => {
     const value = 'value'
     const { getByText } = render(<Toolbar {...{ ...toolbarProps, state: { items: [{ name, value, label, path, download: true }] } }} />)
     fireEvent.click(getByText(label))

--- a/ui/src/toolbar.tsx
+++ b/ui/src/toolbar.tsx
@@ -64,24 +64,19 @@ const
       justifyContent: 'center',
     },
   }),
-  toCommand = ({ name, path, label = path, caption, icon, items, value, download }: Command): ICommandBarItemProps => {
+  toCommand = ({ name, path, label, caption, icon, items, value, download }: Command): ICommandBarItemProps => {
     wave.args[name] = false
     const onClick = (ev?: React.MouseEvent<HTMLElement, MouseEvent> | React.KeyboardEvent<HTMLElement>) => {
       if (ev && download && path) {
         ev.preventDefault()
         forceFileDownload(path)
-        return
       }
-      if (path) {
-        window.open(path, '_blank')
-        return
+      else if (path) window.open(path, '_blank')
+      else if (name.startsWith('#')) window.location.hash = name.substring(1)
+      else {
+        wave.args[name] = value === undefined || value
+        wave.push()
       }
-      if (name.startsWith('#')) {
-        window.location.hash = name.substring(1)
-        return
-      }
-      wave.args[name] = value === undefined || value
-      wave.push()
     }
     return {
       key: name,

--- a/website/widgets/content/toolbar.md
+++ b/website/widgets/content/toolbar.md
@@ -19,11 +19,11 @@ q.page['example'] = ui.toolbar_card(
         ),
         ui.command(name='upload', label='Upload', icon='Upload'),
         ui.command(name='share', label='Share', icon='Share'),
-        ui.command(name='download', label='Download', icon='Download'),
+        ui.command(name='download', label='Download', icon='Download', path='https://wave.h2o.ai/img/logo.svg', download=True),
     ],
     secondary_items=[
         ui.command(name='tile', caption='Grid View', icon='Tiles'),
-        ui.command(name='info', caption='Info', icon='Info'),
+        ui.command(name='info', caption='Info', icon='Info', path='https://wave.h2o.ai'),
     ],
     overflow_items=[
         ui.command(name='move', label='Move to...', icon='MoveToFolder'),


### PR DESCRIPTION
**The PR fulfills these requirements:** (check all the apply)

- [x] It's submitted to the `main` branch.
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `feat: Add a button #xxx`, where "xxx" is the issue number).
- [x] When resolving a specific issue, the PR description includes `Closes #xxx`, where "xxx" is the issue number.
- [x] If changes were made to `ui` folder, unit tests (`make test`) still pass.
- [x] New/updated tests are included

___

Adds `path` and `download` attributes to **ui.command** to support the same behavior as `ui.link()`:

```tsx
export interface Command {
  /** An identifying name for this component. If the name is prefixed with a '#', the command sets the location hash to the name when executed. */
  name: Id
  /** The text displayed for this command. */
  label?: S
  /** The caption for this command (typically a tooltip). */
  caption?: S
  /** The icon to be displayed for this command. */
  icon?: S
  /** Sub-commands, if any */
  items?: Command[]
  /** Data associated with this command, if any. */
  value?: S
  /** The path or URL to link to. The 'items' and 'value' props are ignored when specified. */
  path?: S
  /** True if the link should prompt the user to save the linked URL instead of navigating to it. */
  download?: B
}
```

Closes #2224 
