### PR TITLE
build: 🔒Enable and enforce `boringcrypto` experiment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,10 +104,10 @@ test-ui-watch: ## Run UI unit tests
 	cd ui && $(MAKE) test
 
 build-server: ## Build server for current OS/Arch
-	go build $(LDFLAGS) -o waved cmd/wave/main.go
+	GOEXPERIMENT=boringcrypto go build $(LDFLAGS) -o waved cmd/wave/main.go
 
 build-db: ## Build database server for current OS/Arch
-	go build $(LDFLAGS) -o wavedb cmd/wavedb/main.go
+	GOEXPERIMENT=boringcrypto go build $(LDFLAGS) -o wavedb cmd/wavedb/main.go
 
 build-db-micro:
 	go build -ldflags '-s -w -X main.Version=$(VERSION) -X main.BuildDate=$(BUILD_DATE)' -o wavedb cmd/wavedb/main.go
@@ -201,7 +201,7 @@ release-os:
 	rm -rf test/cypress/screenshots/*.*
 	rm -rf test/cypress/videos/*.*
 	rsync --exclude node_modules -a test build/$(REL)/
-	GOOS=$(OS) GOARCH=$(ARCH) go build $(LDFLAGS) -o build/$(REL)/waved$(EXE_EXT) cmd/wave/main.go
+	GOOS=$(OS) GOARCH=$(ARCH) GOEXPERIMENT=boringcrypto go build $(LDFLAGS) -o build/$(REL)/waved$(EXE_EXT) cmd/wave/main.go
 	cd build && tar -czf $(REL).tar.gz  --exclude='*.state'  --exclude='__pycache__' $(REL)
 
 .PHONY: website

--- a/cmd/wave/main.go
+++ b/cmd/wave/main.go
@@ -29,6 +29,13 @@ import (
 	"strings"
 	"time"
 
+	// Blank import of "crypto/tls/fipsonly" enforces that only FIPS-approved algorithms
+	// are used for TLS.
+	// Package is only available only when GOEXPERIMENT=boringcrypto is set.
+	// We do not hide the import behind a build tag so that we enforce that the binary is built with
+	// the boring crypto experiment enabled.
+	_ "crypto/tls/fipsonly"
+
 	"github.com/h2oai/goconfig"
 	_ "github.com/h2oai/goconfig/env"
 	"github.com/h2oai/wave"

--- a/cmd/wavedb/main.go
+++ b/cmd/wavedb/main.go
@@ -19,6 +19,13 @@ import (
 	"fmt"
 	"runtime"
 
+	// Blank import of "crypto/tls/fipsonly" enforces that only FIPS-approved algorithms
+	// are used for TLS.
+	// Package is only available only when GOEXPERIMENT=boringcrypto is set.
+	// We do not hide the import behind a build tag so that we enforce that the binary is built with
+	// the boring crypto experiment enabled.
+	_ "crypto/tls/fipsonly"
+
 	"github.com/h2oai/wave/pkg/db"
 	"github.com/h2oai/wave/pkg/keychain"
 )


### PR DESCRIPTION
`GOEXPERIMENT=boringcrypto` switches `crypto` packages to call BoringCrypto library. It is included as a precompiled object with Go distibution so can be linked to statically.

We want to have all  binaries consistently built this way to get closer to FIPS 140 compliance.
