### PR TITLE
fix: remove duplicate python server test

### DIFF
--- a/py/tests/test_python_server.py
+++ b/py/tests/test_python_server.py
@@ -114,13 +114,6 @@ class TestPythonServer(unittest.TestCase):
         page.save()
         assert compare(page.load(), make_form_card(buf=dict(f=dict(d=[[1,2,3], None, None], f=['a', 'b', 'c'], n =3))))
 
-    def test_new_card_with_cyc_buf(self):
-        page = site['/test']
-        page.drop()
-        page['card1'] = dict(data=data(fields=sample_fields, size=-3))
-        page.save()
-        assert compare(page.load(),
-                      make_page(card1=make_card(data=make_cyc_buf(fields=sample_fields, data=[None] * 3, i=0))))
 
     def test_form_card_with_cyc_buf(self):
         page = site['/test']


### PR DESCRIPTION
**The PR fulfills these requirements:** (check all the apply)

- [x] It's submitted to the `main` branch.
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `feat: Add a button #xxx`, where "xxx" is the issue number).
- [ ] When resolving a specific issue, the PR description includes `Closes #xxx`, where "xxx" is the issue number.
- [ ] If changes were made to `ui` folder, unit tests (`make test`) still pass.
- [ ] New/updated tests are included

This small PR removes the redundant `test_new_card_with_cyc_buf` function from `py/tests/test_python_server.py`, as it duplicates the logic of an existing test.