### PR TITLE
feat: Add width support for copyable text #2282

### DIFF
--- a/py/h2o_lightwave/h2o_lightwave/types.py
+++ b/py/h2o_lightwave/h2o_lightwave/types.py
@@ -7113,12 +7113,14 @@ class CopyableText:
             name: Optional[str] = None,
             multiline: Optional[bool] = None,
             height: Optional[str] = None,
+            width: Optional[str] = None,
     ):
         _guard_scalar('CopyableText.value', value, (str,), False, False, False)
         _guard_scalar('CopyableText.label', label, (str,), False, False, False)
         _guard_scalar('CopyableText.name', name, (str,), False, True, False)
         _guard_scalar('CopyableText.multiline', multiline, (bool,), False, True, False)
         _guard_scalar('CopyableText.height', height, (str,), False, True, False)
+        _guard_scalar('CopyableText.width', width, (str,), False, True, False)
         self.value = value
         """Text to be displayed inside the component."""
         self.label = label
@@ -7129,6 +7131,8 @@ class CopyableText:
         """True if the component should allow multi-line text entry."""
         self.height = height
         """Custom height in px (e.g. '200px') or '1' to fill the remaining card space. Requires `multiline` to be set."""
+        self.width = width
+        """The width of the copyable text , e.g. '100px'."""
 
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""
@@ -7137,12 +7141,14 @@ class CopyableText:
         _guard_scalar('CopyableText.name', self.name, (str,), False, True, False)
         _guard_scalar('CopyableText.multiline', self.multiline, (bool,), False, True, False)
         _guard_scalar('CopyableText.height', self.height, (str,), False, True, False)
+        _guard_scalar('CopyableText.width', self.width, (str,), False, True, False)
         return _dump(
             value=self.value,
             label=self.label,
             name=self.name,
             multiline=self.multiline,
             height=self.height,
+            width=self.width,
         )
 
     @staticmethod
@@ -7158,17 +7164,21 @@ class CopyableText:
         _guard_scalar('CopyableText.multiline', __d_multiline, (bool,), False, True, False)
         __d_height: Any = __d.get('height')
         _guard_scalar('CopyableText.height', __d_height, (str,), False, True, False)
+        __d_width: Any = __d.get('width')
+        _guard_scalar('CopyableText.width', __d_width, (str,), False, True, False)
         value: str = __d_value
         label: str = __d_label
         name: Optional[str] = __d_name
         multiline: Optional[bool] = __d_multiline
         height: Optional[str] = __d_height
+        width: Optional[str] = __d_width
         return CopyableText(
             value,
             label,
             name,
             multiline,
             height,
+            width,
         )
 
 

--- a/py/h2o_lightwave/h2o_lightwave/ui.py
+++ b/py/h2o_lightwave/h2o_lightwave/ui.py
@@ -2632,6 +2632,7 @@ def copyable_text(
         name: Optional[str] = None,
         multiline: Optional[bool] = None,
         height: Optional[str] = None,
+        width: Optional[str] = None,
 ) -> Component:
     """Create a copyable text component.
     Use this component when you want to enable your users to quickly copy paste sections of text.
@@ -2642,6 +2643,7 @@ def copyable_text(
         name: An identifying name for this component.
         multiline: True if the component should allow multi-line text entry.
         height: Custom height in px (e.g. '200px') or '1' to fill the remaining card space. Requires `multiline` to be set.
+        width: The width of the copyable text , e.g. '100px'.
     Returns:
         A `h2o_wave.types.CopyableText` instance.
     """
@@ -2651,6 +2653,7 @@ def copyable_text(
         name,
         multiline,
         height,
+        width,
     ))
 
 

--- a/py/h2o_wave/h2o_wave/types.py
+++ b/py/h2o_wave/h2o_wave/types.py
@@ -7113,12 +7113,14 @@ class CopyableText:
             name: Optional[str] = None,
             multiline: Optional[bool] = None,
             height: Optional[str] = None,
