### PR TITLE
Security: Server-Side Script Injection from File Content in Inline JavaScript

### DIFF
--- a/studio/studio_editor.py
+++ b/studio/studio_editor.py
@@ -7,8 +7,8 @@ def update_file_tree(q: Q, root: str) -> None:
 
 def open_file(q: Q, file: str) -> None:
     q.page['meta'].script = ui.inline_script(f'''
-editor.setValue(`{file_utils.read_file(file)}`)
-eventBus.emit('activeFile', '{file}')
+editor.setValue({json.dumps(file_utils.read_file(file))})
+eventBus.emit('activeFile', {json.dumps(file)})
 ''')
 
 def clean_editor(q: Q) -> None:


### PR DESCRIPTION
## Problem

File contents are interpolated directly into an inline JavaScript template literal: `editor.setValue(`{file_content}`)`. If a file contains backticks or `${...}`, it can break out of the string/template context and execute arbitrary JavaScript in the browser (XSS).

**Severity**: `high`
**File**: `studio/studio_editor.py`

## Solution

Never embed raw file content in executable JS strings. Send content as JSON-encoded data (`json.dumps`) and parse safely client-side, or deliver via API response and set editor text without code interpolation.

## Changes

- `studio/studio_editor.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
