### PR TITLE
fix: Set ui.inline justify default to start #2267

### DIFF
--- a/ui/src/form.tsx
+++ b/ui/src/form.tsx
@@ -282,7 +282,7 @@ export const
   XInline = ({ model: m }: { model: Inline }) => (
     <XComponents
       items={m.items}
-      justify={m.justify}
+      justify={m.justify || 'start'}
       align={m.align || (m.direction === 'row' ? 'center' : undefined)}
       inset={m.inset}
       height={m.height}


### PR DESCRIPTION
**The PR fulfills these requirements:** (check all the apply)

- [x] It's submitted to the `main` branch.
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `feat: Add a button #xxx`, where "xxx" is the issue number).
- [x] When resolving a specific issue, the PR description includes `Closes #xxx`, where "xxx" is the issue number.
- [x] If changes were made to `ui` folder, unit tests (`make test`) still pass.
- [ ] New/updated tests are included
___

Adds lacking `start` default to ui.inline() justification as declared in the API description.

Closes #2267 