### PR TITLE
ci: Use GH_OIDC_ROLE_H2O_ECR secret for wave-bundle ECR role

### DIFF
--- a/.github/workflows/wave-bundle-docker-build-publish.yaml
+++ b/.github/workflows/wave-bundle-docker-build-publish.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          role-to-assume: arn:aws:iam::353750902984:role/GitHub-OIDC-Role
+          role-to-assume: ${{ secrets.GH_OIDC_ROLE_H2O_ECR }}
           role-session-name: GitHub_to_AWS_via_FederatedOIDC
           aws-region: us-east-1
 


### PR DESCRIPTION
## What

Replaces the hardcoded AWS OIDC role ARN in the `wave-bundle-docker-build-publish` workflow with the `GH_OIDC_ROLE_H2O_ECR` repository secret.

## Why

- Removes the hardcoded IAM role ARN from source control.
- Centralizes the role configuration in a repository secret, so the role can be rotated/updated without code changes.

## Changes

- `.github/workflows/wave-bundle-docker-build-publish.yaml`: `role-to-assume` now references `${{ secrets.GH_OIDC_ROLE_H2O_ECR }}`.
