### PR TITLE
security: Bump Go to 1.25.12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/h2oai/wave
 
-go 1.25.11
+go 1.25.12
 
 require (
 	github.com/coreos/go-oidc/v3 v3.12.0


### PR DESCRIPTION
Automated security bump from `make security-bump`.

**Go:** `1.25.11` → `1.25.12`
**Target release after merge:** `1.8.10`

## Trivy findings (stdlib)

- **CVE-2026-42505** (MEDIUM) — fixed in 1.25.12, 1.26.5, 1.27.0-rc.2  
  crypto/tls: golang: Go crypto/tls: Information disclosure in Encrypted Client Hello
- **CVE-2026-39822** (HIGH) — fixed in 1.25.12, 1.26.5, 1.27.0-rc.2  
  os: golang: Go os.Root: Symlink following vulnerability allows directory traversal

e2e: passed