### PR TITLE
fix: Select All on 2nd filter in table not showing checked checkboxes #2386

### DIFF
--- a/ui/src/table.test.tsx
+++ b/ui/src/table.test.tsx
@@ -16,6 +16,7 @@ import { fireEvent, render } from '@testing-library/react'
 import React from 'react'
 import { Table, XTable } from './table'
 import { wave } from './ui'
+import { KeyCodes } from '@fluentui/react'
 
 const
   name = 'table',
@@ -1012,7 +1013,7 @@ describe('Table.tsx', () => {
       expect(getAllByRole('row')).toHaveLength(2 + headerRow)
     })
 
-    it('Select All on 2nd filter selects all filter checkboxes', () => {
+    it('Select All on 2nd filter selects all filter checkboxes', async () => {
       tableProps = {
         ...tableProps,
         columns: [
@@ -1023,31 +1024,29 @@ describe('Table.tsx', () => {
         rows: [
           { name: 'rowname1', cells: [cell11, 'col2-val2', 'On'] },
           { name: 'rowname2', cells: [cell21, 'col2-val1', 'Off'] },
-          { name: 'rowname3', cells: [cell31, 'col2-val3', 'On'] },     
+          { name: 'rowname3', cells: [cell31, 'col2-val3', 'On'] },
         ]
       }
-      const { container, getByLabelText, getAllByRole, queryAllByTestId, getByText } = render(<XTable model={tableProps} />)
+      const { container, getByLabelText, getAllByRole, getByText, queryByText } = render(<XTable model={tableProps} />)
 
-      expect(getAllByRole('row')).toHaveLength(tableProps.rows!.length + headerRow)
-
-      //Make a selection on the filter in the 2nd column
       fireEvent.click(container.querySelectorAll(filterSelectorName)[0]!)
-      fireEvent.click(getByLabelText('col2-val3'))      
-      expect(getAllByRole('row')).toHaveLength(1 + headerRow)
-      expect(queryAllByTestId('filter-count')[0]).toHaveTextContent('1')
-      expect(getAllByRole('checkbox', {checked: true})).toHaveLength(1)
+      fireEvent.click(getByLabelText('col2-val3'))
+      expect(getAllByRole('checkbox', { checked: true })).toHaveLength(1)
 
-      //Now select the filter on the 3rd column and then click the 'Select All' button
+      // FluentUI uses a deprecated 'which' property instead of the 'key' prop.
+      // Close the menu with escape (does not close when clicking other menu in test).
+      fireEvent.keyDown(window, { which: KeyCodes.escape })
+      expect(queryByText('Show only')).not.toBeInTheDocument()
+
       fireEvent.click(container.querySelectorAll(filterSelectorName)[1]!)
       fireEvent.click(getByText('Select All'))
-
-      //Make sure all the checkboxes available are now checked
-      expect(getAllByRole('checkbox', {checked: true})).toHaveLength(getAllByRole('checkbox').length)
-    })    
+      expect(queryByText('Show only')).toBeInTheDocument()
+      expect(getAllByRole('checkbox', { checked: true })).toHaveLength(getAllByRole('checkbox').length)
+    })
 
     it('Fires event when pagination enabled', () => {
       const { container, getAllByText } = render(<XTable model={{ ...tableProps, pagination: { total_rows: 10, rows_per_page: 5 }, events: ['filter'] }} />)
-      
+
       fireEvent.click(container.querySelector(filterSelectorName) as HTMLDivElement)
       fireEvent.click(getAllByText('1')[3].parentElement as HTMLDivElement)
 
@@ -1087,7 +1086,7 @@ describe('Table.tsx', () => {
       fireEvent.click(getByLabelText('2'))
       expect(getAllByRole('row')).toHaveLength(2 + headerRow)
       expect(queryByTestId('filter-count')).toHaveTextContent('2')
-    })    
+    })
 
     it('Filter counts - manual deselect', () => {
       const { container, getAllByRole, getByLabelText, queryByTestId } = render(<XTable model={tableProps} />)
@@ -1109,25 +1108,25 @@ describe('Table.tsx', () => {
       fireEvent.click(getByLabelText('2'))
       expect(getAllByRole('row')).toHaveLength(tableProps.rows!.length + headerRow)
       expect(queryByTestId('filter-count')).toBeNull
-    })    
+    })
 
     it('Filter counts - select all', () => {
       const { container, getAllByRole, queryByTestId, getByText } = render(<XTable model={tableProps} />)
 
       expect(getAllByRole('row')).toHaveLength(tableProps.rows!.length + headerRow)
       fireEvent.click(container.querySelector(filterSelectorName)!)
-      
+
       fireEvent.click(getByText('Select All'))
       expect(getAllByRole('row')).toHaveLength(tableProps.rows!.length + headerRow)
       expect(queryByTestId('filter-count')).toHaveTextContent(tableProps.rows!.length.toString())
-    })  
+    })
 
     it('Filter counts - deselect all', () => {
       const { container, getAllByRole, queryByTestId, getByText } = render(<XTable model={tableProps} />)
 
       expect(getAllByRole('row')).toHaveLength(tableProps.rows!.length + headerRow)
       fireEvent.click(container.querySelector(filterSelectorName)!)
-      
+
       fireEvent.click(getByText('Select All'))
       expect(getAllByRole('row')).toHaveLength(tableProps.rows!.length + headerRow)
       expect(queryByTestId('filter-count')).toHaveTextContent(tableProps.rows!.length.toString())
@@ -1159,7 +1158,7 @@ describe('Table.tsx', () => {
 
       expect(getAllByRole('row')).toHaveLength(tableProps.rows!.length + headerRow)
       fireEvent.click(container.querySelector(filterSelectorName)!)
-      
+
       fireEvent.click(getByText('Select All'))
       expect(getAllByRole('row')).toHaveLength(tableProps.rows!.length + headerRow)
       expect(queryByTestId('filter-count')).toHaveTextContent('9+')
@@ -1167,7 +1166,7 @@ describe('Table.tsx', () => {
       fireEvent.click(getByText('Deselect All'))
       expect(getAllByRole('row')).toHaveLength(tableProps.rows!.length + headerRow)
       expect(queryByTestId('filter-count')).toBeNull
-    })     
+    })
 
     it('Filter counts - clear selection with reset', () => {
       const { container, getAllByRole, getByLabelText, queryByTestId, getByText } = render(<XTable model={{ ...tableProps, resettable: true }} />)
@@ -1333,7 +1332,7 @@ describe('Table.tsx', () => {
     })
   })
 
-  
+
   describe('Group by', () => {
     beforeEach(() => {
       tableProps = {

--- a/ui/src/table.test.tsx
+++ b/ui/src/table.test.tsx
@@ -1013,7 +1013,7 @@ describe('Table.tsx', () => {
       expect(getAllByRole('row')).toHaveLength(2 + headerRow)
     })
 
-    it('Select All on 2nd filter selects all filter checkboxes', async () => {
+    it('Select All on 2nd filter selects all filter checkboxes', () => {
       tableProps = {
         ...tableProps,
         columns: [

--- a/ui/src/table.test.tsx
+++ b/ui/src/table.test.tsx
@@ -1012,6 +1012,39 @@ describe('Table.tsx', () => {
       expect(getAllByRole('row')).toHaveLength(2 + headerRow)
     })
 
+    it('Select All on 2nd filter selects all filter checkboxes', () => {
+      tableProps = {
+        ...tableProps,
+        columns: [
+          { name: 'colname1', label: 'col1', searchable: true },
+          { name: 'colname2', label: 'col2', filterable: true },
+          { name: 'colname3', label: 'col3', filterable: true },
+        ],
+        rows: [
+          { name: 'rowname1', cells: [cell11, 'col2-val2', 'On'] },
+          { name: 'rowname2', cells: [cell21, 'col2-val1', 'Off'] },
+          { name: 'rowname3', cells: [cell31, 'col2-val3', 'On'] },     
+        ]
+      }
+      const { container, getByLabelText, getAllByRole, queryAllByTestId, getByText } = render(<XTable model={tableProps} />)
+
+      expect(getAllByRole('row')).toHaveLength(tableProps.rows!.length + headerRow)
+
+      //Make a selection on the filter in the 2nd column
+      fireEvent.click(container.querySelectorAll(filterSelectorName)[0]!)
+      fireEvent.click(getByLabelText('col2-val3'))      
+      expect(getAllByRole('row')).toHaveLength(1 + headerRow)
+      expect(queryAllByTestId('filter-count')[0]).toHaveTextContent('1')
+      expect(getAllByRole('checkbox', {checked: true})).toHaveLength(1)
+
+      //Now select the filter on the 3rd column and then click the 'Select All' button
+      fireEvent.click(container.querySelectorAll(filterSelectorName)[1]!)
+      fireEvent.click(getByText('Select All'))
+
+      //Make sure all the checkboxes available are now checked
+      expect(getAllByRole('checkbox', {checked: true})).toHaveLength(getAllByRole('checkbox').length)
+    })    
+
     it('Fires event when pagination enabled', () => {
       const { container, getAllByText } = render(<XTable model={{ ...tableProps, pagination: { total_rows: 10, rows_per_page: 5 }, events: ['filter'] }} />)
       

--- a/ui/src/table.tsx
+++ b/ui/src/table.tsx
@@ -294,7 +294,7 @@ const
   },
   ContextualMenu = ({ onFilterChange, col, listProps, selectedFilters, setFiltersInBulk }: ContextualMenuProps) => {
     const
-      isFilterChecked = (data: S, key: S) => !!selectedFilters && selectedFilters[data]?.includes(key),
+      isFilterChecked = (data: S, key: S) => !!selectedFilters && selectedFilters[data]?.includes(key) ? true : false,
       [menuFilters, setMenuFilters] = React.useState(col.cellType?.tag
         ? Array.from(listProps.items.reduce((_filters, { key, text, data }) => {
           key.split(',').forEach(key => _filters.set(key, { key, text, data, checked: isFilterChecked(data, key) }))

--- a/ui/src/table.tsx
+++ b/ui/src/table.tsx
@@ -294,7 +294,7 @@ const
   },
   ContextualMenu = ({ onFilterChange, col, listProps, selectedFilters, setFiltersInBulk }: ContextualMenuProps) => {
     const
-      isFilterChecked = (data: S, key: S) => !!selectedFilters && selectedFilters[data]?.includes(key) ? true : false,
+      isFilterChecked = (data: S, key: S) => !!selectedFilters && !!selectedFilters[data]?.includes(key),
       [menuFilters, setMenuFilters] = React.useState(col.cellType?.tag
         ? Array.from(listProps.items.reduce((_filters, { key, text, data }) => {
           key.split(',').forEach(key => _filters.set(key, { key, text, data, checked: isFilterChecked(data, key) }))


### PR DESCRIPTION
Closes #2386

**The PR fulfills these requirements:** (check all the apply)

- [x] It's submitted to the `main` branch.
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `feat: Add a button #xxx`, where "xxx" is the issue number).
- [x] When resolving a specific issue, the PR description includes `Closes #xxx`, where "xxx" is the issue number.
- [x] If changes were made to `ui` folder, unit tests (`make test`) still pass.
- [ ] New/updated tests are included

I was able to find the root cause of this bug. The issue is in the definition of the `ContextualMenu` component that is used to display the column filtering options. The bug is in the `isFilterChecked` function in `ContextualMenu`:

```typescript
  ContextualMenu = ({ onFilterChange, col, listProps, selectedFilters, setFiltersInBulk }: ContextualMenuProps) => {
    const
      isFilterChecked = (data: S, key: S) => !!selectedFilters && selectedFilters[data]?.includes(key),
      [menuFilters, setMenuFilters] = React.useState(col.cellType?.tag
        ? Array.from(listProps.items.reduce((_filters, { key, text, data }) => {
          key.split(',').forEach(key => _filters.set(key, { key, text, data, checked: isFilterChecked(data, key) }))
          return _filters
        }, new Map<S, Fluent.IContextualMenuItem>()).values())
        : listProps.items.map(i => ({ ...i, checked: isFilterChecked(i.data, i.key) }))
      ),
```

If the `selectedFilters` prop is not null, but does NOT contain an entry for the current column, then the `isFilteredChecked` function will return `undefined`. This eventually becomes the value of the `checked` prop where `Fluent.Checkbox` is defined. As a result, eventually changing that to `true` when checked, doesn't get recognized and therefore looks like nothing has changed.

The solution is to modify the `isFilteredChecked` function to explicitly return either `true` or `false`. Here's a code snipit for that fix:

```typescript
      isFilterChecked = (data: S, key: S) => !!selectedFilters && selectedFilters[data]?.includes(key) ? true : false,
``` 

With this change, the `checked` prop is always set correctly, and the issue is resolved. 

Here's a short video showing the fix:

https://github.com/user-attachments/assets/668b17e1-7000-4160-8267-1c60c01af30d

I re-ran all the existing unit tests and they still pass:

![Issue2386_ui_tests_after_fix](https://github.com/user-attachments/assets/07a9769c-2000-4c22-aff9-bf5c10b97495)

### New unit test

I have been unable to create a new test for this issue. I've worked on this for several days and cannot find a solution. I suspect this might be an issue with @testing-library/react, but can't be sure. I did try upgrading the library to the latest version of 12.x, which is 12.1.5, but no luck. I'm unable to upgrade any higher since there is a dependency on React 18 in more recent versions.

Let me try to explain the problem I'm having: When the filter icon is clicked, the `ContextualMenu` component defined in `table.tsx` is rendered. On this component, there is a list of checkboxes based on the `menuFilters` state variable defined in the component. The problem is that from the unit test, when a filter icon is clicked for a different column, the `ContextualMenu` component is initialized with the `menuFilters` from the 1st column where the filter icon was clicked. I have verified this by debugging the code in `table.tsx` and in the unit test. I have also proven to myself that this problem never happens when you do the same thing in the browser, it only happens when I do this from the unit test.

And I'm fairly confident that my unit test doesn't have an issue, at least as far as I could figure out. I even tried adding an await thinking that it might be some timing issue waiting for the `menuFilters` state variable to be updated, but nothing works. I put a lot of debug statements in the test and in `table.tsx` and am confident that the code in there is all fine.

Here is a snipit of the test that I wrote to illustrate the problem:

```typescript
    it('Filters correctly - multiple filters with select all', () => {
      tableProps = {
        ...tableProps,
        columns: [
          { name: 'colname1', label: 'col1', searchable: true },
          { name: 'colname2', label: 'col2', filterable: true },
          { name: 'colname3', label: 'col3', filterable: true },
        ],
        rows: [
          { name: 'rowname1', cells: [cell11, 'col2-val2', 'On'] },
          { name: 'rowname2', cells: [cell21, 'col2-val1', 'Off'] },
          { name: 'rowname3', cells: [cell31, 'col2-val3', 'On'] },     
        ]
      }
      const { container, getByLabelText, getAllByRole, queryAllByTestId, queryAllByLabelText, getByText, getByTestId } = render(<XTable model={tableProps} />)

      expect(getAllByRole('row')).toHaveLength(tableProps.rows!.length + headerRow)

      //Make a selection on the filter in the 2nd column
      console.log("Unit test - about to select filter for 'col2'")
      fireEvent.click(container.querySelectorAll(filterSelectorName)[0]!)
      fireEvent.click(getByLabelText('col2-val3'))      
      expect(getAllByRole('row')).toHaveLength(1 + headerRow)
      expect(queryAllByTestId('filter-count')[0]).toHaveTextContent('1')
      expect(getAllByRole('checkbox', {checked: true})).toHaveLength(1)

      //Now click somewhere so ContextualMenu is dismissed
      console.log("Unit test - about to click the search field, but don't actually search for anything - trying to force onDismiss() for context menu")
      fireEvent.click(getByTestId('search'))

      //Now select the filter on the 3rd column
      console.log("Unit test - about to select filter for 'col3'")
      fireEvent.click(container.querySelectorAll(filterSelectorName)[1]!)

      //But notice the menu filter options on the ContextualMenu component contain options from column 2, not column 3
      //This should give lenth of 1 since there should be a checkbox label of 'Off' - but it gives length of 0 
      console.log("Unit test - number of 'Off' labels is ="+queryAllByLabelText('Off').length+"=, but should be 1 for col3")
      //This should give lenth of 0 since there should be NO checkbox label of 'col2-val1' - but it gives length of 1 
      console.log("Unit test - number of 'col2-val1' labels is ="+queryAllByLabelText('col2-val1').length+"=, but should be 0 for col3")

      console.log("Unit test - about to click 'Select All'")
      fireEvent.click(getByText('Select All'))
      console.log("Unit test - number of 'Off' labels is ="+queryAllByLabelText('Off').length+"=, but should be 1 for col3")
      console.log("Unit test - number of 'col2-val1' labels is ="+queryAllByLabelText('col2-val1').length+"=, but should be 0 for col3")
    })  
```

And here's a snipit from `table.tsx` where you can see that I've added console.log() to print out the `listProps` at the top and then `menuFilters` state variable after initialization.

```typescript
  ContextualMenu = ({ onFilterChange, col, listProps, selectedFilters, setFiltersInBulk }: ContextualMenuProps) => {
    console.log("ContextualMenu - at top for col.name="+col.name+"=, listProps is:")
    console.log(listProps)
    
    const
      isFilterChecked = (data: S, key: S) => !!selectedFilters && selectedFilters[data]?.includes(key) ? true : false,
      [menuFilters, setMenuFilters] = React.useState(col.cellType?.tag
        ? Array.from(listProps.items.reduce((_filters, { key, text, data }) => {
          key.split(',').forEach(key => _filters.set(key, { key, text, data, checked: isFilterChecked(data, key) }))
          return _filters
        }, new Map<S, Fluent.IContextualMenuItem>()).values())
        : listProps.items.map(i => ({ ...i, checked: isFilterChecked(i.data, i.key) }))
      ),
      selectAll = () => {
        setMenuFilters(menuFilters.map(i => ({ ...i, checked: true })))
        setFiltersInBulk(col.key, menuFilters.map(f => f.key))
      },
      deselectAll = () => {
        setMenuFilters(menuFilters.map(i => ({ ...i, checked: false })))
        setFiltersInBulk(col.key, [])
      },
      getOnFilterChangeHandler = (data: S, key: S) => (_ev?: React.FormEvent<HTMLInputElement | HTMLElement>, checked?: B) => {
        setMenuFilters(filters => filters.map(f => f.key === key ? ({ ...f, checked }) : f))
        onFilterChange(data, key, checked)
      }
    console.log("ContextualMenu - after initialization for col.name="+col.name+"=, menuFilters is:")
    console.log(menuFilters)

    return (
      <div style={{ padding: 10 }}>
        <Fluent.Text variant='mediumPlus' styles={{ root: { paddingTop: 10, paddingBottom: 10, fontWeight: 'bold' } }} block>Show only</Fluent.Text>
```

And here is the output after running the test:

````
  console.log
    Unit test - about to select filter for 'col2'

      at Object.log (src/table.test.tsx:1035:15)

  console.log
    ContextualMenu - at top for col.name=col2=, listProps is:

      at log (src/table.tsx:296:13)

  console.log
    {
      ariaLabel: undefined,
      items: [
        { key: 'col2-val2', text: 'col2-val2', data: 'colname2' },
        { key: 'col2-val1', text: 'col2-val1', data: 'colname2' },
        { key: 'col2-val3', text: 'col2-val3', data: 'colname2' }
      ],
      totalItemCount: 3,
      hasCheckmarks: false,
      hasIcons: false,
      defaultMenuItemRenderer: [Function: defaultMenuItemRenderer],
      labelElementId: undefined
    }

      at log (src/table.tsx:297:13)

  console.log
    ContextualMenu - after initialization for col.name=col2=, menuFilters is:

      at log (src/table.tsx:320:13)

  console.log
    [
      {
        key: 'col2-val2',
        text: 'col2-val2',
        data: 'colname2',
        checked: false
      },
      {
        key: 'col2-val1',
        text: 'col2-val1',
        data: 'colname2',
        checked: false
      },
      {
        key: 'col2-val3',
        text: 'col2-val3',
        data: 'colname2',
        checked: false
      }
    ]

      at log (src/table.tsx:321:13)

  console.log
    ContextualMenu - at top for col.name=col2=, listProps is:

      at log (src/table.tsx:296:13)

  console.log
    {
      ariaLabel: undefined,
      items: [
        { key: 'col2-val2', text: 'col2-val2', data: 'colname2' },
        { key: 'col2-val1', text: 'col2-val1', data: 'colname2' },
        { key: 'col2-val3', text: 'col2-val3', data: 'colname2' }
      ],
      totalItemCount: 3,
      hasCheckmarks: false,
      hasIcons: false,
      defaultMenuItemRenderer: [Function: defaultMenuItemRenderer],
      labelElementId: undefined
    }

      at log (src/table.tsx:297:13)

  console.log
    ContextualMenu - after initialization for col.name=col2=, menuFilters is:

      at log (src/table.tsx:320:13)

  console.log
    [
      {
        key: 'col2-val2',
        text: 'col2-val2',
        data: 'colname2',
        checked: false
      },
      {
        key: 'col2-val1',
        text: 'col2-val1',
        data: 'colname2',
        checked: false
      },
      {
        key: 'col2-val3',
        text: 'col2-val3',
        data: 'colname2',
        checked: true
      }
    ]

      at log (src/table.tsx:321:13)

  console.log
    Unit test - about to click the search field, but don't actually search for anything - trying to force onDismiss() for context menu

      at Object.log (src/table.test.tsx:1043:15)

  console.log
    Unit test - about to select filter for 'col3'

      at Object.log (src/table.test.tsx:1047:15)

  console.log
    ContextualMenu - at top for col.name=col3=, listProps is:

      at log (src/table.tsx:296:13)

  console.log
    {
      ariaLabel: undefined,
      items: [
        { key: 'On', text: 'On', data: 'colname3' },
        { key: 'Off', text: 'Off', data: 'colname3' }
      ],
      totalItemCount: 2,
      hasCheckmarks: false,
      hasIcons: false,
      defaultMenuItemRenderer: [Function: defaultMenuItemRenderer],
      labelElementId: undefined
    }

      at log (src/table.tsx:297:13)

  console.log
    ContextualMenu - after initialization for col.name=col3=, menuFilters is:

      at log (src/table.tsx:320:13)

  console.log
    [
      {
        key: 'col2-val2',
        text: 'col2-val2',
        data: 'colname2',
        checked: false
      },
      {
        key: 'col2-val1',
        text: 'col2-val1',
        data: 'colname2',
        checked: false
      },
      {
        key: 'col2-val3',
        text: 'col2-val3',
        data: 'colname2',
        checked: true
      }
    ]

      at log (src/table.tsx:321:13)

  console.log
    Unit test - number of 'Off' labels is =0=, but should be 1 for col3

      at Object.log (src/table.test.tsx:1052:15)

  console.log
    Unit test - number of 'col2-val1' labels is =1=, but should be 0 for col3

      at Object.log (src/table.test.tsx:1054:15)

  console.log
    Unit test - about to click 'Select All'

      at Object.log (src/table.test.tsx:1056:15)

  console.log
    ContextualMenu - at top for col.name=col3=, listProps is:

      at log (src/table.tsx:296:13)

  console.log
    {
      ariaLabel: undefined,
      items: [
        { key: 'On', text: 'On', data: 'colname3' },
        { key: 'Off', text: 'Off', data: 'colname3' }
      ],
      totalItemCount: 2,
      hasCheckmarks: false,
      hasIcons: false,
      defaultMenuItemRenderer: [Function: defaultMenuItemRenderer],
      labelElementId: undefined
    }

      at log (src/table.tsx:297:13)

  console.log
    ContextualMenu - after initialization for col.name=col3=, menuFilters is:

      at log (src/table.tsx:320:13)

  console.log
    [
      {
        key: 'col2-val2',
        text: 'col2-val2',
        data: 'colname2',
        checked: true
      },
      {
        key: 'col2-val1',
        text: 'col2-val1',
        data: 'colname2',
        checked: true
      },
      {
        key: 'col2-val3',
        text: 'col2-val3',
        data: 'colname2',
        checked: true
      }
    ]

      at log (src/table.tsx:321:13)

  console.log
    Unit test - number of 'Off' labels is =0=, but should be 1 for col3

      at Object.log (src/table.test.tsx:1058:15)

  console.log
    Unit test - number of 'col2-val1' labels is =1=, but should be 0 for col3

      at Object.log (src/table.test.tsx:1059:15)
````

If you look at the debug statements carefully, you'll notice that when the 2nd filter icon is clicked for col3, it is getting passed the correct data in the `listProps` prop, but the `menuFilters` state variable is initialized for the col2 values.  

Based on the debugging I've done, I think this is happening because the `onDismiss()` on the context menu is never called when running from the unit test. This gets called fine from the UI, but from the unit test `onDismiss()` isn't called, hence the context menu doesn't get initialized properly when it is opened for a different column. I even added a step in the test to click into the Search field, hoping that might trigger `onDismiss()` on the context menu, but that didn't help.

Also, I confirmed that clicking the `Select All` button anyway doesn't work as expected since it ends up selecting menu filter values which don't actually exist.

I hope this all makes sense. And if I'm overlooking something in the unit test or if you see an issue with the fix, please let me know. Thanks!


