### PR TITLE
fix: progress_table_cell_type floating point rounding issues #2380

### DIFF
--- a/ui/src/progress_table_cell_type.test.tsx
+++ b/ui/src/progress_table_cell_type.test.tsx
@@ -33,8 +33,7 @@ const
       {input: 0.1488, output: '14.88%'},
       {input: 0.29, output: '29%'},
       {input: 0.58, output: '58%'},
-      {input: 0.592, output: '59.2%'},
-    ]       
+      {input: 0.592, output: '59.2%'},]       
 
 describe('ProgressTableCellType.tsx', () => {
 

--- a/ui/src/progress_table_cell_type.test.tsx
+++ b/ui/src/progress_table_cell_type.test.tsx
@@ -30,7 +30,8 @@ const
   progressFloatingPointValues = [
       {input: 0.14, output: '14%'},
       {input: 0.148, output: '14.8%'},
-      {input: 0.1488, output: '14.88%'},
+      {input: 0.1414, output: '14.14%'},
+      {input: 0.141414, output: '14.14%'},
       {input: 0.29, output: '29%'},
       {input: 0.58, output: '58%'},
       {input: 0.592, output: '59.2%'},]       

--- a/ui/src/progress_table_cell_type.test.tsx
+++ b/ui/src/progress_table_cell_type.test.tsx
@@ -26,7 +26,15 @@ const
     {input: 0.8888, output: '88.88%'},
     {input: 0.88888, output: '88.89%'},
     {input: 0.88899, output: '88.90%'},
-    {input: 0.88999, output: '89.00%'},]  
+    {input: 0.88999, output: '89.00%'},],
+  progressFloatingPointValues = [
+      {input: 0.14, output: '14%'},
+      {input: 0.148, output: '14.8%'},
+      {input: 0.1488, output: '14.88%'},
+      {input: 0.29, output: '29%'},
+      {input: 0.58, output: '58%'},
+      {input: 0.592, output: '59.2%'},
+    ]       
 
 describe('ProgressTableCellType.tsx', () => {
 
@@ -47,5 +55,14 @@ describe('ProgressTableCellType.tsx', () => {
       expect(queryByTestId(name)).toBeInTheDocument()
       expect(queryByTestId(name)).toHaveTextContent(progressValue.output)      
     })
-  })  
+  })
+  
+  it('Handle potential floating-point decimal errors', () => {
+    const { queryByTestId, rerender } = render(<XProgressTableCellType model={progressCellProps} progress={progress} />)
+    progressFloatingPointValues.map(progressValue => {
+      rerender(<XProgressTableCellType model={progressCellProps} progress={progressValue.input} />)
+      expect(queryByTestId(name)).toBeInTheDocument()
+      expect(queryByTestId(name)).toHaveTextContent(progressValue.output)      
+    })
+  })   
 })

