### PR TITLE
fix: Dropdown of filterable columns not always visible #2400

### DIFF
--- a/ui/src/table.tsx
+++ b/ui/src/table.tsx
@@ -396,7 +396,8 @@ const
             const sortIconName = sortCols && sortCols[props.column.key] ? 'Sort' + sortCols[props.column.key] : 'Sort'
 
             return (
-              <div style={{ display: 'flex', alignItems: 'center' }}>{props.column.name}
+              <div style={{ display: 'flex', alignItems: 'center' }}>
+                <span style={{ textOverflow: 'ellipsis', overflow: 'hidden' }}>{props.column.name}</span>
                 {c.sortable && (
                   <Fluent.Icon iconName={sortIconName}
                     className={css.sortingIcon}


### PR DESCRIPTION
**The PR fulfills these requirements:** (check all the apply)

- [x] It's submitted to the `main` branch.
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `feat: Add a button #xxx`, where "xxx" is the issue number).
- [x] When resolving a specific issue, the PR description includes `Closes #xxx`, where "xxx" is the issue number.
- [x] If changes were made to `ui` folder, unit tests (`make test`) still pass.
- [ ] New/updated tests are included

Closes #2400

I have fixed this bug, which was a regression that I introduced in PR [#2371](https://github.com/h2oai/wave/pull/2371). 

This was resolved by adding wrapping the column name in a `span` and adding styling to hide overflow text and replace with an ellipsis. The code looks like this:

```typescript
      <span style={{ textOverflow: 'ellipsis', overflow: 'hidden' }}>{props.column.name}</span>
```

I made local changes to the `table.py` example to have some really long names and made sure the text is properly clipped and that sorting icon and filtering stuff still works fine. Here's a screen shot:

![Issue2400_ui_test](https://github.com/user-attachments/assets/7e3dc049-8eea-4814-a639-c1718a074cbf)

And here's a short video:

https://github.com/user-attachments/assets/27cc00f6-d334-49b7-bf69-282ff6518a45

I tried creating a new unit test, but that didn't work as I initially expected. No matter how long the column name was, the document always had the entire content. I guess that makes sense since the rendering of the ellipses will occur in the browser. If I'm overlooking something and there is a way to write a unit test for this, please advise.

I did re-run all the existing unit tests and they worked fine:

![Issue2400_unit_tests](https://github.com/user-attachments/assets/136bf50d-c0b9-4bce-8f70-bfc56b433c00)

Let me know if you have any questions or would like me to make any changes. Thanks!