+            width: Optional[str] = None,
     ):
         _guard_scalar('CopyableText.value', value, (str,), False, False, False)
         _guard_scalar('CopyableText.label', label, (str,), False, False, False)
         _guard_scalar('CopyableText.name', name, (str,), False, True, False)
         _guard_scalar('CopyableText.multiline', multiline, (bool,), False, True, False)
         _guard_scalar('CopyableText.height', height, (str,), False, True, False)
+        _guard_scalar('CopyableText.width', width, (str,), False, True, False)
         self.value = value
         """Text to be displayed inside the component."""
         self.label = label
@@ -7129,6 +7131,8 @@ class CopyableText:
         """True if the component should allow multi-line text entry."""
         self.height = height
         """Custom height in px (e.g. '200px') or '1' to fill the remaining card space. Requires `multiline` to be set."""
+        self.width = width
+        """The width of the copyable text , e.g. '100px'."""
 
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""
@@ -7137,12 +7141,14 @@ class CopyableText:
         _guard_scalar('CopyableText.name', self.name, (str,), False, True, False)
         _guard_scalar('CopyableText.multiline', self.multiline, (bool,), False, True, False)
         _guard_scalar('CopyableText.height', self.height, (str,), False, True, False)
+        _guard_scalar('CopyableText.width', self.width, (str,), False, True, False)
         return _dump(
             value=self.value,
             label=self.label,
             name=self.name,
             multiline=self.multiline,
             height=self.height,
+            width=self.width,
         )
 
     @staticmethod
@@ -7158,17 +7164,21 @@ class CopyableText:
         _guard_scalar('CopyableText.multiline', __d_multiline, (bool,), False, True, False)
         __d_height: Any = __d.get('height')
         _guard_scalar('CopyableText.height', __d_height, (str,), False, True, False)
+        __d_width: Any = __d.get('width')
+        _guard_scalar('CopyableText.width', __d_width, (str,), False, True, False)
         value: str = __d_value
         label: str = __d_label
         name: Optional[str] = __d_name
         multiline: Optional[bool] = __d_multiline
         height: Optional[str] = __d_height
+        width: Optional[str] = __d_width
         return CopyableText(
             value,
             label,
             name,
             multiline,
             height,
+            width,
         )
 
 

--- a/py/h2o_wave/h2o_wave/ui.py
+++ b/py/h2o_wave/h2o_wave/ui.py
@@ -2632,6 +2632,7 @@ def copyable_text(
         name: Optional[str] = None,
         multiline: Optional[bool] = None,
         height: Optional[str] = None,
+        width: Optional[str] = None,
 ) -> Component:
     """Create a copyable text component.
     Use this component when you want to enable your users to quickly copy paste sections of text.
@@ -2642,6 +2643,7 @@ def copyable_text(
         name: An identifying name for this component.
         multiline: True if the component should allow multi-line text entry.
         height: Custom height in px (e.g. '200px') or '1' to fill the remaining card space. Requires `multiline` to be set.
+        width: The width of the copyable text , e.g. '100px'.
     Returns:
         A `h2o_wave.types.CopyableText` instance.
     """
@@ -2651,6 +2653,7 @@ def copyable_text(
         name,
         multiline,
         height,
+        width,
     ))
 
 

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -3066,6 +3066,7 @@ ui_facepile <- function(
 #' @param name An identifying name for this component.
 #' @param multiline True if the component should allow multi-line text entry.
 #' @param height Custom height in px (e.g. '200px') or '1' to fill the remaining card space. Requires `multiline` to be set.
+#' @param width The width of the copyable text , e.g. '100px'.
 #' @return A CopyableText instance.
 #' @export
 ui_copyable_text <- function(
@@ -3073,18 +3074,21 @@ ui_copyable_text <- function(
   label,
   name = NULL,
   multiline = NULL,
-  height = NULL) {
+  height = NULL,
+  width = NULL) {
   .guard_scalar("value", "character", value)
   .guard_scalar("label", "character", label)
   .guard_scalar("name", "character", name)
   .guard_scalar("multiline", "logical", multiline)
   .guard_scalar("height", "character", height)
+  .guard_scalar("width", "character", width)
   .o <- list(copyable_text=list(
     value=value,
     label=label,
     name=name,
     multiline=multiline,
-    height=height))
+    height=height,
+    width=width))
   class(.o) <- append(class(.o), c(.wave_obj, "WaveComponent"))
   return(.o)
 }

