### PR TITLE
Security: Information Disclosure in Debug Handler

### DIFF
--- a/debug.go
+++ b/debug.go
@@ -48,6 +48,10 @@ func newDebugHandler(broker *Broker) *DebugHandler {
 }
 
 func (h *DebugHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if !h.broker.isAdmin(r) {
+		w.WriteHeader(http.StatusForbidden)
+		return
+	}
 	data := struct {
 		Apps  []string
 		Pages []string


### PR DESCRIPTION
## Summary

Security: Information Disclosure in Debug Handler

## Problem

**Severity**: `Medium` | **File**: `debug.go:L30`

The debug.go template exposes all application routes and page URLs. This information could be useful for attackers mapping the application's structure.

## Solution

Restrict debug endpoint to authenticated admin users only. Consider disabling debug endpoint in production.

## Changes

- `debug.go` (modified)