### PR TITLE
feat: Support decimal values in table progress cell type #824

### DIFF
--- a/ui/src/progress_table_cell_type.test.tsx
+++ b/ui/src/progress_table_cell_type.test.tsx
@@ -25,8 +25,8 @@ const
     {input: 0.888, output: '88.8%'},
     {input: 0.8888, output: '88.88%'},
     {input: 0.88888, output: '88.89%'},
-    {input: 0.88899, output: '88.9%'},
-    {input: 0.88999, output: '89%'},]  
+    {input: 0.88899, output: '88.90%'},
+    {input: 0.88999, output: '89.00%'},]  
 
 describe('ProgressTableCellType.tsx', () => {
 

--- a/ui/src/progress_table_cell_type.test.tsx
+++ b/ui/src/progress_table_cell_type.test.tsx
@@ -19,7 +19,14 @@ import { ProgressTableCellType, XProgressTableCellType } from './progress_table_
 const
   name = 'progress-cell',
   progress = 0.0,
-  progressCellProps: ProgressTableCellType = { name }
+  progressCellProps: ProgressTableCellType = { name },
+  progressValues = [
+    {input: 0.88, output: '88%'},
+    {input: 0.888, output: '88.8%'},
+    {input: 0.8888, output: '88.88%'},
+    {input: 0.88888, output: '88.89%'},
+    {input: 0.88899, output: '88.9%'},
+    {input: 0.88999, output: '89%'},]  
 
 describe('ProgressTableCellType.tsx', () => {
 
@@ -32,4 +39,13 @@ describe('ProgressTableCellType.tsx', () => {
     const { queryByTestId } = render(<XProgressTableCellType model={progressCellProps} progress={progress} />)
     expect(queryByTestId(name)).toBeInTheDocument()
   })
+
+  it('Renders data-test attr with decimal values', () => {
+    const { queryByTestId, rerender } = render(<XProgressTableCellType model={progressCellProps} progress={progress} />)
+    progressValues.map(progressValue => {
+      rerender(<XProgressTableCellType model={progressCellProps} progress={progressValue.input} />)
+      expect(queryByTestId(name)).toBeInTheDocument()
+      expect(queryByTestId(name)).toHaveTextContent(progressValue.output)      
+    })
+  })  
 })

--- a/ui/src/progress_table_cell_type.tsx
+++ b/ui/src/progress_table_cell_type.tsx
@@ -50,7 +50,7 @@ export const XProgressTableCellType = ({ model: m, progress }: { model: Progress
   <div data-test={m.name} className={css.container}>
     <ProgressArc thickness={2} color={cssVar(m.color || '$red')} value={progress} />
     <Fluent.Stack horizontalAlign='center' verticalAlign='center' className={clas(css.percentContainer, 'wave-s12')}>
-      <div className={css.percent}>{`${Math.round(progress * 100)}%`}</div>
+      <div className={css.percent}>{`${Number.parseFloat((progress * 100).toFixed(2))}%`}</div>
     </Fluent.Stack>
   </div >
 )

--- a/ui/src/progress_table_cell_type.tsx
+++ b/ui/src/progress_table_cell_type.tsx
@@ -50,7 +50,7 @@ export const XProgressTableCellType = ({ model: m, progress }: { model: Progress
   <div data-test={m.name} className={css.container}>
     <ProgressArc thickness={2} color={cssVar(m.color || '$red')} value={progress} />
     <Fluent.Stack horizontalAlign='center' verticalAlign='center' className={clas(css.percentContainer, 'wave-s12')}>
-      <div className={css.percent}>{`${Number.parseFloat((progress * 100).toFixed(2))}%`}</div>
+      <div className={css.percent}>{`${Number.isInteger(progress * 1000) ? (progress * 100) : (progress * 100).toFixed(2)}%`}</div>
     </Fluent.Stack>
   </div >
 )


### PR DESCRIPTION
Closes #824 

**The PR fulfills these requirements:** (check all the apply)

- [x] It's submitted to the `main` branch.
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `feat: Add a button #xxx`, where "xxx" is the issue number).
- [x] When resolving a specific issue, the PR description includes `Closes #xxx`, where "xxx" is the issue number.
- [x] If changes were made to `ui` folder, unit tests (`make test`) still pass.
- [x] New/updated tests are included

As explained in the issue, the table progress cell currently rounds values to whole numbers when diplaying them as a percentage. With this change, the percentage will now render with up to 2 decimal places. This is accomplished by using toFixed(2) and parseFloat() together to ensure data is rounded properly and then trailing zeros are removed. The code change in `ui/src/progress_table_cell_type.tsx` looks like this:

```{typescript}
<div className={css.percent}>{`${Number.parseFloat((progress * 100).toFixed(2))}%`}</div>
```

Here is a partial screen shot of the Table example where you can see the progress data now being displayed with up to 2 decimal places:

![output_example_issue_824](https://github.com/h2oai/wave/assets/61979454/6a53fbbe-239d-48fb-9570-1576258a0ed5)

There is a new test case in `progress_table_cell_type.test.tsx`. The test rerenders the `XProgressTableCellType` component in a loop to make sure that the component is rendering the following input decimal values correctly:

```{typescript}
  progressValues = [
    {input: 0.88, output: '88%'},
    {input: 0.888, output: '88.8%'},
    {input: 0.8888, output: '88.88%'},
    {input: 0.88888, output: '88.89%'},
    {input: 0.88899, output: '88.9%'},
    {input: 0.88999, output: '89%'},]
```

I ran all the ui tests and confirmed they passed. Here is a screen shot for that:

![wave_ui_test_issue_824](https://github.com/h2oai/wave/assets/61979454/35502489-4df3-40b2-a1ea-7d683d000677)





