### PR TITLE
feat: Display active table filter count #1689

### DIFF
--- a/ui/src/table.test.tsx
+++ b/ui/src/table.test.tsx
@@ -1042,7 +1042,21 @@ describe('Table.tsx', () => {
       expect(emitMock).toHaveBeenCalledTimes(1)
     })
 
-    it('Filter counts - manual select, deselect', () => {
+    it('Filter counts - manual select', () => {
+      const { container, getAllByRole, getByLabelText, queryByTestId } = render(<XTable model={tableProps} />)
+
+      expect(getAllByRole('row')).toHaveLength(tableProps.rows!.length + headerRow)
+      fireEvent.click(container.querySelector(filterSelectorName)!)
+      //select 2 options
+      fireEvent.click(getByLabelText('1'))
+      expect(getAllByRole('row')).toHaveLength(1 + headerRow)
+      expect(queryByTestId('filter-count')).toHaveTextContent('1')
+      fireEvent.click(getByLabelText('2'))
+      expect(getAllByRole('row')).toHaveLength(2 + headerRow)
+      expect(queryByTestId('filter-count')).toHaveTextContent('2')
+    })    
+
+    it('Filter counts - manual deselect', () => {
       const { container, getAllByRole, getByLabelText, queryByTestId } = render(<XTable model={tableProps} />)
 
       expect(getAllByRole('row')).toHaveLength(tableProps.rows!.length + headerRow)
@@ -1064,7 +1078,18 @@ describe('Table.tsx', () => {
       expect(queryByTestId('filter-count')).toBeNull
     })    
 
-    it('Filter counts - select all, deselect all', () => {
+    it('Filter counts - select all', () => {
+      const { container, getAllByRole, queryByTestId, getByText } = render(<XTable model={tableProps} />)
+
+      expect(getAllByRole('row')).toHaveLength(tableProps.rows!.length + headerRow)
+      fireEvent.click(container.querySelector(filterSelectorName)!)
+      
+      fireEvent.click(getByText('Select All'))
+      expect(getAllByRole('row')).toHaveLength(tableProps.rows!.length + headerRow)
+      expect(queryByTestId('filter-count')).toHaveTextContent(tableProps.rows!.length.toString())
+    })  
+
+    it('Filter counts - deselect all', () => {
       const { container, getAllByRole, queryByTestId, getByText } = render(<XTable model={tableProps} />)
 
       expect(getAllByRole('row')).toHaveLength(tableProps.rows!.length + headerRow)
@@ -1077,7 +1102,7 @@ describe('Table.tsx', () => {
       fireEvent.click(getByText('Deselect All'))
       expect(getAllByRole('row')).toHaveLength(tableProps.rows!.length + headerRow)
       expect(queryByTestId('filter-count')).toBeNull
-    })  
+    })
 
     it('Filter counts - more than 9 selections', () => {
 
@@ -1110,6 +1135,25 @@ describe('Table.tsx', () => {
       expect(getAllByRole('row')).toHaveLength(tableProps.rows!.length + headerRow)
       expect(queryByTestId('filter-count')).toBeNull
     })     
+
+    it('Filter counts - clear selection with reset', () => {
+      const { container, getAllByRole, getByLabelText, queryByTestId, getByText } = render(<XTable model={{ ...tableProps, resettable: true }} />)
+
+      expect(getAllByRole('row')).toHaveLength(tableProps.rows!.length + headerRow)
+      fireEvent.click(container.querySelector(filterSelectorName)!)
+      //select 2 options
+      fireEvent.click(getByLabelText('1'))
+      expect(getAllByRole('row')).toHaveLength(1 + headerRow)
+      expect(queryByTestId('filter-count')).toHaveTextContent('1')
+      fireEvent.click(getByLabelText('2'))
+      expect(getAllByRole('row')).toHaveLength(2 + headerRow)
+      expect(queryByTestId('filter-count')).toHaveTextContent('2')
+
+      //hit reset to clear the 2 options
+      fireEvent.click(getByText('Reset table'))
+      expect(getAllByRole('row')).toHaveLength(tableProps.rows!.length + headerRow)
+      expect(queryByTestId('filter-count')).toBeNull
+    })
   })
 
 

--- a/ui/src/table.test.tsx
+++ b/ui/src/table.test.tsx
@@ -41,7 +41,8 @@ const
         ]
       }
     }
-  }
+  },
+  filterSelectorName = 'i[class^="filterIcon"]'
 
 let tableProps: Table
 let sortTableProps: Table
@@ -105,8 +106,7 @@ describe('Table.tsx', () => {
     }
 
     const { container, getAllByRole, getAllByTestId } = render(<XTable model={tableProps} />)
-
-    fireEvent.click(container.querySelector('.ms-DetailsHeader-filterChevron')!)
+    fireEvent.click(container.querySelector(filterSelectorName)!)
 
     const checkboxes = getAllByRole('checkbox')
     expect(checkboxes).toHaveLength(3)
@@ -131,7 +131,7 @@ describe('Table.tsx', () => {
 
     const { container, getAllByRole, getAllByTestId } = render(<XTable model={tableProps} />)
 
-    fireEvent.click(container.querySelector('.ms-DetailsHeader-filterChevron')!)
+    fireEvent.click(container.querySelector(filterSelectorName)!)
 
     expect(getAllByRole('checkbox')).toHaveLength(2)
 
@@ -446,7 +446,7 @@ describe('Table.tsx', () => {
       expect(emitMock).toHaveBeenCalledTimes(1)
 
       // Exclude selected item by using filter.
-      fireEvent.click(container.querySelector('.ms-DetailsHeader-filterChevron') as HTMLElement)
+      fireEvent.click(container.querySelector(filterSelectorName) as HTMLElement)
       fireEvent.click(getAllByText('2')[1].parentElement as HTMLDivElement)
 
       expect(getAllByRole('gridcell')[1].textContent).toBe('Quick brown fox.')
@@ -670,7 +670,7 @@ describe('Table.tsx', () => {
       expect(getAllByRole('gridcell')[0].textContent).toBe('a')
 
       // Open filter menu
-      fireEvent.click(container.querySelector('.ms-DetailsHeader-filterChevron') as HTMLElement)
+      fireEvent.click(container.querySelector(filterSelectorName) as HTMLElement)
 
       fireEvent.click(getAllByText('closed')[2].parentElement as HTMLDivElement)
       expect(getAllByRole('gridcell')[0].textContent).toBe('c')
@@ -690,7 +690,7 @@ describe('Table.tsx', () => {
       expect(getAllByRole('gridcell')[0].textContent).toBe('a')
 
       // Open filter menu
-      fireEvent.click(container.querySelector('.ms-DetailsHeader-filterChevron') as HTMLElement)
+      fireEvent.click(container.querySelector(filterSelectorName) as HTMLElement)
 
       fireEvent.click(getByText('Select All'))
       expect(getAllByRole('gridcell')[0].textContent).toBe('a')
@@ -724,7 +724,7 @@ describe('Table.tsx', () => {
       expect(getAllByRole('gridcell')[14].textContent).toBe('b')
 
       // Open filter menu
-      fireEvent.click(container.querySelector('.ms-DetailsHeader-filterChevron') as HTMLElement)
+      fireEvent.click(container.querySelector(filterSelectorName) as HTMLElement)
 
       fireEvent.click(getAllByText('closed')[3].parentElement as HTMLDivElement)
       expect(getAllByRole('gridcell')[3].textContent).toBe('c')
@@ -766,7 +766,7 @@ describe('Table.tsx', () => {
       expectCorrectSortOrder()
 
       // Open filter menu
-      fireEvent.click(container.querySelector('.ms-DetailsHeader-filterChevron') as HTMLElement)
+      fireEvent.click(container.querySelector(filterSelectorName) as HTMLElement)
 
       fireEvent.click(getByText('Select All'))
       expectCorrectSortOrder()
@@ -789,7 +789,7 @@ describe('Table.tsx', () => {
       fireEvent.click(getByText('Reset table'))
 
       // Open filter menu
-      fireEvent.click(container.querySelector('.ms-DetailsHeader-filterChevron') as HTMLElement)
+      fireEvent.click(container.querySelector(filterSelectorName) as HTMLElement)
 
       fireEvent.click(getAllByText('open')[2].parentElement as HTMLDivElement)
       expect(getAllByRole('gridcell')[0].textContent).toBe('b')
@@ -942,7 +942,7 @@ describe('Table.tsx', () => {
         ]
       }
       const { container, getByText, getAllByText } = render(<XTable model={tableProps} />)
-      fireEvent.click(container.querySelector('.ms-DetailsHeader-filterChevron') as HTMLElement)
+      fireEvent.click(container.querySelector(filterSelectorName) as HTMLElement)
       fireEvent.click(getAllByText('1')[1].parentElement as HTMLDivElement)
       expect(getByText('foo')).toBeInTheDocument()
       expect(getByText('bar')).toBeInTheDocument()
@@ -952,7 +952,7 @@ describe('Table.tsx', () => {
       const { container, getAllByText, getAllByRole } = render(<XTable model={tableProps} />)
 
       expect(getAllByRole('row')).toHaveLength(tableProps.rows!.length + headerRow)
-      fireEvent.click(container.querySelector('.ms-DetailsHeader-filterChevron')!)
+      fireEvent.click(container.querySelector(filterSelectorName)!)
       fireEvent.click(getAllByText('1')[1].parentElement!)
       expect(getAllByRole('row')).toHaveLength(1 + headerRow)
     })
@@ -961,7 +961,7 @@ describe('Table.tsx', () => {
       const { container, getAllByText, getAllByRole, getByText } = render(<XTable model={tableProps} />)
 
       expect(getAllByRole('row')).toHaveLength(tableProps.rows!.length + headerRow)
-      fireEvent.click(container.querySelector('.ms-DetailsHeader-filterChevron')!)
+      fireEvent.click(container.querySelector(filterSelectorName)!)
       fireEvent.click(getAllByText('1')[1].parentElement!)
       expect(getAllByRole('row')).toHaveLength(1 + headerRow)
       fireEvent.click(getByText('Select All'))
@@ -972,7 +972,7 @@ describe('Table.tsx', () => {
       const { container, getAllByText, getAllByRole, getByText } = render(<XTable model={tableProps} />)
 
       expect(getAllByRole('row')).toHaveLength(tableProps.rows!.length + headerRow)
-      fireEvent.click(container.querySelector('.ms-DetailsHeader-filterChevron')!)
+      fireEvent.click(container.querySelector(filterSelectorName)!)
       fireEvent.click(getAllByText('1')[1].parentElement!)
       expect(getAllByRole('row')).toHaveLength(1 + headerRow)
       fireEvent.click(getByText('Deselect All'))
@@ -983,7 +983,7 @@ describe('Table.tsx', () => {
       const { container, getAllByText, getAllByRole } = render(<XTable model={tableProps} />)
 
       expect(getAllByRole('row')).toHaveLength(tableProps.rows!.length + headerRow)
-      fireEvent.click(container.querySelector('.ms-DetailsHeader-filterChevron')!)
+      fireEvent.click(container.querySelector(filterSelectorName)!)
       fireEvent.click(getAllByText('1')[1].parentElement!)
       fireEvent.click(getAllByText('2')[0].parentElement!)
       expect(getAllByRole('row')).toHaveLength(2 + headerRow)
@@ -1006,7 +1006,7 @@ describe('Table.tsx', () => {
       const { container, getAllByText, getAllByRole } = render(<XTable model={tableProps} />)
 
       expect(getAllByRole('row')).toHaveLength(tableProps.rows!.length + headerRow)
-      fireEvent.click(container.querySelector('.ms-DetailsHeader-filterChevron')!)
+      fireEvent.click(container.querySelector(filterSelectorName)!)
       fireEvent.click(getAllByText('1')[1].parentElement!)
       fireEvent.click(getAllByText('2')[0].parentElement!)
       expect(getAllByRole('row')).toHaveLength(2 + headerRow)
@@ -1014,8 +1014,8 @@ describe('Table.tsx', () => {
 
     it('Fires event when pagination enabled', () => {
       const { container, getAllByText } = render(<XTable model={{ ...tableProps, pagination: { total_rows: 10, rows_per_page: 5 }, events: ['filter'] }} />)
-
-      fireEvent.click(container.querySelector('.ms-DetailsHeader-filterChevron') as HTMLDivElement)
+      
+      fireEvent.click(container.querySelector(filterSelectorName) as HTMLDivElement)
       fireEvent.click(getAllByText('1')[3].parentElement as HTMLDivElement)
 
       expect(emitMock).toHaveBeenCalledWith(tableProps.name, 'filter', { 'colname2': ['1'] })
@@ -1025,7 +1025,7 @@ describe('Table.tsx', () => {
     it('Fires event when pagination enabled - select all', () => {
       const { container, getByText } = render(<XTable model={{ ...tableProps, pagination: { total_rows: 10, rows_per_page: 5 }, events: ['filter'] }} />)
 
-      fireEvent.click(container.querySelector('.ms-DetailsHeader-filterChevron') as HTMLDivElement)
+      fireEvent.click(container.querySelector(filterSelectorName) as HTMLDivElement)
       fireEvent.click(getByText('Select All'))
 
       expect(emitMock).toHaveBeenCalledWith(tableProps.name, 'filter', { 'colname2': ['2', '1', '3'] })
@@ -1035,13 +1035,83 @@ describe('Table.tsx', () => {
     it('Fires event when pagination enabled - deselect all', () => {
       const { container, getByText } = render(<XTable model={{ ...tableProps, pagination: { total_rows: 10, rows_per_page: 5 }, events: ['filter'] }} />)
 
-      fireEvent.click(container.querySelector('.ms-DetailsHeader-filterChevron') as HTMLDivElement)
+      fireEvent.click(container.querySelector(filterSelectorName) as HTMLDivElement)
       fireEvent.click(getByText('Deselect All'))
 
       expect(emitMock).toHaveBeenCalledWith(tableProps.name, 'filter', { 'colname2': [] })
       expect(emitMock).toHaveBeenCalledTimes(1)
     })
+
+    it('Filter counts - manual select, deselect', () => {
+      const { container, getAllByRole, getByLabelText, queryByTestId } = render(<XTable model={tableProps} />)
+
+      expect(getAllByRole('row')).toHaveLength(tableProps.rows!.length + headerRow)
+      fireEvent.click(container.querySelector(filterSelectorName)!)
+      //select 2 options
+      fireEvent.click(getByLabelText('1'))
+      expect(getAllByRole('row')).toHaveLength(1 + headerRow)
+      expect(queryByTestId('filter-count')).toHaveTextContent('1')
+      fireEvent.click(getByLabelText('2'))
+      expect(getAllByRole('row')).toHaveLength(2 + headerRow)
+      expect(queryByTestId('filter-count')).toHaveTextContent('2')
+
+      //deselect the 2 options
+      fireEvent.click(getByLabelText('1'))
+      expect(getAllByRole('row')).toHaveLength(1 + headerRow)
+      expect(queryByTestId('filter-count')).toHaveTextContent('1')
+      fireEvent.click(getByLabelText('2'))
+      expect(getAllByRole('row')).toHaveLength(tableProps.rows!.length + headerRow)
+      expect(queryByTestId('filter-count')).toBeNull
+    })    
+
+    it('Filter counts - select all, deselect all', () => {
+      const { container, getAllByRole, queryByTestId, getByText } = render(<XTable model={tableProps} />)
+
+      expect(getAllByRole('row')).toHaveLength(tableProps.rows!.length + headerRow)
+      fireEvent.click(container.querySelector(filterSelectorName)!)
+      
+      fireEvent.click(getByText('Select All'))
+      expect(getAllByRole('row')).toHaveLength(tableProps.rows!.length + headerRow)
+      expect(queryByTestId('filter-count')).toHaveTextContent(tableProps.rows!.length.toString())
+
+      fireEvent.click(getByText('Deselect All'))
+      expect(getAllByRole('row')).toHaveLength(tableProps.rows!.length + headerRow)
+      expect(queryByTestId('filter-count')).toBeNull
+    })  
+
+    it('Filter counts - more than 9 selections', () => {
+
+      tableProps = {
+        ...tableProps,
+        rows: [
+          { name: 'rowname1', cells: ['col1a', 'col2a'] },
+          { name: 'rowname2', cells: ['col1b', 'col2b'] },
+          { name: 'rowname3', cells: ['col1c', 'col2c'] },
+          { name: 'rowname4', cells: ['col1d', 'col2d'] },
+          { name: 'rowname5', cells: ['col1e', 'col2e'] },
+          { name: 'rowname6', cells: ['col1f', 'col2f'] },
+          { name: 'rowname7', cells: ['col1g', 'col2g'] },
+          { name: 'rowname8', cells: ['col1h', 'col2h'] },
+          { name: 'rowname9', cells: ['col1i', 'col2i'] },
+          { name: 'rowname10', cells: ['col1j', 'col2j'] },
+        ]
+      }
+
+      const { container, getAllByRole, queryByTestId, getByText } = render(<XTable model={tableProps} />)
+
+      expect(getAllByRole('row')).toHaveLength(tableProps.rows!.length + headerRow)
+      fireEvent.click(container.querySelector(filterSelectorName)!)
+      
+      fireEvent.click(getByText('Select All'))
+      expect(getAllByRole('row')).toHaveLength(tableProps.rows!.length + headerRow)
+      expect(queryByTestId('filter-count')).toHaveTextContent('9+')
+
+      fireEvent.click(getByText('Deselect All'))
+      expect(getAllByRole('row')).toHaveLength(tableProps.rows!.length + headerRow)
+      expect(queryByTestId('filter-count')).toBeNull
+    })     
   })
+
 
   describe('filter - tags', () => {
     beforeEach(() => {
@@ -1062,11 +1132,11 @@ describe('Table.tsx', () => {
     it('Filters correctly - tags - correct tags are selected', () => {
       const { getByTestId, container, getAllByText, getAllByRole } = render(<XTable model={tableProps} />)
 
-      fireEvent.click(container.querySelector('.ms-DetailsHeader-filterChevron')!)
+      fireEvent.click(container.querySelector(filterSelectorName)!)
       fireEvent.click(getAllByText('TAG3')[1].parentElement!)
       // Mimic close and reopen filter context menu.
       fireEvent.click(getByTestId(name))
-      fireEvent.click(container.querySelector('.ms-DetailsHeader-filterChevron')!)
+      fireEvent.click(container.querySelector(filterSelectorName)!)
       const [tag1, tag2, tag3] = getAllByRole('checkbox')
       expect(tag1).not.toBeChecked()
       expect(tag2).not.toBeChecked()
@@ -1077,7 +1147,7 @@ describe('Table.tsx', () => {
       const { container, getAllByText, getByText, getAllByRole } = render(<XTable model={tableProps} />)
 
       expect(getAllByRole('row')).toHaveLength(tableProps.rows!.length + headerRow)
-      fireEvent.click(container.querySelector('.ms-DetailsHeader-filterChevron')!)
+      fireEvent.click(container.querySelector(filterSelectorName)!)
       fireEvent.click(getAllByText('TAG1')[1].parentElement!)
       fireEvent.click(getByText('TAG3').parentElement!)
       expect(getAllByRole('row')).toHaveLength(2 + headerRow)
@@ -1087,7 +1157,7 @@ describe('Table.tsx', () => {
       const { container, getAllByText, getAllByRole } = render(<XTable model={tableProps} />)
 
       expect(getAllByRole('row')).toHaveLength(tableProps.rows!.length + headerRow)
-      fireEvent.click(container.querySelector('.ms-DetailsHeader-filterChevron')!)
+      fireEvent.click(container.querySelector(filterSelectorName)!)
       fireEvent.click(getAllByText('TAG1')[1].parentElement!)
       expect(getAllByRole('row')).toHaveLength(1 + headerRow)
     })
@@ -1095,7 +1165,7 @@ describe('Table.tsx', () => {
     it('Fires event when pagination enabled', () => {
       const { container, getAllByText } = render(<XTable model={{ ...tableProps, pagination: { total_rows: 10, rows_per_page: 5 }, events: ['filter'] }} />)
 
-      fireEvent.click(container.querySelector('.ms-DetailsHeader-filterChevron')!)
+      fireEvent.click(container.querySelector(filterSelectorName)!)
       fireEvent.click(getAllByText('TAG1')[1].parentElement!)
       expect(emitMock).toHaveBeenCalledWith(tableProps.name, 'filter', { 'tagsColumn': ['TAG1'] })
       expect(emitMock).toHaveBeenCalledTimes(1)
@@ -1122,7 +1192,7 @@ describe('Table.tsx', () => {
       const { container, getAllByText, getAllByRole, getByTestId } = render(<XTable model={tableProps} />)
 
       expect(getAllByRole('row')).toHaveLength(tableProps.rows!.length + headerRow)
-      fireEvent.click(container.querySelector('.ms-DetailsHeader-filterChevron')!)
+      fireEvent.click(container.querySelector(filterSelectorName)!)
       fireEvent.click(getAllByText('1')[2].parentElement!)
       expect(getAllByRole('row')).toHaveLength(2 + headerRow)
 
@@ -1134,7 +1204,7 @@ describe('Table.tsx', () => {
       const { container, getAllByText, getAllByRole, getByTestId } = render(<XTable model={tableProps} />)
 
       expect(getAllByRole('row')).toHaveLength(tableProps.rows!.length + headerRow)
-      fireEvent.click(container.querySelector('.ms-DetailsHeader-filterChevron')!)
+      fireEvent.click(container.querySelector(filterSelectorName)!)
       fireEvent.click(getAllByText('1')[2].parentElement!)
       expect(getAllByRole('row')).toHaveLength(2 + headerRow)
 
@@ -1147,7 +1217,7 @@ describe('Table.tsx', () => {
 
       expect(getAllByRole('row')).toHaveLength(tableProps.rows!.length + headerRow)
 
-      fireEvent.click(container.querySelector('.ms-DetailsHeader-filterChevron')!)
+      fireEvent.click(container.querySelector(filterSelectorName)!)
       fireEvent.click(getAllByText('1')[2].parentElement!)
       expect(getAllByRole('row')).toHaveLength(2 + headerRow)
 
@@ -1165,27 +1235,28 @@ describe('Table.tsx', () => {
       fireEvent.change(getByTestId('search'), { target: { value: 'w' } })
       expect(getAllByRole('row')).toHaveLength(2 + headerRow)
 
-      fireEvent.click(container.querySelector('.ms-DetailsHeader-filterChevron')!)
+      fireEvent.click(container.querySelector(filterSelectorName)!)
       fireEvent.click(getAllByText('1')[1].parentElement!)
       expect(getAllByRole('row')).toHaveLength(1 + headerRow)
     })
 
     it('Search -> filter clear', () => {
-      const { container, getAllByText, getAllByRole, getByTestId } = render(<XTable model={tableProps} />)
+      const { container, getAllByRole, getByTestId, getByLabelText } = render(<XTable model={tableProps} />)
 
       expect(getAllByRole('row')).toHaveLength(tableProps.rows!.length + headerRow)
 
       fireEvent.change(getByTestId('search'), { target: { value: 'w' } })
       expect(getAllByRole('row')).toHaveLength(2 + headerRow)
 
-      fireEvent.click(container.querySelector('.ms-DetailsHeader-filterChevron')!)
-      fireEvent.click(getAllByText('1')[1].parentElement!)
+      fireEvent.click(container.querySelector(filterSelectorName)!)
+      fireEvent.click(getByLabelText('1'))
       expect(getAllByRole('row')).toHaveLength(1 + headerRow)
-      fireEvent.click(getAllByText('1')[1].parentElement!)
+      fireEvent.click(getByLabelText('1'))
       expect(getAllByRole('row')).toHaveLength(2 + headerRow)
     })
   })
 
+  
   describe('Group by', () => {
     beforeEach(() => {
       tableProps = {
@@ -1252,7 +1323,7 @@ describe('Table.tsx', () => {
       expectAllGroupsToBeVisible()
       expectAllItemsToBePresent()
 
-      fireEvent.click(container.querySelector('.ms-DetailsHeader-filterChevron')!)
+      fireEvent.click(container.querySelector(filterSelectorName)!)
       fireEvent.click(getAllByText('Group1')[3].parentElement!)
 
       expectAllGroupsToBeVisible()
@@ -1458,7 +1529,7 @@ describe('Table.tsx', () => {
       fireEvent.click(container.querySelector('.ms-DetailsHeader-collapseButton')!)
 
       expect(getAllByRole('row')).toHaveLength(headerRow + groupHeaderRowsCount + tableProps.rows!.length)
-      fireEvent.click(container.querySelector('.ms-DetailsHeader-filterChevron')!)
+      fireEvent.click(container.querySelector(filterSelectorName)!)
       fireEvent.click(getAllByText('Group2')[2].parentElement!)
       expect(getAllByRole('row')).toHaveLength(headerRow + groupHeaderRowsCount + filteredItem)
     })
@@ -1471,7 +1542,7 @@ describe('Table.tsx', () => {
       fireEvent.click(container.querySelector('.ms-DetailsHeader-collapseButton')!)
 
       expect(getAllByRole('row')).toHaveLength(headerRow + groupHeaderRowsCount + tableProps.rows!.length)
-      fireEvent.click(container.querySelector('.ms-DetailsHeader-filterChevron')!)
+      fireEvent.click(container.querySelector(filterSelectorName)!)
       fireEvent.click(getAllByText('Group1')[1].parentElement!)
       fireEvent.click(getAllByText('Group2')[0].parentElement!)
       expect(getAllByRole('row')).toHaveLength(headerRow + groupHeaderRowsCount + tableProps.rows!.length)
@@ -1522,7 +1593,7 @@ describe('Table.tsx', () => {
 
       expect(getAllByRole('row')).toHaveLength(headerRow + groupHeaderRowsCount + tableProps.rows!.length)
 
-      fireEvent.click(container.querySelector('.ms-DetailsHeader-filterChevron')!)
+      fireEvent.click(container.querySelector(filterSelectorName)!)
       fireEvent.click(getAllByText('6/22/2022, 8:47:51 PM')[2].parentElement!)
 
       expect(getAllByRole('row')).toHaveLength(headerRow + groupHeaderRowsCount + filteredItem)
@@ -1588,7 +1659,7 @@ describe('Table.tsx', () => {
     it('Filters grouped list - single option', () => {
       const { container, getAllByText, getAllByRole } = render(<XTable model={tableProps} />)
 
-      fireEvent.click(container.querySelector('.ms-DetailsHeader-filterChevron')!)
+      fireEvent.click(container.querySelector(filterSelectorName)!)
       fireEvent.click(getAllByText('Group1')[1].parentElement!)
       expect(getAllByRole('row')).toHaveLength(headerRow + groupHeaderRowsCount + filteredItem)
     })
@@ -1596,7 +1667,7 @@ describe('Table.tsx', () => {
     it('Filters grouped list - multiple options', () => {
       const { container, getAllByText, getAllByRole } = render(<XTable model={tableProps} />)
 
-      fireEvent.click(container.querySelector('.ms-DetailsHeader-filterChevron')!)
+      fireEvent.click(container.querySelector(filterSelectorName)!)
       fireEvent.click(getAllByText('Group1')[1].parentElement!)
       fireEvent.click(getAllByText('Group2')[0].parentElement!)
       expect(getAllByRole('row')).toHaveLength(headerRow + groupHeaderRowsCount + items)
@@ -1644,7 +1715,7 @@ describe('Table.tsx', () => {
       fireEvent.click(container.querySelector('.ms-GroupHeader-expand')!)
       expect(getAllByRole('row')).toHaveLength(headerRow + groupHeaderRowsCount + filteredItem)
 
-      fireEvent.click(container.querySelector('.ms-DetailsHeader-filterChevron')!)
+      fireEvent.click(container.querySelector(filterSelectorName)!)
       fireEvent.click(getAllByText('Group1')[0].parentElement!)
       expect(getAllByRole('row')).toHaveLength(headerRow + groupHeaderRowsCount)
 
@@ -1721,7 +1792,7 @@ describe('Table.tsx', () => {
       expectAllGroupsToBeVisible()
       expectAllItemsToBePresent()
 
-      fireEvent.click(container.querySelector('.ms-DetailsHeader-filterChevron')!)
+      fireEvent.click(container.querySelector(filterSelectorName)!)
       fireEvent.click(getAllByText('Group1')[1].parentElement!)
 
       expectAllGroupsToBeVisible()

--- a/ui/src/table.tsx
+++ b/ui/src/table.tsx
@@ -21,7 +21,7 @@ import { IconTableCellType, XIconTableCellType } from "./icon_table_cell_type"
 import { MarkdownTableCellType, XMarkdownTableCellType } from './markdown_table_cell_type'
 import { ProgressTableCellType, XProgressTableCellType } from "./progress_table_cell_type"
 import { TagTableCellType, XTagTableCellType } from "./tag_table_cell_type"
-import { border, cssVar, important, margin, rem } from './theme'
+import { border, cssVar, important, margin, padding, rem } from './theme'
 import useUpdateOnlyEffect from './parts/useUpdateOnlyEffectHook'
 import { wave } from './ui'
 import { Z_INDEX } from './parts/styleConstants'
@@ -210,27 +210,27 @@ type PaginationProps = {
 
 const
   // TODO: Clean up into correct Fluent style slots.
-  css = stylesheet({ 
-  sortingIcon: {
+  css = stylesheet({
+    sortingIcon: {
       fontSize: rem(1.1),
       position: 'relative',
       top: -2,
     },
-  filterIcon: {
+    filterIcon: {
       color: cssVar('$neutralSecondary'),
       fontSize: 12,
       paddingLeft: 6,
       verticalAlign: 'middle',
     },
-  filterCount: {
-      position: 'relative', 
-      top: -5, 
-      padding: 5,
-      marginLeft: 5, 
-      lineHeight: 'normal', 
+    filterCount: {
+      position: 'relative',
+      top: -10,
+      padding: padding(3, 5),
+      marginLeft: 3,
+      lineHeight: 'normal',
       borderRadius: 8,
       backgroundColor: cssVar('$neutralQuaternary'),
-    }    
+    }
   }),
   styles: Partial<Fluent.IDetailsListStyles> = {
     contentWrapper: {
@@ -364,10 +364,10 @@ const
       }, [items, onRenderMenuList]),
       onColumnClick = React.useCallback((_e: React.MouseEvent<HTMLElement>, column: WaveColumn) => {
         if (column.isSortable) {
-          const sortColAsc = !sortCols || !sortCols[column.key] || sortCols[column.key].includes('Down')  
+          const sortColAsc = !sortCols || !sortCols[column.key] || sortCols[column.key].includes('Down')
           onSortChange(column, sortColAsc)
           setSortCols({
-            [column.key]: sortColAsc ? 'Up' : 'Down', 
+            [column.key]: sortColAsc ? 'Up' : 'Down',
           })
         }
       }, [onSortChange, sortCols]),
@@ -393,33 +393,33 @@ const
             if (!props) return null
 
             const filterCount = selectedFilters?.[props.column.key]?.length || 0
-            const sortIconName = sortCols && sortCols[props.column.key] ? 'Sort'+sortCols[props.column.key] : 'Sort'
+            const sortIconName = sortCols && sortCols[props.column.key] ? 'Sort' + sortCols[props.column.key] : 'Sort'
 
             return (
-              <div style={{ display: 'flex', alignItems: 'center'}}>{props.column.name}
+              <div style={{ display: 'flex', alignItems: 'center' }}>{props.column.name}
                 {c.sortable && (
-                  <Fluent.Icon iconName={sortIconName} 
-                    className={css.sortingIcon} 
-                    style={{ visibility: `${sortIconName === 'Sort' ? 'hidden' : 'visible'}`}}
-                  />                  
+                  <Fluent.Icon iconName={sortIconName}
+                    className={css.sortingIcon}
+                    style={{ visibility: `${sortIconName === 'Sort' ? 'hidden' : 'visible'}` }}
+                  />
                 )}
 
                 {c.filterable && (
-                    <Fluent.Icon iconName='ChevronDown' 
-                                onClick={(ev: React.MouseEvent<HTMLElement>) => {
-                                    ev.stopPropagation()
-                                    onColumnContextMenu(props.column, ev)
-                                }}
-                                className={css.filterIcon}
-                    />
+                  <Fluent.Icon iconName='ChevronDown'
+                    onClick={(ev: React.MouseEvent<HTMLElement>) => {
+                      ev.stopPropagation()
+                      onColumnContextMenu(props.column, ev)
+                    }}
+                    className={css.filterIcon}
+                  />
                 )}
-                
+
                 {filterCount > 0 && (
-                  <span data-test='filter-count' className={css.filterCount}>
+                  <span data-test='filter-count' className={`${css.filterCount} wave-s11 wave-w5`}>
                     {`${filterCount > 9 ? '9+' : filterCount}`}
                   </span>
                 )}
-            </div> 
+              </div>
             )
           },
           onColumnClick,

--- a/ui/src/table.tsx
+++ b/ui/src/table.tsx
@@ -223,14 +223,13 @@ const
       verticalAlign: 'middle',
     },
   filterCount: {
-    position: 'relative', 
-    top: -5, 
-    padding: '0 2px', 
-    color: cssVar('$red'), 
-    border: '0.5px solid', 
-    borderColor: cssVar('$red'), 
-    marginLeft: 5, 
-    lineHeight: 'normal', 
+      position: 'relative', 
+      top: -5, 
+      padding: 5,
+      marginLeft: 5, 
+      lineHeight: 'normal', 
+      borderRadius: 8,
+      backgroundColor: cssVar('$neutralQuaternary'),
     }    
   }),
   styles: Partial<Fluent.IDetailsListStyles> = {
@@ -391,27 +390,21 @@ const
           minWidth,
           maxWidth,
           onRenderHeader: (props?: Fluent.IDetailsColumnProps) => {
-            if (props) {
-              let sortIcon = undefined
-              if (c.sortable) {
-                const sortIconName = sortCols && sortCols[props.column.key] ? 'Sort'+sortCols[props.column.key] : 'Sort'
-                sortIcon = <Fluent.Icon iconName={sortIconName} 
-                                    className={css.sortingIcon} 
-                                    style={{ visibility: `${sortIconName === 'Sort' ? 'hidden' : 'visible'}`}}
-                                  />
-              }
-              let filterCountField = undefined
-              const filterCount = selectedFilters?.[props.column.key]?.length || 0
-              if (filterCount > 0){
-                filterCountField = 
-                  <span data-test='filter-count' className={css.filterCount}>
-                    {`${filterCount > 9 ? '9+' : filterCount}`}
-                  </span>
-              }
-              return <div style={{ display: 'flex', alignItems: 'center'}}>{props.column.name}
-              {sortIcon ? sortIcon : null}
+            if (!props) return null
 
-              {c.filterable ? (
+            const filterCount = selectedFilters?.[props.column.key]?.length || 0
+            const sortIconName = sortCols && sortCols[props.column.key] ? 'Sort'+sortCols[props.column.key] : 'Sort'
+
+            return (
+              <div style={{ display: 'flex', alignItems: 'center'}}>{props.column.name}
+                {c.sortable && (
+                  <Fluent.Icon iconName={sortIconName} 
+                    className={css.sortingIcon} 
+                    style={{ visibility: `${sortIconName === 'Sort' ? 'hidden' : 'visible'}`}}
+                  />                  
+                )}
+
+                {c.filterable && (
                     <Fluent.Icon iconName='ChevronDown' 
                                 onClick={(ev: React.MouseEvent<HTMLElement>) => {
                                     ev.stopPropagation()
@@ -419,11 +412,15 @@ const
                                 }}
                                 className={css.filterIcon}
                     />
-                ) : null
-              }
-              {filterCountField ? filterCountField : null}
-              </div> 
-            } else return null
+                )}
+                
+                {filterCount > 0 && (
+                  <span data-test='filter-count' className={css.filterCount}>
+                    {`${filterCount > 9 ? '9+' : filterCount}`}
+                  </span>
+                )}
+            </div> 
+            )
           },
           onColumnClick,
           columnActionsMode: Fluent.ColumnActionsMode.clickable,
@@ -577,10 +574,6 @@ const
     }, [m.columns, tableToWaveColumn])
     React.useImperativeHandle(ref, () => ({
       resetSortIcons: () => {
-        setColumns(columns => columns.map(col => {
-          if (col.iconName) col.iconName = undefined
-          return col
-        }))
         setSortCols(null)
       }
     }))


### PR DESCRIPTION
**The PR fulfills these requirements:** (check all the apply)

- [x] It's submitted to the `main` branch.
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `feat: Add a button #xxx`, where "xxx" is the issue number).
- [x] When resolving a specific issue, the PR description includes `Closes #xxx`, where "xxx" is the issue number.
- [x] If changes were made to `ui` folder, unit tests (`make test`) still pass.
- [x] New/updated tests are included

Closes #1689

As requested in the ticket, I have updated the table component so that it will display a count of selected options just to the top right of the chevron down icon. As suggested, I used `onRenderHeader` to accomplish this - this means the custom renderer for the column now displays the name, sort icon, chevron icon and count. The code changes are in `ui/src/table.tsx` and here is a screen shot of what it looks like:

![issue1689_output_example](https://github.com/user-attachments/assets/96903b04-f669-43db-9a11-363d5a34733c)

And here is a short video demonstrating the filtering after this change:

https://github.com/user-attachments/assets/fa6f7b85-4a62-40cc-bb08-834b366f4339

Question for you: The count is being rendered in red with a red border to match how the requirement is defined in the ticket. I wasn't sure if that was done in red make it stand-out in the screen shot or if this is how it was supposed to be implemented. Can you confirm if red text with red border is what you expect?

I added 3 new unit tests to `ui/src/table.test.tsx` that check for the new filter counts. These pass along with all the other unit tests. Here is a screen shot of the results from running all the regression tests:

![issue1689_unit-tests_after](https://github.com/user-attachments/assets/f01f33ee-763e-467e-847f-e8fef64cb488)

I also ran the visual regression tool at `tools/showcase`. This was fine except for 3 mismatches found with `time_picker-2.png`, `time_picker-3.png`, and `time_picker-4.png`. I looked at the before and after images and they looked identical to me, so I could not figure out why these were flagged. I suspect these were just false positives?

Let me know how this looks and if you have any questions or suggested changes. Thanks!



