### PR TITLE
feat: v1.1.0 pre-release QA based fixes #2276

### DIFF
--- a/py/examples/toolbar.py
+++ b/py/examples/toolbar.py
@@ -18,7 +18,7 @@ async def serve(q: Q):
             ),
             ui.command(name='upload', label='Upload', icon='Upload'),
             ui.command(name='share', label='Share', icon='Share'),
-            ui.command(name='download', label='Download', icon='Download', path='https://wave.h2o.ai/img/logo.svg', download=True),
+            ui.command(name='download', label='Download', icon='Download', path='http://localhost:10101/assets/brand/h2o-wave-b&w.png', download=True),
         ],
         secondary_items=[
             ui.command(name='tile', caption='Grid View', icon='Tiles'),

--- a/ui/src/audio_annotator.test.tsx
+++ b/ui/src/audio_annotator.test.tsx
@@ -395,7 +395,7 @@ describe('AudioAnnotator.tsx', () => {
       expect(wave.args[name]).toMatchObject([items[0], { ...items[1], start: end - moveOffset, end: start }])
     })
 
-    it.only('Does not remove active tag when leaving and getting back into the zoom rectangle during dragging', async () => {
+    it('Does not remove active tag when leaving and getting back into the zoom rectangle during dragging', async () => {
       const { container } = render(<XAudioAnnotator model={model} />)
       await waitForComponentLoad()
       const canvasEl = container.querySelector('canvas')!

--- a/ui/src/audio_annotator.test.tsx
+++ b/ui/src/audio_annotator.test.tsx
@@ -395,6 +395,19 @@ describe('AudioAnnotator.tsx', () => {
       expect(wave.args[name]).toMatchObject([items[0], { ...items[1], start: end - moveOffset, end: start }])
     })
 
+    it.only('Does not remove active tag when leaving and getting back into the zoom rectangle during dragging', async () => {
+      const { container } = render(<XAudioAnnotator model={model} />)
+      await waitForComponentLoad()
+      const canvasEl = container.querySelector('canvas')!
+
+      expect(container.querySelector('[class*=activeTag]')).toBeInTheDocument()
+
+      fireEvent.mouseDown(canvasEl, { clientX: 30, clientY: 10, buttons: 1 })
+      fireEvent.mouseLeave(canvasEl)
+      fireEvent.click(canvasEl, { clientX: 31, clientY: 20, buttons: 1 })
+
+      expect(container.querySelector('[class*=activeTag]')).toBeInTheDocument()
+    })
   })
 
   describe('Tooltip', () => {

--- a/ui/src/parts/range_annotator.tsx
+++ b/ui/src/parts/range_annotator.tsx
@@ -366,7 +366,7 @@ const
           : 'pointer'
 
         if (!currDrawnAnnotation.current || !action) {
-          if (intersected && intersected.tag !== activeTag) setActiveTag(intersected.tag)
+          if (intersected && intersected.tag !== activeTag && intersected.tag !== '') setActiveTag(intersected.tag)
           if (intersected) focusAnnotation(intersected)
           return
         }

--- a/ui/src/parts/range_annotator.tsx
+++ b/ui/src/parts/range_annotator.tsx
@@ -408,7 +408,13 @@ const
 
     React.useEffect(() => {
       window.addEventListener('resize', init)
-      return () => window.removeEventListener('resize', init)
+      // HACK: Fix canvas having default dimensions of 300x150 if app is loaded when browser tab is not visible.
+      const onVisibilityChange = () => { if (canvasRef.current && canvasRef.current.width === 300) setTimeout(init, 60) }
+      window.addEventListener("visibilitychange", onVisibilityChange)
+      return () => {
+        window.removeEventListener('resize', init)
+        window.removeEventListener("visibilitychange", onVisibilityChange)
+      }
     }, [init])
 
     React.useEffect(() => redrawAnnotations(), [annotations, redrawAnnotations])

--- a/ui/src/parts/waveform.tsx
+++ b/ui/src/parts/waveform.tsx
@@ -50,8 +50,13 @@ export const Waveform = React.memo(({ color, data }: Props) => {
   React.useLayoutEffect(() => {
     updateDimensions()
     const onResize = debounce(1000, updateDimensions)
+    const onVisibilityChange = () => setTimeout(updateDimensions, 60)
     window.addEventListener('resize', onResize)
-    return () => window.removeEventListener('resize', onResize)
+    window.addEventListener('visibilitychange', onVisibilityChange)
+    return () => {
+      window.removeEventListener('resize', onResize)
+      window.removeEventListener('visibilitychange', onVisibilityChange)
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 

--- a/website/widgets/form/link.md
+++ b/website/widgets/form/link.md
@@ -56,7 +56,7 @@ q.page['example'] = ui.form_card(box='1 1 2 2', items=[
 
 If you want to allow your users to download a file, use the `download` attribute.
 
-The `download` attribute will only start the download if the path points to a location on the same origin (if your app is running on <http://localhost:10101>, the `path` either starts with `/` or `http://localhost:10101`) or has a `Content-disposition` response header set to `attachment`. See [the docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-download).
+The `download` attribute will only start the download if the path points to a location on the same origin (wave server).
 
 ```py
 q.page['example'] = ui.form_card(box='1 1 2 2', items=[


### PR DESCRIPTION
**The PR fulfills these requirements:** (check all the apply)

- [x] It's submitted to the `main` branch.
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `feat: Add a button #xxx`, where "xxx" is the issue number).
- [x] When resolving a specific issue, the PR description includes `Closes #xxx`, where "xxx" is the issue number.
- [x] If changes were made to `ui` folder, unit tests (`make test`) still pass.
- [x] New/updated tests are included
____

This PR fixes several issues based on the v1.0.0 pre-release QA, namely:

- **Audio annotator**: Wrong annotator dimensions if Wave app is loaded when browser tab is not visible
- **Audio annotator**: In [specific scenario](https://github.com/h2oai/wave/issues/2276#issuecomment-1968481977) user was able to activate empty tag and annotate with it
- **Toolbar**: Download prop example was not working due to link being from different origin.

TBD:
- [x] Firefox "randomly" dropping Wave server connection since [this commit](https://github.com/h2oai/wave/commit/26f3c73ed1d36de568ce622f5047c9cda2386966). - Fixed by #2278 
- [ ] Audio annotator playback issues for several file formats when using Safari and/or Firefox. - TBD later [as agreed](https://github.com/h2oai/wave/issues/2276#issuecomment-1965948700).

Closes #2276 