--- a/ui/src/progress_table_cell_type.test.tsx
+++ b/ui/src/progress_table_cell_type.test.tsx
@@ -50,7 +50,7 @@ describe('ProgressTableCellType.tsx', () => {
 
   it('Renders data-test attr with decimal values', () => {
     const { queryByTestId, rerender } = render(<XProgressTableCellType model={progressCellProps} progress={progress} />)
-    progressValues.map(progressValue => {
+    progressValues.forEach(progressValue => {
       rerender(<XProgressTableCellType model={progressCellProps} progress={progressValue.input} />)
       expect(queryByTestId(name)).toBeInTheDocument()
       expect(queryByTestId(name)).toHaveTextContent(progressValue.output)      
@@ -59,7 +59,7 @@ describe('ProgressTableCellType.tsx', () => {
   
   it('Handle potential floating-point decimal errors', () => {
     const { queryByTestId, rerender } = render(<XProgressTableCellType model={progressCellProps} progress={progress} />)
-    progressFloatingPointValues.map(progressValue => {
+    progressFloatingPointValues.forEach(progressValue => {
       rerender(<XProgressTableCellType model={progressCellProps} progress={progressValue.input} />)
       expect(queryByTestId(name)).toBeInTheDocument()
       expect(queryByTestId(name)).toHaveTextContent(progressValue.output)      

--- a/ui/src/progress_table_cell_type.tsx
+++ b/ui/src/progress_table_cell_type.tsx
@@ -50,7 +50,7 @@ export const XProgressTableCellType = ({ model: m, progress }: { model: Progress
   <div data-test={m.name} className={css.container}>
     <ProgressArc thickness={2} color={cssVar(m.color || '$red')} value={progress} />
     <Fluent.Stack horizontalAlign='center' verticalAlign='center' className={clas(css.percentContainer, 'wave-s12')}>
-      <div className={css.percent}>{`${Number.isInteger(progress * 1000) ? (progress * 100) : (progress * 100).toFixed(2)}%`}</div>
+      <div className={css.percent}>{`${Number.isInteger(progress * 1000) ? (progress * 1000)/10 : (progress * 100).toFixed(2)}%`}</div>
     </Fluent.Stack>
   </div >
 )


### PR DESCRIPTION
**The PR fulfills these requirements:** (check all the apply)

- [x] It's submitted to the `main` branch.
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `feat: Add a button #xxx`, where "xxx" is the issue number).
- [x] When resolving a specific issue, the PR description includes `Closes #xxx`, where "xxx" is the issue number.
- [x] If changes were made to `ui` folder, unit tests (`make test`) still pass.
- [x] New/updated tests are included

Closes #2380

I have fixed this bug relating to floating-point error when rendering the `ProgressTableCellType` component.

The bug is in `progress_table_cell_type.tsx` where the progress value is multiplied by 100. Here's a snipit of that:

```typescript
<div className={css.percent}>{`${Number.isInteger(progress * 1000) ? (progress * 100) : (progress * 100).toFixed(2)}%`}</div>
```

This bit of code can result in unexpected behavior because of floating-point arithmetic. The value `0.14` is an example of this and when multiplied by `100` it actually returns `14.000000000000002`. Here is a screen shot from the Chrome js console where I show a few examples of this happening:

![Issue2380_js_error_examples](https://github.com/user-attachments/assets/ef714a93-eb1c-4ec6-90cd-a2ec659a54b8)

Background: If you recall from the [PR](https://github.com/h2oai/wave/pull/2329) I submitted back in May to introduced these decimal values here, there was a discussion about not keeping trailing 0's and instead ensuring the rendered % value had the same number of digits as the original input, with up to 2 decimal places. Here's that [discussion](https://github.com/h2oai/wave/pull/2329#discussion_r1599087502) from the PR. That's the reason we simply had `(progress * 100)` without `toFixed(2)` here.  

I found a few ways to resolve this, but I decided the most efficient way to deal with this is to just avoid multiplying by 100 and instead multiply by 1000 then divide that by 10. We don't need this in the else-block since we have the `toFixed(2)` there. Here's what that looks like:

```typescript
<div className={css.percent}>{`${Number.isInteger(progress * 1000) ? (progress * 1000)/10 : (progress * 100).toFixed(2)}%`}</div>
```

If there is a more efficient or elegant way to resolve this, please let me know.

I modified my local copy of the `table` py example to have values of `0.14` and you can see here it now renders fine:

![Issue2380_ui_test](https://github.com/user-attachments/assets/0917b73e-3a6b-4a11-901d-ffea5603b612)

I also created a new test in `progress_table_cell_type_test.tsx` that tested 6 different float values that cause this issue. Here's a snipit of the values tested and expected results:

```typescript
  progressFloatingPointValues = [
    {input: 0.14, output: '14%'},
    {input: 0.148, output: '14.8%'},
    {input: 0.1488, output: '14.88%'},
    {input: 0.29, output: '29%'},
    {input: 0.58, output: '58%'},
    {input: 0.592, output: '59.2%'},
  ]  
```

I know that I could have just added these values to the `progressValues` array defined just above and then these would have been tested as part of the existing test `Renders data-test attr with decimal values`. But I thought it was important for this bug to have its own named test case since it is meant to verify a very specific scenario.

Before fixing the bug, I ran the new test and you can see here it failed as expected:

![Issue2380_unit_test_failure](https://github.com/user-attachments/assets/9c39444e-fbcf-4d42-b6bc-e6f03463b1ef)

After the fix is applied, everything works fine. Here's a screen shot after running all test suites:

![Issue2380_unit_tests](https://github.com/user-attachments/assets/aa2a7ad7-9198-41f2-ab78-e8910bd3180c)

Let me know if you have any questions or would like me to make any changes. Thanks!

