### PR TITLE
feat: Add data-test attribute to picker item remove button #273

### DIFF
--- a/py/examples/picker_selection.py
+++ b/py/examples/picker_selection.py
@@ -14,14 +14,14 @@ async def serve(q: Q):
         ]
     else:
         q.page['example'] = ui.form_card(box='1 1 4 5', items=[
-            ui.picker(name='picker', label='Picker with initial values', choices=[
+            ui.picker(name='picker', label='Picker with initial values and max of 3 choices', choices=[
                 ui.choice(name='spam', label='Spam'),
                 ui.choice(name='eggs', label='Eggs'),
                 ui.choice(name='ham', label='Ham'),
                 ui.choice(name='cheese', label='Cheese'),
                 ui.choice(name='beans', label='Beans'),
                 ui.choice(name='toast', label='Toast'),
-            ], values=['spam', 'eggs']),
+            ], max_choices=3, values=['spam', 'eggs']),
             ui.button(name='show_inputs', label='Submit', primary=True),
         ])
     await q.page.save()

--- a/py/examples/picker_selection.py
+++ b/py/examples/picker_selection.py
@@ -14,14 +14,14 @@ async def serve(q: Q):
         ]
     else:
         q.page['example'] = ui.form_card(box='1 1 4 5', items=[
-            ui.picker(name='picker', label='Picker with initial values and max of 3 choices', choices=[
+            ui.picker(name='picker', label='Picker with initial values', choices=[
                 ui.choice(name='spam', label='Spam'),
                 ui.choice(name='eggs', label='Eggs'),
                 ui.choice(name='ham', label='Ham'),
                 ui.choice(name='cheese', label='Cheese'),
                 ui.choice(name='beans', label='Beans'),
                 ui.choice(name='toast', label='Toast'),
-            ], max_choices=3, values=['spam', 'eggs']),
+            ], values=['spam', 'eggs']),
             ui.button(name='show_inputs', label='Submit', primary=True),
         ])
     await q.page.save()

--- a/ui/src/picker.test.tsx
+++ b/ui/src/picker.test.tsx
@@ -41,6 +41,25 @@ describe('Picker.tsx', () => {
     expect(queryByTestId(name)).toBeInTheDocument()
   })
 
