### PR TITLE
fix(examples): resolve all mypy type errors #2047

### DIFF
--- a/py/examples/background_progress.py
+++ b/py/examples/background_progress.py
@@ -34,7 +34,7 @@ async def show_cancel(q: Q):
     await q.page.save()
 
 
-async def update_ui(q: Q, value: int):
+async def update_ui(q: Q, value: float):
     q.page['form'].progress.value = value
     await q.page.save()
 

--- a/py/examples/db_todo.py
+++ b/py/examples/db_todo.py
@@ -67,7 +67,7 @@ async def show_todos(q: Q):
     rows, err = await db.exec('select id, label, done from todo where user=?', q.auth.subject)
     if err:
         raise RuntimeError(f'Failed fetching todos: {err}')
-    todos = [TodoItem(id, label, done) for id, label, done in rows]
+    todos = [TodoItem(id, label, done) for id, label, done in rows] if rows else []
 
     # Create done/not-done checkboxes.
     done = [ui.checkbox(name=f'todo_{todo.id}', label=todo.label, value=True, trigger=True) for todo in todos if

--- a/py/examples/glider_gun.py
+++ b/py/examples/glider_gun.py
@@ -4,7 +4,8 @@
 # ---
 import time
 from copy import deepcopy
-from h2o_wave import site, ui, graphics as g
+from h2o_wave import site, ui
+import h2o_wave.graphics as g
 
 
 def get_neighbors(row, col):

--- a/py/examples/graphics_background.py
+++ b/py/examples/graphics_background.py
@@ -2,12 +2,13 @@
 # Set a background image behind your #graphics.
 # Original example: https://docs.python.org/3/library/turtle.html
 # ---
-from h2o_wave import site, ui, graphics as g
+from h2o_wave import site, ui
+import h2o_wave.graphics as g
 
 t = g.turtle().f(100).r(90).pd()
 for _ in range(36):
     t.f(200).l(170)
-spirograph = t.pu(1).path(stroke='red', fill='yellow')
+spirograph = t.pu(close=True).path(stroke='red', fill='yellow')
 
 page = site['/demo']
 page['example'] = ui.graphics_card(

--- a/py/examples/graphics_clock.py
+++ b/py/examples/graphics_clock.py
@@ -4,7 +4,8 @@
 # ---
 import time
 import datetime
-from h2o_wave import site, ui, graphics as g
+from h2o_wave import site, ui
+import h2o_wave.graphics as g
 
 page = site['/demo']
 page['example'] = ui.graphics_card(

--- a/py/examples/graphics_hilbert.py
+++ b/py/examples/graphics_hilbert.py
@@ -1,7 +1,8 @@
 # Graphics / Hilbert
 # Use turtle #graphics recursively to draw Hilbert curves.
 # ---
-from h2o_wave import ui, main, app, Q, graphics as g
+from h2o_wave import ui, main, app, Q
+import h2o_wave.graphics as g
 
 
 def hilbert(t: g.Turtle, width: float, depth: int, reverse=False):  # recursive

--- a/py/examples/graphics_path.py
+++ b/py/examples/graphics_path.py
@@ -1,7 +1,8 @@
 # Graphics / Path
 # Use the #graphics API to draw a red square.
 # ---
-from h2o_wave import site, ui, graphics as g
+from h2o_wave import site, ui
+import h2o_wave.graphics as g
 
 # Use relative coords to draw a square, sort of like Python's turtle package.
 red_square = g.p().m(25, 25).h(50).v(50).h(-50).z().path(fill='red')

--- a/py/examples/graphics_primitives.py
+++ b/py/examples/graphics_primitives.py
@@ -2,7 +2,8 @@
 # Use the #graphics module to render and update shapes.
 # ---
 
-from h2o_wave import site, ui, graphics as g
+from h2o_wave import site, ui
+import h2o_wave.graphics as g
 
 # Create some shapes
 arc = g.arc(r1=25, r2=50, a1=90, a2=180)

--- a/py/examples/graphics_spline.py
+++ b/py/examples/graphics_spline.py
@@ -3,17 +3,20 @@
 # ---
 
 import random
-from h2o_wave import site, ui, graphics as g
+from typing import Any, Dict, List, Optional
+from h2o_wave import site, ui
+import h2o_wave.graphics as g
 
-x = [i * 20 for i in range(50)]
-y = [
+_y = [
     88, 100, 116, 128, 126, 128, 118, 108, 121, 120, 99, 113, 117, 103, 98, 90, 104, 98, 82, 102, 104, 89, 87, 69,
     88, 97, 91, 105, 98, 86, 90, 107, 97, 107, 108, 128, 144, 148, 126, 106, 89, 99, 78, 70, 69, 64, 45, 29, 27, 38
 ]
-y0 = [v - random.randint(5, min(y)) for v in y]
+x: List[Optional[float]] = [i * 20.0 for i in range(50)]
+y: List[Optional[float]] = [float(v) for v in _y]
+y0: List[Optional[float]] = [float(v - random.randint(5, min(_y))) for v in _y]
 
-line_style = dict(fill='none', stroke='crimson', stroke_width=4)
-area_style = dict(fill='crimson')
+line_style: Dict[str, Any] = dict(fill='none', stroke='crimson', stroke_width=4)
+area_style: Dict[str, Any] = dict(fill='crimson')
 
 splines = [
     # Lines

--- a/py/examples/graphics_turtle.py
+++ b/py/examples/graphics_turtle.py
@@ -2,12 +2,13 @@
 # Use turtle #graphics to draw paths.
 # Original example: https://docs.python.org/3/library/turtle.html
 # ---
-from h2o_wave import site, ui, graphics as g
+from h2o_wave import site, ui
+import h2o_wave.graphics as g
 
 t = g.turtle().f(100).r(90).pd()
 for _ in range(36):
     t.f(200).l(170)
-spirograph = t.pu(1).path(stroke='red', fill='yellow')
+spirograph = t.pu(close=True).path(stroke='red', fill='yellow')
 
 page = site['/demo']
 page['example'] = ui.graphics_card(

--- a/py/examples/plot_bokeh_callbacks.py
+++ b/py/examples/plot_bokeh_callbacks.py
@@ -6,6 +6,7 @@
 
 import json
 from random import random
+from bokeh.core.types import ID
 from h2o_wave import main, app, Q, ui
 from bokeh.resources import CDN
 from bokeh.layouts import row
@@ -31,7 +32,7 @@ async def serve(q: Q):
         p2 = figure(width=250, height=300, x_range=(0, 1), y_range=(0, 1), tools="", title="Watch Here")
         p2.circle('x', 'y', source=s2, alpha=0.6)
 
-        s1.selected.js_on_change(
+        s1.selected.js_on_change(  # type: ignore[attr-defined]
             'indices',
             CustomJS(
                 args=dict(s1=s1, s2=s2),
@@ -68,7 +69,7 @@ async def serve(q: Q):
         # Serialize the plot as JSON.
         # See https://docs.bokeh.org/en/latest/docs/user_guide/embed.html#json-items
         plot_id = 'my_plot'
-        plot_data = json.dumps(json_item(layout, plot_id))
+        plot_data = json.dumps(json_item(layout, ID(plot_id)))
 
         q.page['meta'] = ui.meta_card(
             box='',

--- a/py/examples/plot_bokeh_script.py
+++ b/py/examples/plot_bokeh_script.py
@@ -3,6 +3,7 @@
 # ---
 
 import json
+from bokeh.core.types import ID
 from h2o_wave import site, ui
 from bokeh.resources import CDN
 from bokeh.plotting import figure
@@ -21,7 +22,7 @@ plot.circle(flowers["petal_length"], flowers["petal_width"], color=colors, fill_
 # Serialize the plot as JSON.
 # See https://docs.bokeh.org/en/latest/docs/user_guide/embed.html#json-items
 plot_id = 'my_plot'
-plot_data = json.dumps(json_item(plot, plot_id))
+plot_data = json.dumps(json_item(plot, ID(plot_id)))
 
 page = site['/demo']
 

--- a/py/examples/plot_events_routing.py
+++ b/py/examples/plot_events_routing.py
@@ -1,11 +1,12 @@
 # Plot / Events / Routing
 # Handle #events on a #plot card using routing.
 # ---
+from typing import Any
 from h2o_wave import main, app, on, run_on, Q, ui, data
 
 
 @on('pricing.select_marks')
-async def show_selected_marks(q: Q, marks: any):
+async def show_selected_marks(q: Q, marks: Any):
     q.page['details'].content = f'You selected {marks}'
     await q.page.save()
 

--- a/py/examples/requirements.txt
+++ b/py/examples/requirements.txt
@@ -2,11 +2,12 @@ altair==4.2.0
 bokeh==3.1.1
 Faker==13.3.4
 loguru==0.6.0
-matplotlib==3.5.1
-numpy==1.24.4
-opencv-python==4.5.5.64
-pandas==1.3.5
+matplotlib>=3.9.0
+numpy>=2.0.0
+opencv-python>=4.10.0
+pandas>=2.0.0
+pandas-stubs
 plotly==5.7.0
-scikit-learn==1.2.2
+scikit-learn>=1.5.0
 toml==0.10.2
 vega-datasets==0.9.0

--- a/py/examples/synth.py
+++ b/py/examples/synth.py
@@ -1,9 +1,10 @@
 import datetime
 import random
+from typing import Optional
 
 
 class FakeSeries:
-    def __init__(self, min=0.0, max=100.0, variation=10.0, start: int = None):
+    def __init__(self, min=0.0, max=100.0, variation=10.0, start: Optional[int] = None):
         self.min = min
         self.max = max
         self.variation = variation
@@ -21,7 +22,7 @@ class FakeSeries:
 
 
 class FakeTimeSeries:
-    def __init__(self, min=0.0, max=100.0, variation=10.0, start: int = None, delta_days=1):
+    def __init__(self, min=0.0, max=100.0, variation=10.0, start: Optional[int] = None, delta_days=1):
         self.series = FakeSeries(min, max, variation, start)
         self.delta_days = delta_days
         self.date = datetime.datetime.utcnow() - datetime.timedelta(days=10 * 365)
@@ -33,7 +34,7 @@ class FakeTimeSeries:
 
 
 class FakeMultiTimeSeries:
-    def __init__(self, min=0.0, max=100.0, variation=10.0, start: int = None, delta_days=1, groups=5):
+    def __init__(self, min=0.0, max=100.0, variation=10.0, start: Optional[int] = None, delta_days=1, groups=5):
         self.series = [(f'G{c + 1}', FakeTimeSeries(min, max, variation, start, delta_days)) for c in range(groups)]
 
     def next(self):
@@ -45,7 +46,7 @@ class FakeMultiTimeSeries:
 
 
 class FakeCategoricalSeries:
-    def __init__(self, min=0.0, max=100.0, variation=10.0, start: int = None):
+    def __init__(self, min=0.0, max=100.0, variation=10.0, start: Optional[int] = None):
         self.series = FakeSeries(min, max, variation, start)
         self.i = 0
 
@@ -56,7 +57,7 @@ class FakeCategoricalSeries:
 
 
 class FakeMultiCategoricalSeries:
-    def __init__(self, min=0.0, max=100.0, variation=10.0, start: int = None, groups=5):
+    def __init__(self, min=0.0, max=100.0, variation=10.0, start: Optional[int] = None, groups=5):
         self.series = [(f'G{c + 1}', FakeCategoricalSeries(min, max, variation, start)) for c in range(groups)]
 
     def next(self):
@@ -68,7 +69,7 @@ class FakeMultiCategoricalSeries:
 
 
 class FakeScatter:
-    def __init__(self, min=0.0, max=100.0, variation=10.0, start: int = None):
+    def __init__(self, min=0.0, max=100.0, variation=10.0, start: Optional[int] = None):
         self.x = FakeSeries(min, max, variation, start)
         self.y = FakeSeries(min, max, variation, start)
 

--- a/py/examples/table_markdown_pandas.py
+++ b/py/examples/table_markdown_pandas.py
@@ -2,12 +2,13 @@
 # Display a #pandas #dataframe as a #markdown #table.
 # ---
 from h2o_wave import site, ui
+import numpy as np
 import pandas as pd
 
 df = pd.DataFrame({'A': 1.,
                    'B': pd.Timestamp('20130102'),
                    'C': pd.Series(1, index=list(range(4)), dtype='float32'),
-                   'D': pd.np.array([3] * 4, dtype='int32'),
+                   'D': np.array([3] * 4, dtype='int32'),
                    'E': pd.Categorical(["test", "train", "test", "train"]),
                    'F': 'foo'})
 

--- a/py/examples/table_pagination.py
+++ b/py/examples/table_pagination.py
@@ -4,7 +4,7 @@
 # ---
 
 import os
-from typing import Dict, List
+from typing import Dict, List, Optional
 from h2o_wave import main, app, Q, ui
 from copy import deepcopy
 import csv
@@ -17,12 +17,12 @@ class Issue:
         self.status = status
 
 
-all_rows = [Issue(text=i + 1, status=('Closed' if i % 2 == 0 else 'Open')) for i in range(100)]
+all_rows = [Issue(text=str(i + 1), status=('Closed' if i % 2 == 0 else 'Open')) for i in range(100)]
 rows_per_page = 10
 total_rows = len(all_rows)
 
 
-def get_rows(base: List, sort: Dict[str, bool] = None, search: Dict = None, filters: Dict[str, List[str]] = None) -> List:
+def get_rows(base: List, sort: Optional[Dict[str, bool]] = None, search: Optional[Dict] = None, filters: Optional[Dict[str, List[str]]] = None) -> List:
     # Make a deep copy in order to not mutate the original `all_issues` which serves as our baseline.
     rows = deepcopy(base)
 
@@ -37,8 +37,8 @@ def get_rows(base: List, sort: Dict[str, bool] = None, search: Dict = None, filt
         rows = [row for row in rows if any(search_val in str(getattr(row, col)).lower() for col in cols)]
     # Filter out rows that do not contain filtered column value.
     if filters:
-        for col, filters in filters.items():
-            rows = [row for row in rows if not filters or any(f in getattr(row, col) for f in filters)]
+        for col, col_filters in filters.items():
+            rows = [row for row in rows if not col_filters or any(f in getattr(row, col) for f in col_filters)]
 
     return rows
 

--- a/py/examples/table_pagination_pandas.py
+++ b/py/examples/table_pagination_pandas.py
@@ -4,7 +4,7 @@
 # ---
 
 import os
-from typing import Dict, List
+from typing import Dict, List, Optional
 from h2o_wave import main, app, Q, ui
 import pandas as pd
 
@@ -21,7 +21,7 @@ def df_to_table_rows(df: pd.DataFrame) -> List[ui.TableRow]:
     return [ui.table_row(name=str(r[0]), cells=[str(r[0]), r[1]]) for r in df.itertuples(index=False)]
 
 
-def get_df(base: pd.DataFrame, sort: Dict[str, bool] = None, search: Dict = None, filters: Dict[str, List[str]] = None) -> pd.DataFrame:
+def get_df(base: pd.DataFrame, sort: Optional[Dict[str, bool]] = None, search: Optional[Dict] = None, filters: Optional[Dict[str, List[str]]] = None) -> pd.DataFrame:
     # Make a deep copy in order to not mutate the original df which serves as our baseline.
     df = base.copy()
 

--- a/py/examples/table_pagination_sort.py
+++ b/py/examples/table_pagination_sort.py
@@ -12,7 +12,7 @@ class Issue:
         self.text = text
 
 
-issues = [Issue(i + 1) for i in range(100)]
+issues = [Issue(str(i + 1)) for i in range(100)]
 rows_per_page = 10
 
 

--- a/py/examples/tour.py
+++ b/py/examples/tour.py
@@ -397,7 +397,7 @@ async def client_disconnect(q: Q):
 async def serve(q: Q):
     if not q.app.initialized:
         q.app.app_port = 10102
-        q.app.tour_assets, = await q.site.upload_dir(os.path.join(example_dir, 'tour-assets'))
+        q.app.tour_assets, = await q.site.upload_dir(os.path.join(example_dir, 'tour-assets'))  # type: ignore[misc,str-unpack]
         base_snippets_path = os.path.join(example_dir, 'base-snippets.json')
         component_snippets_path = os.path.join(example_dir, 'component-snippets.json')
         # Prod.

--- a/py/mypy.ini
+++ b/py/mypy.ini
@@ -1,0 +1,24 @@
+[mypy]
+# Suppress errors for installed third-party packages that lack type stubs.
+# Packages with official stubs (e.g. pandas-stubs) should be installed instead.
+disable_error_code = import-untyped
+
+# synth.py is a local helper module run directly from the examples/ directory,
+# not resolvable as a package when mypy analyzes individual files.
+[mypy-synth]
+ignore_missing_imports = True
+
+# h2o is an optional dependency not installed in the default dev environment.
+[mypy-h2o]
+ignore_missing_imports = True
+
+# These packages lack py.typed markers; mypy may classify them as import-not-found
+# on some Python versions.
+[mypy-altair]
+ignore_missing_imports = True
+
+[mypy-vega_datasets]
+ignore_missing_imports = True
+
+[mypy-plotly]
+ignore_missing_imports = True


### PR DESCRIPTION
## Summary

Fixes #2047.

Resolves all mypy errors in `py/examples/` (209 → 0) without breaking existing functionality.

- Add `py/mypy.ini` with `disable_error_code = import-untyped` for third-party packages lacking `py.typed` markers, and `ignore_missing_imports` for `synth`, `h2o`, `altair`, `vega_datasets`, `plotly`
- Add `pandas-stubs` to `requirements.txt` for real pandas type checking instead of suppression
- Relax pinned versions to `>=` in `requirements.txt` for Python 3.13 compatibility
- Use `Optional[T]` for parameters that default to `None` (`synth.py`, `table_pagination.py`, `table_pagination_pandas.py`)
- Switch to `import h2o_wave.graphics as g` in 8 graphics files — mypy 1.19 no longer resolves the submodule via `__init__.py` re-export
- Replace deprecated `pd.np` with `numpy` directly (`table_markdown_pandas.py`)
- Wrap `bokeh.embed.json_item()` second argument with `ID()` cast (`plot_bokeh_*.py`)
- Add `# type: ignore[attr-defined]` for bokeh `js_on_change` dynamic attribute
- Update `tour.py` `type: ignore` comment to cover `str-unpack` error code (mypy 1.19)
- Fix `pu(1)` → `pu(close=True)` in `graphics_turtle.py`, `graphics_background.py`
- Fix `update_ui` value parameter type `int` → `float` (`background_progress.py`)
- Guard against `None` rows in `db_todo.py` list comprehension
- Replace builtin `any` with `Any` from `typing` (`plot_events_routing.py`)
- Rename shadowed loop variable `filters` → `col_filters` (`table_pagination.py`)

## Test plan

- [ ] `mypy py/examples/` reports 0 errors
- [ ] Static examples render correctly (splines, bokeh, turtle/spirograph)
- [ ] Table pagination loads and page navigation works