### PR TITLE
feat: Support loading ESM modules using ui.script #2331

### DIFF
--- a/py/h2o_lightwave/h2o_lightwave/types.py
+++ b/py/h2o_lightwave/h2o_lightwave/types.py
@@ -10567,12 +10567,14 @@ class Script:
             cross_origin: Optional[str] = None,
             referrer_policy: Optional[str] = None,
             integrity: Optional[str] = None,
+            type: Optional[str] = None,
     ):
         _guard_scalar('Script.path', path, (str,), False, False, False)
         _guard_scalar('Script.asynchronous', asynchronous, (bool,), False, True, False)
         _guard_scalar('Script.cross_origin', cross_origin, (str,), False, True, False)
         _guard_scalar('Script.referrer_policy', referrer_policy, (str,), False, True, False)
         _guard_scalar('Script.integrity', integrity, (str,), False, True, False)
+        _guard_scalar('Script.type', type, (str,), False, True, False)
         self.path = path
         """The URI of an external script."""
         self.asynchronous = asynchronous
@@ -10583,6 +10585,8 @@ class Script:
         """Indicates which referrer to send when fetching the script. See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script"""
         self.integrity = integrity
         """The cryptographic hash to verify the script's integrity. See https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity"""
+        self.type = type
+        """Type of the script. See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type"""
 
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""
@@ -10591,12 +10595,14 @@ class Script:
         _guard_scalar('Script.cross_origin', self.cross_origin, (str,), False, True, False)
         _guard_scalar('Script.referrer_policy', self.referrer_policy, (str,), False, True, False)
         _guard_scalar('Script.integrity', self.integrity, (str,), False, True, False)
+        _guard_scalar('Script.type', self.type, (str,), False, True, False)
         return _dump(
             path=self.path,
             asynchronous=self.asynchronous,
             cross_origin=self.cross_origin,
             referrer_policy=self.referrer_policy,
             integrity=self.integrity,
+            type=self.type,
         )
 
     @staticmethod
@@ -10612,17 +10618,21 @@ class Script:
         _guard_scalar('Script.referrer_policy', __d_referrer_policy, (str,), False, True, False)
         __d_integrity: Any = __d.get('integrity')
         _guard_scalar('Script.integrity', __d_integrity, (str,), False, True, False)
+        __d_type: Any = __d.get('type')
+        _guard_scalar('Script.type', __d_type, (str,), False, True, False)
         path: str = __d_path
         asynchronous: Optional[bool] = __d_asynchronous
         cross_origin: Optional[str] = __d_cross_origin
         referrer_policy: Optional[str] = __d_referrer_policy
         integrity: Optional[str] = __d_integrity
+        type: Optional[str] = __d_type
         return Script(
             path,
             asynchronous,
             cross_origin,
             referrer_policy,
             integrity,
+            type,
         )
 
 

--- a/py/h2o_lightwave/h2o_lightwave/ui.py
+++ b/py/h2o_lightwave/h2o_lightwave/ui.py
@@ -3725,6 +3725,7 @@ def script(
         cross_origin: Optional[str] = None,
         referrer_policy: Optional[str] = None,
         integrity: Optional[str] = None,
+        type: Optional[str] = None,
 ) -> Script:
     """Create a reference to an external Javascript file to be included on a page.
 
@@ -3734,6 +3735,7 @@ def script(
         cross_origin: The CORS setting for this script. See https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin
         referrer_policy: Indicates which referrer to send when fetching the script. See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script
         integrity: The cryptographic hash to verify the script's integrity. See https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity
+        type: Type of the script. See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type
     Returns:
         A `h2o_wave.types.Script` instance.
     """
@@ -3743,6 +3745,7 @@ def script(
         cross_origin,
         referrer_policy,
         integrity,
+        type,
     )
 
 

--- a/py/h2o_wave/h2o_wave/types.py
+++ b/py/h2o_wave/h2o_wave/types.py
@@ -10567,12 +10567,14 @@ class Script:
             cross_origin: Optional[str] = None,
             referrer_policy: Optional[str] = None,
             integrity: Optional[str] = None,
+            type: Optional[str] = None,
     ):
         _guard_scalar('Script.path', path, (str,), False, False, False)
         _guard_scalar('Script.asynchronous', asynchronous, (bool,), False, True, False)
         _guard_scalar('Script.cross_origin', cross_origin, (str,), False, True, False)
         _guard_scalar('Script.referrer_policy', referrer_policy, (str,), False, True, False)
         _guard_scalar('Script.integrity', integrity, (str,), False, True, False)
+        _guard_scalar('Script.type', type, (str,), False, True, False)
         self.path = path
         """The URI of an external script."""
         self.asynchronous = asynchronous
@@ -10583,6 +10585,8 @@ class Script:
         """Indicates which referrer to send when fetching the script. See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script"""
         self.integrity = integrity
         """The cryptographic hash to verify the script's integrity. See https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity"""
