### PR TITLE
feat: Raise error if waved cannot find public/private dir #2130

### DIFF
--- a/server.go
+++ b/server.go
@@ -170,9 +170,9 @@ func splitDirMapping(m string) (string, string) {
 		panic(fmt.Sprintf("invalid directory mapping: want \"remote@local\", got %s", m))
 	}
 
-    if _, err := os.Stat(xs[1]); os.IsNotExist(err){
-        panic(fmt.Sprintf("directory does not exist: %s", xs[1]))
-    }
+	if _, err := os.Stat(xs[1]); os.IsNotExist(err) {
+		panic(fmt.Sprintf("directory does not exist: %s", xs[1]))
+	}
 
 	// Windows prepends the drive letter to the path with a leading slash, e.g. "/foo/" => "C:/foo/".
 	if xs[0][1] == ':' {

--- a/server.go
+++ b/server.go
@@ -22,6 +22,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
 	"path"
 	"path/filepath"
 	"strings"
@@ -168,6 +169,10 @@ func splitDirMapping(m string) (string, string) {
 	if len(xs) < 2 {
 		panic(fmt.Sprintf("invalid directory mapping: want \"remote@local\", got %s", m))
 	}
+
+    if _, err := os.Stat(xs[1]); os.IsNotExist(err){
+        panic(fmt.Sprintf("directory does not exist: %s", xs[1]))
+    }
 
 	// Windows prepends the drive letter to the path with a leading slash, e.g. "/foo/" => "C:/foo/".
 	if xs[0][1] == ':' {


### PR DESCRIPTION
**The PR fulfills these requirements:** (check all the apply)

- [x] It's submitted to the `main` branch.
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `feat: Add a button #xxx`, where "xxx" is the issue number).
- [x] When resolving a specific issue, the PR description includes `Closes #xxx`, where "xxx" is the issue number.
- [ ] If changes were made to `ui` folder, unit tests (`make test`) still pass.
- [ ] New/updated tests are included

Closes #2130

As requested in the ticket, I have made changes so that an error is thrown when an invalid public or private directory is provided when starting the wave server. The following validation was added to `server.go` in the `splitDirMapping()` function:

```go
    if _, err := os.Stat(xs[1]); os.IsNotExist(err){
        panic(fmt.Sprintf("directory does not exist: %s", xs[1]))
    }
```

I tested the change by temporarily modifying the `run` target in the `Makefile` to have various combinations of valid and invalid values for `public-dir` and `public-dir`. Here are screen shots of a couple examples where invalid directories were given:

![issue2130_badPublicDir1](https://github.com/user-attachments/assets/90083119-f972-4808-a7c4-a88a02608f45)

![issue2130_badPrivateDir1](https://github.com/user-attachments/assets/b258c39a-a67e-428b-b357-f1c5502d8d84)

And here are screen shots where valid directories are provided and I also included the browser in the screen shots to show that the server came up fine and the custom directory is accessible:

![issue2130_validDirs1](https://github.com/user-attachments/assets/1acd299b-fd8f-49f9-91df-338abfc353db)

![issue2130_validDirs2](https://github.com/user-attachments/assets/addd238b-52e1-49ed-bbd3-75a1bafe3d4f)

A couple things to note:

1. I assume testing this by running `make run` rather than using the `waved` command is sufficient. I normally run everything in my dev environment with `make`, but if you would rather I test using the `waved` command then let me know.
2. I did not test this on Windows, since I run on macos. I'm confident this should work fine on Windows, but wanted to make sure you were aware that I don't have a Windows machine to test this on.

Let me know if you have any questions or would like me to make any changes. Thanks!
