### PR TITLE
docs: add @app decorator example to pages guide

### DIFF
--- a/website/docs/pages.md
+++ b/website/docs/pages.md
@@ -30,6 +30,7 @@ page = site['/foo']
 To reference the current page in a Wave app, use `q.page`.
 
 ```py
+@app('/foo')
 async def serve(q: Q):
     page = q.page
 ```

--- a/website/docs/pages.md
+++ b/website/docs/pages.md
@@ -30,6 +30,13 @@ page = site['/foo']
 To reference the current page in a Wave app, use `q.page`.
 
 ```py
+async def serve(q: Q):
+    page = q.page
+```
+
+To reference a specific page in a Wave app, use the `@app('/foo')` decorator.
+
+```py
 @app('/foo')
 async def serve(q: Q):
     page = q.page


### PR DESCRIPTION
Adds an example demonstrating the use of the @app('/foo') decorator in the Pages guide.

- Added explanation for referencing a specific page using @app('/foo')
- Added code example alongside the existing q.page example

Fixes #581