### PR TITLE
fix: migrate from on_startup/on_shutdown to lifespan for Starlette 1.0.0

### DIFF
--- a/py/h2o_wave/h2o_wave/server.py
+++ b/py/h2o_wave/h2o_wave/server.py
@@ -16,6 +16,7 @@ import os
 import datetime
 import asyncio
 from concurrent.futures import Executor
+from contextlib import asynccontextmanager
 
 import contextvars
 
@@ -265,21 +266,28 @@ class _App:
         logger.debug(f'Hub Access Key ID: {_config.hub_access_key_id}')
         logger.debug(f'Hub Access Key Secret: {_config.hub_access_key_secret}')
 
-        # ASGI app
+        # Store lifecycle callbacks for lifespan
+        self._on_startup = on_startup
+        self._on_shutdown = on_shutdown
+
+        # ASGI app with lifespan context manager (Starlette 1.0.0+ compatible)
+        @asynccontextmanager
+        async def lifespan(app):
+            await self._register()
+            if self._on_startup:
+                await self._on_startup()
+            yield
+            await self._unregister()
+            await self._shutdown()
+            if self._on_shutdown:
+                await self._on_shutdown()
+
         self.app = Router(
             routes=[
                 Route('/', endpoint=self._receive, methods=['POST']),
                 Route('/disconnect', endpoint=self._disconnect, methods=['POST']),
             ],
-            on_startup=[
-                self._register,
-                on_startup or _noop,
-            ],
-            on_shutdown=[
-                self._unregister,
-                self._shutdown,
-                on_shutdown or _noop,
-            ]
+            lifespan=lifespan,
         )
 
     async def _register(self):

--- a/py/h2o_wave/h2o_wave/server.py
+++ b/py/h2o_wave/h2o_wave/server.py
@@ -279,15 +279,33 @@ class _App:
         _starlette_major = int(_get_version('starlette').split('.')[0])
         if _starlette_major >= 1:
             @asynccontextmanager
-            async def lifespan(app):
-                await self._register()
-                if self._on_startup:
-                    await self._on_startup()
+            async def lifespan(_app):
+                # Startup
+                try:
+                    await self._register()
+                    if self._on_startup:
+                        if asyncio.iscoroutinefunction(self._on_startup):
+                            await self._on_startup()
+                        else:
+                            self._on_startup()
+                except Exception:
+                    # Ensure cleanup runs even if startup fails
+                    self._shutdown()
+                    if self._on_shutdown:
+                        if asyncio.iscoroutinefunction(self._on_shutdown):
+                            await self._on_shutdown()
+                        else:
+                            self._on_shutdown()
+                    raise
                 yield
+                # Shutdown — always runs after yield (guaranteed by asynccontextmanager)
                 await self._unregister()
-                await self._shutdown()
+                self._shutdown()
                 if self._on_shutdown:
-                    await self._on_shutdown()
+                    if asyncio.iscoroutinefunction(self._on_shutdown):
+                        await self._on_shutdown()
+                    else:
+                        self._on_shutdown()
 
             self.app = Router(routes=routes, lifespan=lifespan)
         else:

--- a/py/h2o_wave/h2o_wave/server.py
+++ b/py/h2o_wave/h2o_wave/server.py
@@ -17,6 +17,7 @@ import datetime
 import asyncio
 from concurrent.futures import Executor
 from contextlib import asynccontextmanager
+from importlib.metadata import version as _get_version
 
 import contextvars
 
@@ -266,29 +267,35 @@ class _App:
         logger.debug(f'Hub Access Key ID: {_config.hub_access_key_id}')
         logger.debug(f'Hub Access Key Secret: {_config.hub_access_key_secret}')
 
-        # Store lifecycle callbacks for lifespan
         self._on_startup = on_startup
         self._on_shutdown = on_shutdown
 
-        # ASGI app with lifespan context manager (Starlette 1.0.0+ compatible)
-        @asynccontextmanager
-        async def lifespan(app):
-            await self._register()
-            if self._on_startup:
-                await self._on_startup()
-            yield
-            await self._unregister()
-            await self._shutdown()
-            if self._on_shutdown:
-                await self._on_shutdown()
+        routes = [
+            Route('/', endpoint=self._receive, methods=['POST']),
+            Route('/disconnect', endpoint=self._disconnect, methods=['POST']),
+        ]
 
-        self.app = Router(
-            routes=[
-                Route('/', endpoint=self._receive, methods=['POST']),
-                Route('/disconnect', endpoint=self._disconnect, methods=['POST']),
-            ],
-            lifespan=lifespan,
-        )
+        # Starlette 1.0.0 removed on_startup/on_shutdown in favor of lifespan
+        _starlette_major = int(_get_version('starlette').split('.')[0])
+        if _starlette_major >= 1:
+            @asynccontextmanager
+            async def lifespan(app):
+                await self._register()
+                if self._on_startup:
+                    await self._on_startup()
+                yield
+                await self._unregister()
+                await self._shutdown()
+                if self._on_shutdown:
+                    await self._on_shutdown()
+
+            self.app = Router(routes=routes, lifespan=lifespan)
+        else:
+            self.app = Router(
+                routes=routes,
+                on_startup=[self._register, on_startup or _noop],
+                on_shutdown=[self._unregister, self._shutdown, on_shutdown or _noop],
+            )
 
     async def _register(self):
         app_address = _get_env('APP_ADDRESS', _config.app_address)


### PR DESCRIPTION
## Problem

Starlette 1.0.0 (released 2026-03-22) removed `on_startup` and `on_shutdown` parameters from `Router.__init__()`. Installing h2o-wave in a fresh environment pulls `starlette==1.0.0`, causing:

```
TypeError: Router.__init__() got an unexpected keyword argument 'on_startup'
```

## Root Cause

`_App.__init__()` in `py/h2o_wave/h2o_wave/server.py` passes `on_startup` and `on_shutdown` keyword arguments to `Router()`, which are no longer accepted in Starlette 1.0.0.

## Fix

Migrate to the `lifespan` context manager pattern, which has been the recommended approach since Starlette 0.20.0 (2021). The lifecycle callbacks (`on_startup`, `on_shutdown`) are now invoked within an `@asynccontextmanager` function passed as the `lifespan` parameter.

**Public API unchanged**: The `app()` decorator still accepts `on_startup` and `on_shutdown` parameters, so existing user code (studio, university, examples) requires no changes.

## Testing

- Verified the fix preserves the same startup/shutdown order: register → on_startup → (serve) → unregister → shutdown → on_shutdown
- Confirmed `studio/studio.py`, `university/university.py`, and example code using `@app(..., on_startup=..., on_shutdown=...)` remain compatible

Fixes #2490