+        self.type = type
+        """Type of the script. See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type"""
 
     def dump(self) -> Dict:
         """Returns the contents of this object as a dict."""
@@ -10591,12 +10595,14 @@ class Script:
         _guard_scalar('Script.cross_origin', self.cross_origin, (str,), False, True, False)
         _guard_scalar('Script.referrer_policy', self.referrer_policy, (str,), False, True, False)
         _guard_scalar('Script.integrity', self.integrity, (str,), False, True, False)
+        _guard_scalar('Script.type', self.type, (str,), False, True, False)
         return _dump(
             path=self.path,
             asynchronous=self.asynchronous,
             cross_origin=self.cross_origin,
             referrer_policy=self.referrer_policy,
             integrity=self.integrity,
+            type=self.type,
         )
 
     @staticmethod
@@ -10612,17 +10618,21 @@ class Script:
         _guard_scalar('Script.referrer_policy', __d_referrer_policy, (str,), False, True, False)
         __d_integrity: Any = __d.get('integrity')
         _guard_scalar('Script.integrity', __d_integrity, (str,), False, True, False)
+        __d_type: Any = __d.get('type')
+        _guard_scalar('Script.type', __d_type, (str,), False, True, False)
         path: str = __d_path
         asynchronous: Optional[bool] = __d_asynchronous
         cross_origin: Optional[str] = __d_cross_origin
         referrer_policy: Optional[str] = __d_referrer_policy
         integrity: Optional[str] = __d_integrity
+        type: Optional[str] = __d_type
         return Script(
             path,
             asynchronous,
             cross_origin,
             referrer_policy,
             integrity,
+            type,
         )
 
 

--- a/py/h2o_wave/h2o_wave/ui.py
+++ b/py/h2o_wave/h2o_wave/ui.py
@@ -3725,6 +3725,7 @@ def script(
         cross_origin: Optional[str] = None,
         referrer_policy: Optional[str] = None,
         integrity: Optional[str] = None,
+        type: Optional[str] = None,
 ) -> Script:
     """Create a reference to an external Javascript file to be included on a page.
 
@@ -3734,6 +3735,7 @@ def script(
         cross_origin: The CORS setting for this script. See https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin
         referrer_policy: Indicates which referrer to send when fetching the script. See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script
         integrity: The cryptographic hash to verify the script's integrity. See https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity
+        type: Type of the script. See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type
     Returns:
         A `h2o_wave.types.Script` instance.
     """
@@ -3743,6 +3745,7 @@ def script(
         cross_origin,
         referrer_policy,
         integrity,
+        type,
     )
 
 