--- a/tools/intellij-plugin/src/main/resources/templates/wave-components.xml
+++ b/tools/intellij-plugin/src/main/resources/templates/wave-components.xml
@@ -1249,12 +1249,13 @@
       <option name="Python" value="true"/>
     </context>
   </template>
-  <template name="w_full_copyable_text" value="ui.copyable_text(value='$value$',label='$label$',name='$name$',multiline=$multiline$,height='$height$'),$END$" description="Create Wave CopyableText with full attributes." toReformat="true" toShortenFQNames="true">
+  <template name="w_full_copyable_text" value="ui.copyable_text(value='$value$',label='$label$',name='$name$',multiline=$multiline$,height='$height$',width='$width$'),$END$" description="Create Wave CopyableText with full attributes." toReformat="true" toShortenFQNames="true">
     <variable name="value" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="label" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="name" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="multiline" expression="" defaultValue="&quot;False&quot;" alwaysStopAt="true"/>
     <variable name="height" expression="" defaultValue="" alwaysStopAt="true"/>
+    <variable name="width" expression="" defaultValue="" alwaysStopAt="true"/>
     <context>
       <option name="Python" value="true"/>
     </context>

--- a/tools/vscode-extension/component-snippets.json
+++ b/tools/vscode-extension/component-snippets.json
@@ -1129,7 +1129,7 @@
   "Wave Full CopyableText": {
     "prefix": "w_full_copyable_text",
     "body": [
-      "ui.copyable_text(value='$1', label='$2', name='$3', multiline=${4:False}, height='$5'),$0"
+      "ui.copyable_text(value='$1', label='$2', name='$3', multiline=${4:False}, height='$5', width='$6'),$0"
     ],
     "description": "Create a full Wave CopyableText."
   },

--- a/ui/src/copyable_text.tsx
+++ b/ui/src/copyable_text.tsx
@@ -51,6 +51,8 @@ export interface CopyableText {
   multiline?: B
   /** Custom height in px (e.g. '200px') or '1' to fill the remaining card space. Requires `multiline` to be set. */
   height?: S
+  /** The width of the copyable text , e.g. '100px'. */
+  width?: S
 }
 
 export const ClipboardCopyButton = ({ value }: { value: S }) => {


### PR DESCRIPTION
**The PR fulfills these requirements:** (check all the apply)

- [x] It's submitted to the `main` branch.
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `feat: Add a button #xxx`, where "xxx" is the issue number).
- [x] When resolving a specific issue, the PR description includes `Closes #xxx`, where "xxx" is the issue number.
- [x] If changes were made to `ui` folder, unit tests (`make test`) still pass.
- [ ] New/updated tests are included
___

This PR adds support for `width` property for ui.copyable_text and makes it consistent with the rest of the form components. Updated API is as follows:

```tsx
export interface CopyableText {
  /** Text to be displayed inside the component. */
  value: S
  /** The text displayed above the textbox. */
  label: S
  /** An identifying name for this component. */
  name?: S
  /** True if the component should allow multi-line text entry. */
  multiline?: B
  /** Custom height in px (e.g. '200px') or '1' to fill the remaining card space. Requires `multiline` to be set. */
  height?: S
  /** The width of the copyable text , e.g. '100px'. */
  width?: S
}
```

<img width="451" alt="image" src="https://github.com/h2oai/wave/assets/23740173/702c5cb8-819a-4c1f-8875-1192e5aa82c3">


Closes #2282