### PR TITLE
docs: fixed API link for proper navigation

### DIFF
--- a/website/widgets/content/tall_info.md
+++ b/website/widgets/content/tall_info.md
@@ -19,7 +19,7 @@ q.page['example'] = ui.tall_info_card(
 )
 ```
 
-Check the full API at [ui.tall_info](/docs/api/ui#tall_info).
+Check the full API at [ui.tall_info_card](/docs/api/ui#tall_info_card).
 
 ## Icon
 

--- a/website/widgets/content/wide_info.md
+++ b/website/widgets/content/wide_info.md
@@ -25,7 +25,7 @@ maiores consequatur dolores illo inventore quae obcaecati culpa totam corporis! 
 )
 ```
 
-Check the full API at [ui.wide_info](/docs/api/ui#wide_info).
+Check the full API at [ui.wide_info_card](/docs/api/ui#wide_info_card).
 
 ## Icon
 


### PR DESCRIPTION
Currently the API link on the widgets page for `tall_info` and `wide_info` navigate to the right page but a different section. This PR fixes that. 

**The PR fulfills these requirements:** (check all the apply)

- [x] It's submitted to the `main` branch.
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `feat: Add a button #xxx`, where "xxx" is the issue number).
- [ ] When resolving a specific issue, the PR description includes `Closes #xxx`, where "xxx" is the issue number.
- [ ] If changes were made to `ui` folder, unit tests (`make test`) still pass.
- [ ] New/updated tests are included