--- a/r/R/ui.R
+++ b/r/R/ui.R
@@ -4347,6 +4347,7 @@ ui_tracker <- function(
 #' @param cross_origin The CORS setting for this script. See https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin
 #' @param referrer_policy Indicates which referrer to send when fetching the script. See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script
 #' @param integrity The cryptographic hash to verify the script's integrity. See https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity
+#' @param type Type of the script. See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type
 #' @return A Script instance.
 #' @export
 ui_script <- function(
@@ -4354,18 +4355,21 @@ ui_script <- function(
   asynchronous = NULL,
   cross_origin = NULL,
   referrer_policy = NULL,
-  integrity = NULL) {
+  integrity = NULL,
+  type = NULL) {
   .guard_scalar("path", "character", path)
   .guard_scalar("asynchronous", "logical", asynchronous)
   .guard_scalar("cross_origin", "character", cross_origin)
   .guard_scalar("referrer_policy", "character", referrer_policy)
   .guard_scalar("integrity", "character", integrity)
+  .guard_scalar("type", "character", type)
   .o <- list(
     path=path,
     asynchronous=asynchronous,
     cross_origin=cross_origin,
     referrer_policy=referrer_policy,
-    integrity=integrity)
+    integrity=integrity,
+    type=type)
   class(.o) <- append(class(.o), c(.wave_obj, "WaveScript"))
   return(.o)
 }

--- a/tools/intellij-plugin/src/main/resources/templates/wave-components.xml
+++ b/tools/intellij-plugin/src/main/resources/templates/wave-components.xml
@@ -2146,12 +2146,13 @@
       <option name="Python" value="true"/>
     </context>
   </template>
-  <template name="w_full_script" value="ui.script(path='$path$',asynchronous=$asynchronous$,cross_origin='$cross_origin$',referrer_policy='$referrer_policy$',integrity='$integrity$'),$END$" description="Create Wave Script with full attributes." toReformat="true" toShortenFQNames="true">
+  <template name="w_full_script" value="ui.script(path='$path$',asynchronous=$asynchronous$,cross_origin='$cross_origin$',referrer_policy='$referrer_policy$',integrity='$integrity$',type='$type$'),$END$" description="Create Wave Script with full attributes." toReformat="true" toShortenFQNames="true">
     <variable name="path" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="asynchronous" expression="" defaultValue="&quot;False&quot;" alwaysStopAt="true"/>
     <variable name="cross_origin" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="referrer_policy" expression="" defaultValue="" alwaysStopAt="true"/>
     <variable name="integrity" expression="" defaultValue="" alwaysStopAt="true"/>
+    <variable name="type" expression="" defaultValue="" alwaysStopAt="true"/>
     <context>
       <option name="Python" value="true"/>
     </context>

--- a/tools/vscode-extension/component-snippets.json
+++ b/tools/vscode-extension/component-snippets.json
@@ -1605,7 +1605,7 @@
   "Wave Full Script": {
     "prefix": "w_full_script",
     "body": [
-      "ui.script(path='$1', asynchronous=${2:False}, cross_origin='$3', referrer_policy='$4', integrity='$5'),$0"
+      "ui.script(path='$1', asynchronous=${2:False}, cross_origin='$3', referrer_policy='$4', integrity='$5', type='$6'),$0"
     ],
     "description": "Create a full Wave Script."
   },

--- a/ui/src/script.ts
+++ b/ui/src/script.ts
@@ -14,6 +14,8 @@ export interface Script {
   referrer_policy?: S
   /** The cryptographic hash to verify the script's integrity. See https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity */
   integrity?: S
+  /** Type of the script. See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type */
+  type?: S
 }
 
 /**
@@ -58,10 +60,10 @@ const
 
 export const
   installScripts = (scripts: Script[]) => {
-    scripts.forEach(({ path, asynchronous, cross_origin, referrer_policy, integrity }) => {
+    scripts.forEach(({ path, asynchronous, cross_origin, referrer_policy, integrity, type }) => {
       if (installedScripts[path]) return // load exactly once
       const e = document.createElement('script')
-      e.type = 'text/javascript'
+      e.type = type || 'text/javascript'
       e.src = path
       if (asynchronous) e.async = true
       if (cross_origin) e.crossOrigin = cross_origin

--- a/website/docs/javascript.md
+++ b/website/docs/javascript.md
@@ -76,6 +76,16 @@ In the above example, we create an empty `div` HTML element on the page, load an
 - The `requires` argument ensures that the library we intend to use (in this case, `anime.js`) is downloaded, imported, and ready to use.
 - The `targets` argument ensures that the HTML element the scripts operates on (in this case, the `div` element named `animation`), is available on the page. [CSS selectors](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors) can also be used to identify target elements.
 
+Import ESM module:
+
+When using JavaScript module files (`.mjs`), the script `type="module"` attribute needs to be specified.
+
+```py
+q.page['meta'] = ui.meta_card(box='', scripts=[ui.script(type="module", path='https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.2.67/pdf.min.mjs')])
+```
+
+For other script types see the [official documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type).
+
 ## Handling Events
 
 In most cases, when employing custom Javascript libraries, you'll want to handle and transmit events from the library to your app. To do this, use the Javascript function `wave.emit()`:

--- a/website/docs/javascript.md
+++ b/website/docs/javascript.md
@@ -32,13 +32,13 @@ q.page.save()
 
 Passing `scripts` to `ui.meta_card()` dynamically imports external Javascript libraries.
 
-Import a library:
+### Import a library
 
 ```py
 q.page['meta'] = ui.meta_card(box='', scripts=[ui.script('https://cdnjs.cloudflare.com/ajax/libs/animejs/2.0.2/anime.min.js')])
 ```
 
-Import multiple libraries:
+### Import multiple libraries
 
 ```py
 q.page['meta'] = ui.meta_card(box='', scripts=[
@@ -48,7 +48,7 @@ q.page['meta'] = ui.meta_card(box='', scripts=[
 ])
 ```
 
-Import and use a library:
+### Import and use a library
 
 ```py
 q.page['meta'] = ui.meta_card(
@@ -76,7 +76,7 @@ In the above example, we create an empty `div` HTML element on the page, load an
 - The `requires` argument ensures that the library we intend to use (in this case, `anime.js`) is downloaded, imported, and ready to use.
 - The `targets` argument ensures that the HTML element the scripts operates on (in this case, the `div` element named `animation`), is available on the page. [CSS selectors](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors) can also be used to identify target elements.
 
-Import ESM module:
+### Import ESM module
 
 When using JavaScript module files (`.mjs`), the script `type="module"` attribute needs to be specified.
 


### PR DESCRIPTION
**The PR fulfills these requirements:** (check all the apply)

- [x] It's submitted to the `main` branch.
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `feat: Add a button #xxx`, where "xxx" is the issue number).
- [x] When resolving a specific issue, the PR description includes `Closes #xxx`, where "xxx" is the issue number.
- [x] If changes were made to `ui` folder, unit tests (`make test`) still pass.
- [ ] New/updated tests are included
___

Adds `type` attribute to `ui.script()`. Tested manually - it loads JavaScript modules properly when `type="module"` is specified.

Closes #2331 