### PR TITLE
fix: Include spacing in width for inline horizontal components #2251

### DIFF
--- a/tools/showcase/showcase.py
+++ b/tools/showcase/showcase.py
@@ -201,7 +201,9 @@ def main():
 
     try:
         os.makedirs(example_file_path)
-        wave_server = subprocess.Popen(['make', 'run'], cwd=os.path.join('..', '..'), stderr=subprocess.DEVNULL, preexec_fn=os.setsid) # noqa
+        env = os.environ.copy()
+        env['H2O_WAVE_RECONNECT_TIMEOUT'] = "0s"
+        wave_server = subprocess.Popen(['make', 'run'], cwd=os.path.join('..', '..'), stderr=subprocess.DEVNULL, preexec_fn=os.setsid, env=env) # noqa
         time.sleep(1)
 
         retries = 3

--- a/ui/src/form.tsx
+++ b/ui/src/form.tsx
@@ -215,7 +215,8 @@ const
       alignItems: 'center',
       $nest: {
         '> [data-visible="true"] ~ div': {
-          marginLeft: 8
+          paddingLeft: 8,
+          boxSizing: 'border-box'
         }
       }
     },


### PR DESCRIPTION
**The PR fulfills these requirements:** (check all the apply)

- [x] It's submitted to the `main` branch.
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `feat: Add a button #xxx`, where "xxx" is the issue number).
- [x] When resolving a specific issue, the PR description includes `Closes #xxx`, where "xxx" is the issue number.
- [x] If changes were made to `ui` folder, unit tests (`make test`) still pass.
- [ ] New/updated tests are included
___

The problem was that left margin for ui.inline horizontally laid components adds to total component width causing the overflow. Since something like `boxSizing: "margin-box"` does not exist, the issue is fixed by replacing left margin with left padding and using `boxSizing: "border-box"` which accounts for both borders and paddings when calculating component dimensions.

<img width="582" alt="image" src="https://github.com/h2oai/wave/assets/23740173/dde02e04-4167-499e-8633-ea8f7e8d9fa0">

This PR also includes a fix for firefox visual regression tests incompatibility with new `H2O_WAVE_RECONNECT_TIMEOUT` (#2252).

Solution tested across all browsers.
Also both unit and visual regression tests pass.

Closes #2251 