### PR TITLE
fix: Changed the artifact upload action version

### DIFF
--- a/.github/workflows/publish-university.yml
+++ b/.github/workflows/publish-university.yml
@@ -69,14 +69,14 @@ jobs:
             --helm-app-runtime-image-repo 524466471676.dkr.ecr.us-east-1.amazonaws.com/h2oai/university \
             --generate-dockerfile
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: wave-bundle
           path: |
             ./university/*.Dockerfile
             ./university/*.wave
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: wave-bundle-helm
           path: university/helm/

--- a/.github/workflows/release-wave.yml
+++ b/.github/workflows/release-wave.yml
@@ -194,14 +194,14 @@ jobs:
             --helm-app-runtime-image-repo 524466471676.dkr.ecr.us-east-1.amazonaws.com/h2oai/tour \
             --generate-dockerfile
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: wave-bundle
           path: |
             ./py/tmp/tour/*.Dockerfile
             ./py/tmp/tour/*.wave
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: wave-bundle-helm
           path: py/tmp/tour/helm/

--- a/.github/workflows/wave-bundle-docker-build-publish.yaml
+++ b/.github/workflows/wave-bundle-docker-build-publish.yaml
@@ -35,7 +35,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Download Wave bundle and Dockerfiles
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.bundle-artifact }}
           path: ./


### PR DESCRIPTION
**The PR fulfills these requirements:** (check all the apply)

- [ ] It's submitted to the `main` branch.
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `feat: Add a button #xxx`, where "xxx" is the issue number).
- [ ] When resolving a specific issue, the PR description includes `Closes #xxx`, where "xxx" is the issue number.
- [ ] If changes were made to `ui` folder, unit tests (`make test`) still pass.
- [ ] New/updated tests are included

Description:
Updated version of Upload Artifact Github Action to v4 as v3 is deprecated by Nov 2024

reference -: https://github.com/actions/upload-artifact?tab=readme-ov-file#actionsupload-artifact