+  it('Does not render data-test attr when max choices reached', () => {
+    const { queryByTestId } = render(<XPicker model={{...pickerProps, values: [name], max_choices: 1}} />)
+    expect(queryByTestId(name)).toBe(null)
+  })
+
+  it('Remove selection so data-test attr for picker renders', () => {
+    const { queryByTestId } = render(<XPicker model={{...pickerProps, values: [name], max_choices: 1}} />)
+    expect(queryByTestId(name)).toBe(null)
+
+    //get the 'remove' button using its data-test attr 
+    const removeButton = (queryByTestId('remove_'+name) as HTMLElement)
+    expect(removeButton).toBeInTheDocument()
+    fireEvent.click(removeButton)
+
+    //now the picker data-test attr is in the DOM
+    expect(queryByTestId(name)).toBeInTheDocument()
+    expect(queryByTestId('remove_'+name)).toBe(null)      
+  })
+
   it('Sets correct args - init', () => {
     render(<XPicker model={pickerProps} />)
     expect(wave.args[name]).toBeNull()

--- a/ui/src/picker.test.tsx
+++ b/ui/src/picker.test.tsx
@@ -41,22 +41,12 @@ describe('Picker.tsx', () => {
     expect(queryByTestId(name)).toBeInTheDocument()
   })
 
-  it('Does not render data-test attr when max choices reached', () => {
-    const { queryByTestId } = render(<XPicker model={{...pickerProps, values: [name], max_choices: 1}} />)
-    expect(queryByTestId(name)).toBe(null)
-  })
+  it('Renders data-test attr on selection remove button', () => {
+    const { queryByTestId } = render(<XPicker model={{...pickerProps, values: [name]}} />)
 
-  it('Remove selection so data-test attr for picker renders', () => {
-    const { queryByTestId } = render(<XPicker model={{...pickerProps, values: [name], max_choices: 1}} />)
-    expect(queryByTestId(name)).toBe(null)
-
-    //get the 'remove' button using its data-test attr 
     const removeButton = (queryByTestId('remove_'+name) as HTMLElement)
     expect(removeButton).toBeInTheDocument()
     fireEvent.click(removeButton)
-
-    //now the picker data-test attr is in the DOM
-    expect(queryByTestId(name)).toBeInTheDocument()
     expect(queryByTestId('remove_'+name)).toBe(null)      
   })
 

--- a/ui/src/picker.tsx
+++ b/ui/src/picker.tsx
@@ -53,10 +53,6 @@ const pickerSuggestionsProps: Fluent.IBasePickerSuggestionsProps = {
   noResultsFoundText: 'No results found',
 }
 
-const removeButtonIconProps: Fluent.IIconProps = {
-  iconName: 'Cancel'
-}
-
 export const XPicker = ({ model: m }: { model: Picker }) => {
   const
     tags: Fluent.ITag[] = React.useMemo(() => m.choices.map(({ name, label }) => ({ key: name, name: label || name })), [m.choices]),
@@ -83,7 +79,7 @@ export const XPicker = ({ model: m }: { model: Picker }) => {
       {m.label && <Fluent.Label required={m.required}>{m.label}</Fluent.Label>}
       <Fluent.TagPicker
         inputProps={{ 'data-test': m.name } as Fluent.IInputProps}
-        removeButtonIconProps={{ ...removeButtonIconProps, 'data-test' : 'remove_'+m.name } as Fluent.IIconProps}
+        removeButtonIconProps={{ iconName: 'Cancel', 'data-test' : 'remove_' + m.name } as Fluent.IIconProps}
         removeButtonAriaLabel="Remove"
         onResolveSuggestions={filterSuggestedTags}
         onChange={onChange}

--- a/ui/src/picker.tsx
+++ b/ui/src/picker.tsx
@@ -53,6 +53,10 @@ const pickerSuggestionsProps: Fluent.IBasePickerSuggestionsProps = {
   noResultsFoundText: 'No results found',
 }
 
+const removeButtonIconProps: Fluent.IIconProps = {
+  iconName: 'Cancel'
+}
+
 export const XPicker = ({ model: m }: { model: Picker }) => {
   const
     tags: Fluent.ITag[] = React.useMemo(() => m.choices.map(({ name, label }) => ({ key: name, name: label || name })), [m.choices]),
@@ -79,6 +83,7 @@ export const XPicker = ({ model: m }: { model: Picker }) => {
       {m.label && <Fluent.Label required={m.required}>{m.label}</Fluent.Label>}
       <Fluent.TagPicker
         inputProps={{ 'data-test': m.name } as Fluent.IInputProps}
+        removeButtonIconProps={{ ...removeButtonIconProps, 'data-test' : 'remove_'+m.name } as Fluent.IIconProps}
         removeButtonAriaLabel="Remove"
         onResolveSuggestions={filterSuggestedTags}
         onChange={onChange}


### PR DESCRIPTION
Closes #273 

**The PR fulfills these requirements:** (check all the apply)

- [x] It's submitted to the `main` branch.
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `feat: Add a button #xxx`, where "xxx" is the issue number).
- [x] When resolving a specific issue, the PR description includes `Closes #xxx`, where "xxx" is the issue number.
- [x] If changes were made to `ui` folder, unit tests (`make test`) still pass.
- [x] New/updated tests are included

As explained in the issue, the picker `data-test` attribute is missing from the DOM once the `max_choices` defined for the FluentUI TagPicker component is reached. With the change in this PR, a new `data-test` attribute is added to the remove button for the choices selected in the picker. This allows a Cypress test to locate the picker remove button with the `data-test` attribute and click it. Since the `max_choices` is no longer satisfied, the `input` element with the picker `data-test` attribute is added back to the DOM.

This was accomplished by using `removeButtonIconProps` on `TagPicker` to add a new `data_test` attribute that includes the picker name prefixed with `remove_`. The code in `ui/src/picker.tsx` looks like this:

```{typescript}
removeButtonIconProps={{ ...removeButtonIconProps, 'data-test' : 'remove_'+m.name } as Fluent.IIconProps}
```

There are 2 new test cases in `picker.test.tsx`. First is to confirm that the picker `data-test` attribute is unavailable when `max_choices` is met. The other is to confirm that the new `data-test` attribute for the remove button can be located and clicked, which returns the original picker `data-test` attribute back in DOM.

I ran all the ui tests and confirmed they passed. Here is a screen shot for that:
![wave_ui_test_issue_273](https://github.com/h2oai/wave/assets/61979454/f5cdd3eb-1582-4ffe-8ef5-8b957998af5e)

Lastly, I also created a new Cypress test to confirm this would work. To support this, I modified the `picker_selection.py` example so that it defined a `max_choices` of 3. This allows the Cypress test to use an existing example. I noticed that there are no Python test definitions for Cypress in the repository, so I wasn't sure what to do with the test. Here is the test, you can see it is very simple:

```{python}
from h2o_wave import cypress

@cypress('Use picker and reach maximum number of choices')
def test_picker(cy):
    cy.visit('/demo')
    cy.locate('picker').type('Ham').type('{enter}')
    cy.locate('picker').should('not.exist')
    cy.locate('remove_picker').should('exist').first().click()
    cy.locate('picker').should('exist').type('Beans').type('{enter}')
    cy.locate('picker').should('not.exist')
```

Here is video showing the Cypress test in action:
https://github.com/h2oai/wave/assets/61979454/6cf63b01-1b8e-461d-a1b6-4b019c65e4cf


