### PR TITLE
fix: Conform standalone button width to its container #2361

### DIFF
--- a/ui/src/button.tsx
+++ b/ui/src/button.tsx
@@ -108,6 +108,10 @@ const
       boxSizing: 'border-box',
       overflowX: 'auto'
     },
+    standaloneButton: {
+      display: 'flex',
+      alignItems: 'center',
+    }
   }),
   justifications: Dict<Fluent.Alignment> = {
     start: 'start',
@@ -201,7 +205,7 @@ export const
     )
   },
   XStandAloneButton = ({ model: m }: { model: Button }) => (
-    <div className={css.buttons}>
+    <div className={css.standaloneButton}>
       <XButton key={m.name} model={m} />
     </div>
   ),


### PR DESCRIPTION
**The PR fulfills these requirements:** (check all the apply)

- [x] It's submitted to the `main` branch.
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `feat: Add a button #xxx`, where "xxx" is the issue number).
- [x] When resolving a specific issue, the PR description includes `Closes #xxx`, where "xxx" is the issue number.
- [x] If changes were made to `ui` folder, unit tests (`make test`) still pass.
- [ ] New/updated tests are included
____
The idea of this fix is to make the standalone button together with its left margin to fit its container width. This is by specifying `display: 'flex` for the button wrapper. 

**Example:**
When the standalone button with has specified width of `150px` is followed by another standalone button with the same width, the first button will be 150px wide but the second one and every other will be 142px wide as it accounts for 8px left padding. This marginal difference can only be caught by a perfectionist eye. This is demonstrated in the recording below:

https://github.com/user-attachments/assets/019abfb7-5192-463e-9d49-db65f4d459fe

The `alignItems: 'center'` is specified not to break existing button stylings.

The solution was manually and visual regression tested.

Closes #2361 
