### PR TITLE
fix: Sort items correctly when empty custom group is present #2268

### DIFF
--- a/ui/src/table.test.tsx
+++ b/ui/src/table.test.tsx
@@ -1535,7 +1535,22 @@ describe('Table.tsx', () => {
     const
       items = 3,
       firstGroupLabel = 'GroupA',
-      secondGroupLabel = 'GroupB'
+      secondGroupLabel = 'GroupB',
+      groupA = {
+        label: firstGroupLabel,
+        rows: [
+          { name: 'rowname1', cells: [cell11, 'Group2'] },
+          { name: 'rowname2', cells: [cell21, 'Group1'] }
+        ],
+        collapsed: false
+      },
+      groupB = {
+        label: secondGroupLabel,
+        rows: [
+          { name: 'rowname3', cells: [cell31, 'Group2'] }
+        ],
+        collapsed: false
+      }
     beforeEach(() => {
       tableProps = {
         name,
@@ -1543,23 +1558,7 @@ describe('Table.tsx', () => {
           { name: 'colname1', label: 'Col1', sortable: true, searchable: true },
           { name: 'colname2', label: 'Col2', sortable: true, filterable: true },
         ],
-        groups: [
-          {
-            label: firstGroupLabel,
-            rows: [
-              { name: 'rowname1', cells: [cell11, 'Group2'] },
-              { name: 'rowname2', cells: [cell21, 'Group1'] },
-            ],
-            collapsed: false
-          },
-          {
-            label: secondGroupLabel,
-            rows: [
-              { name: 'rowname3', cells: [cell31, 'Group2'] }
-            ],
-            collapsed: false
-          }
-        ]
+        groups: [groupA, groupB]
       }
     })
 
@@ -1764,6 +1763,22 @@ describe('Table.tsx', () => {
 
       expectAllGroupsToBeVisible()
       expectAllItemsToBePresent()
+    })
+
+    it("Sort items correctly when empty custom group is present", () => {
+      const
+        props = { ...tableProps, groups: [groupA, groupB, { label: 'GroupC', rows: [], collapsed: false }] },
+        { container, getAllByRole } = render(<XTable model={props} />)
+
+      expect(getAllByRole('gridcell')[3].textContent).toBe(cell11)
+      expect(getAllByRole('gridcell')[6].textContent).toBe(cell21)
+      expect(getAllByRole('gridcell')[11].textContent).toBe(cell31)
+
+      fireEvent.click(container.querySelector('.ms-DetailsHeader-cellTitle')!)
+
+      expect(getAllByRole('gridcell')[3].textContent).toBe(cell21)
+      expect(getAllByRole('gridcell')[6].textContent).toBe(cell11)
+      expect(getAllByRole('gridcell')[11].textContent).toBe(cell31)
     })
   })
 

--- a/ui/src/table.tsx
+++ b/ui/src/table.tsx
@@ -818,7 +818,9 @@ export const
             setFilteredItems(filteredItems => [...groups]
               // sorts groups by startIndex to match its order in filteredItems
               .sort((group1, group2) => group1.startIndex - group2.startIndex)
-              .reduce((acc, group) => [...acc, ...filteredItems.slice(group.startIndex, acc.length + group.count).sort(sortingF(column, sortAsc))],
+              .reduce((acc, group) => group.count
+                ? [...acc, ...filteredItems.slice(group.startIndex, acc.length + group.count).sort(sortingF(column, sortAsc))]
+                : acc,
                 [] as any[]) || [])
           }
           else setFilteredItems(filteredItems => [...filteredItems].sort(sortingF(column, sortAsc)))


### PR DESCRIPTION
**The PR fulfills these requirements:** (check all the apply)

- [x] It's submitted to the `main` branch.
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `feat: Add a button #xxx`, where "xxx" is the issue number).
- [x] When resolving a specific issue, the PR description includes `Closes #xxx`, where "xxx" is the issue number.
- [x] If changes were made to `ui` folder, unit tests (`make test`) still pass.
- [x] New/updated tests are included
___

The problem was in reducer inside `onSortChange` function 
```tsx
setFilteredItems(filteredItems => [...groups]
     // sorts groups by startIndex to match its order in filteredItems
     .sort((group1, group2) => group1.startIndex - group2.startIndex)
     .reduce((acc, group) => [...acc, ...filteredItems.slice(group.startIndex, acc.length + group.count).sort(sortingF(column, sortAsc))],
     [] as any[]) || [])
``` 
adding `acc.length + group.count` filtered items into the final array even in case of empty group present (`group.count` equal to `0`) but `acc.length` having non-zero value most of the time.

Fixed by conditional adding of items:
```tsx
group.count
       ? [...acc, ...filteredItems.slice(group.startIndex, acc.length + group.count).sort(sortingF(column, sortAsc))]
       : acc
```

Closes #2268 